### PR TITLE
feat: add release workflow for automated floating version tags

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,93 @@
+name: Auto-Tag on Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  auto-tag:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Determine version bump from commit messages
+        id: bump
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          # Get all commit messages from the PR (merge commit parents)
+          COMMITS=$(git log --format="%s" "$(git rev-parse "${MERGE_SHA}^1")..${MERGE_SHA}^2" 2>/dev/null || echo "$PR_TITLE")
+
+          # Also include PR title (used as merge commit message in squash merges)
+          ALL_MESSAGES="$(printf '%s\n%s' "$PR_TITLE" "$COMMITS")"
+
+          echo "Commit messages:"
+          echo "$ALL_MESSAGES"
+          echo ""
+
+          # Determine bump level from conventional commit prefixes
+          BUMP="patch"
+          if echo "$ALL_MESSAGES" | grep -qE '^[a-z]+(\(.+\))?!:'; then
+            BUMP="major"
+            echo "Detected: breaking change (! suffix)"
+          elif echo "$ALL_MESSAGES" | grep -qi 'BREAKING CHANGE'; then
+            BUMP="major"
+            echo "Detected: BREAKING CHANGE in message body"
+          elif echo "$ALL_MESSAGES" | grep -qE '^feat(\(.+\))?:'; then
+            BUMP="minor"
+            echo "Detected: feat → minor bump"
+          else
+            echo "Detected: fix/refactor/chore/docs → patch bump"
+          fi
+
+          echo "bump=$BUMP" >> "$GITHUB_OUTPUT"
+
+      - name: Compute next version and tag
+        env:
+          BUMP: ${{ steps.bump.outputs.bump }}
+        run: |
+          # Find the latest semver tag
+          LATEST=$(git tag -l 'v*.*.*' --sort=-version:refname | head -1)
+
+          if [ -z "$LATEST" ]; then
+            LATEST="v0.0.0"
+            echo "No existing tags found, starting from v0.0.0"
+          fi
+          echo "Latest tag: $LATEST"
+
+          # Parse version components
+          VERSION="${LATEST#v}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+          # Apply bump
+          case "$BUMP" in
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
+          esac
+
+          NEXT_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "Bump: $BUMP → $NEXT_TAG"
+
+          # Create and push the tag
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag -a "$NEXT_TAG" -m "Release $NEXT_TAG"
+          git push origin "$NEXT_TAG"
+
+          echo "Tagged $NEXT_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Update Floating Version Tags
+
+on:
+  push:
+    tags: ['v*.*.*']
+
+permissions:
+  contents: write
+
+jobs:
+  update-tags:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Update floating major and minor tags
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          # Parse semver components: v1.2.3 → MAJOR=v1, MINOR=v1.2
+          MAJOR=$(echo "$TAG" | sed 's/\..*//')
+          MINOR=$(echo "$TAG" | sed 's/\.[^.]*$//')
+
+          echo "Semver tag: $TAG (immutable)"
+          echo "Minor tag:  $MINOR (floats to latest patch)"
+          echo "Major tag:  $MAJOR (floats to latest minor+patch)"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Update minor floating tag (e.g., v1.2 → v1.2.3)
+          git tag -fa "$MINOR" -m "Release $TAG"
+          git push origin "$MINOR" --force
+          echo "Updated $MINOR → $TAG"
+
+          # Update major floating tag (e.g., v1 → v1.2.3)
+          git tag -fa "$MAJOR" -m "Release $TAG"
+          git push origin "$MAJOR" --force
+          echo "Updated $MAJOR → $TAG"


### PR DESCRIPTION
## Summary

Adds a release workflow that manages all three semver tag levels when a release tag is pushed.

## How it works

Push `v1.2.3` → workflow automatically:
- Keeps `v1.2.3` immutable (the exact patch release)
- Creates/updates `v1.2` floating tag (tracks latest patch: `v1.2.3`, `v1.2.4`, ...)
- Creates/updates `v1` floating tag (tracks latest minor+patch: `v1.1.0`, `v1.2.3`, ...)

## Consumer pinning options

| Pin | Gets updates | Use when |
|-----|-------------|----------|
| `@v1` | All non-breaking changes | Default, most convenient |
| `@v1.2` | Patch fixes only | Want patches but not new features |
| `@v1.2.3` | Nothing (frozen) | Need exact reproducibility or rollback |

## Versioning guide

| Change type | Bump | Example |
|-------------|------|---------|
| Breaking input/output changes | Major (`v2.0.0`) | Rename or remove a workflow input |
| New features, new inputs | Minor (`v1.1.0`) | Add Scorecard enrichment |
| Bug fixes | Patch (`v1.0.1`) | Fix label name typo |