### PR TITLE
fix: use github_actions label to match Dependabot convention

### DIFF
--- a/.github/workflows/dependency-cooldown-gate.yml
+++ b/.github/workflows/dependency-cooldown-gate.yml
@@ -155,7 +155,7 @@ jobs:
           # --- Detect ecosystem labels ---
           LABELS="dependencies"
           case "$PR_BRANCH" in
-            dependabot/github_actions/*) LABELS="dependencies,github-actions" ;;
+            dependabot/github_actions/*) LABELS="dependencies,github_actions" ;;
             dependabot/pip/*)                       LABELS="dependencies,python" ;;
           esac
 


### PR DESCRIPTION
## Summary

- Dependabot auto-creates labels with underscores (`github_actions`), not hyphens (`github-actions`)
- The `gh issue create --label` command fails if the label doesn't exist
- All 3 new Dependabot PRs in nexus-mcp failed tracking issue creation because of this mismatch

## Fix

Change `github-actions` → `github_actions` in the ecosystem label case statement.