### PR TITLE
fix: replace secrets.GITHUB_TOKEN with github.token

### DIFF
--- a/.github/workflows/dependency-cooldown-gate.yml
+++ b/.github/workflows/dependency-cooldown-gate.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Set cooldown status
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           ACTOR: ${{ github.actor }}
@@ -72,7 +72,7 @@ jobs:
 
       - name: Create tracking issue and link to PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/dependency-cooldown-scan.yml
+++ b/.github/workflows/dependency-cooldown-scan.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Find mature bot PRs
         id: find-prs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           COOLING_DAYS: ${{ inputs.cooling_business_days }}
         run: |
@@ -84,7 +84,7 @@ jobs:
       - name: Scan and comment
         if: steps.find-prs.outputs.pr_numbers != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBERS: ${{ steps.find-prs.outputs.pr_numbers }}
           BYPASS_LABEL: ${{ inputs.bypass_label }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Update floating major and minor tags
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
         run: |
           # Parse semver components: v1.2.3 → MAJOR=v1, MINOR=v1.2


### PR DESCRIPTION
## Summary

Replace `${{ secrets.GITHUB_TOKEN }}` with `${{ github.token }}` in all reusable workflow files.

## Why

Reusable workflows can access the caller's token via `github.token` without needing `secrets: inherit`. This allows consumer repos to drop `secrets: inherit` from their thin callers, resolving `zizmor/secrets-inherit` warnings.

## What changes

- `dependency-cooldown-gate.yml` — 2 occurrences
- `dependency-cooldown-scan.yml` — 2 occurrences
- `release.yml` — 1 occurrence

## Consumer impact

After this merges, consumer repos should:
1. Update their SHA pin to the new commit
2. Remove `secrets: inherit` from their caller YAML

This is a **patch** bump (bug fix, no input changes).