### PR TITLE
fix: use PR author instead of github.actor for bot detection

### DIFF
--- a/.github/workflows/dependency-cooldown-gate.yml
+++ b/.github/workflows/dependency-cooldown-gate.yml
@@ -34,11 +34,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          ACTOR: ${{ github.actor }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BYPASS_LABEL: ${{ inputs.bypass_label }}
         run: |
-          if [[ "$ACTOR" != "dependabot[bot]" ]]; then
+          if [[ "$PR_AUTHOR" != "dependabot[bot]" ]]; then
             STATE="success"
             DESC="Non-bot PR — no cool-down required"
           else
@@ -62,7 +62,7 @@ jobs:
     if: >-
       inputs.create_tracking_issue &&
       github.event.action == 'opened' &&
-      github.actor == 'dependabot[bot]'
+      github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Harden runner


### PR DESCRIPTION
## Summary

Replace `github.actor` with `github.event.pull_request.user.login` for bot detection in the gate workflow.

## Problem

`github.actor` changes to the person who clicked "Re-run" on workflow re-runs. This causes two bugs:

1. **Cooldown bypass** — `set-pending-status` sets `success` (non-bot path) instead of `pending` when a human re-runs the gate on a Dependabot PR
2. **Missing Fixes link** — `create-tracking-issue` job is skipped because the actor check fails

## Fix

| Location | Before | After |
|----------|--------|-------|
| Step env | `ACTOR: ${{ github.actor }}` | `PR_AUTHOR: ${{ github.event.pull_request.user.login }}` |
| Shell check | `$ACTOR != "dependabot[bot]"` | `$PR_AUTHOR != "dependabot[bot]"` |
| Job condition | `github.actor == 'dependabot[bot]'` | `github.event.pull_request.user.login == 'dependabot[bot]'` |

`github.event.pull_request.user.login` is the PR author — stable regardless of who triggers or re-runs the workflow.

Also resolves the `zizmor/bot-conditions` warning about spoofable actor context.

## Test plan

- [ ] Re-run the gate workflow on a Dependabot PR — status should remain `pending`
- [ ] Re-run should add `Fixes #N` to PR body if missing
- [ ] Non-bot PRs still get `success` status immediately