### PR TITLE
fix: ensure Fixes link on every PR event, not just opened

### DIFF
--- a/.github/workflows/dependency-cooldown-gate.yml
+++ b/.github/workflows/dependency-cooldown-gate.yml
@@ -58,6 +58,50 @@ jobs:
             -f context="dependency-cooldown / gate" \
             -f description="$DESC"
 
+      - name: Ensure Fixes link in PR body
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          ISSUE_TITLE="Track: ${PR_TITLE}"
+
+          # Find tracking issue by title
+          ISSUE_NUMBER=$(gh issue list --repo "$GH_REPO" --state open \
+            --search "in:title \"${ISSUE_TITLE}\"" \
+            --json number --jq '.[0].number // empty')
+
+          if [ -z "$ISSUE_NUMBER" ]; then
+            echo "No tracking issue found — will be created by create-tracking-issue job"
+            exit 0
+          fi
+
+          # Check if Fixes link already exists
+          CURRENT_BODY=$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json body --jq '.body')
+          if echo "$CURRENT_BODY" | grep -q "Fixes #${ISSUE_NUMBER}"; then
+            echo "Fixes #${ISSUE_NUMBER} already in PR body"
+            exit 0
+          fi
+
+          # Compute eligible date for the link text
+          ELIGIBLE_DATE=$(python3 -c "
+          from datetime import datetime, timedelta, timezone
+          now = datetime.now(timezone.utc)
+          count = 0
+          current = now
+          while count < 5:
+              current += timedelta(days=1)
+              if current.weekday() < 5:
+                  count += 1
+          print(current.strftime('%Y-%m-%d'))
+          ")
+
+          NEW_BODY="$(printf 'Fixes #%s \u2014 Tracking issue (cooldown expires %s)\n\n%s' "$ISSUE_NUMBER" "$ELIGIBLE_DATE" "$CURRENT_BODY")"
+          gh pr edit "$PR_NUMBER" --repo "$GH_REPO" --body "$NEW_BODY"
+          echo "Added Fixes #${ISSUE_NUMBER} to PR body"
+
   create-tracking-issue:
     if: >-
       inputs.create_tracking_issue &&


### PR DESCRIPTION
## Summary

Add a new step in the `set-pending-status` job that ensures the `Fixes #N` link exists in the PR body on every trigger, not just `opened`.

## Problem

The `Fixes` link logic was only reachable inside the `create-tracking-issue` job, which is gated on `github.event.action == 'opened'`. If that job failed on first run (e.g., label typo, API timeout), the link was never added. Re-runs and `synchronize` events couldn't recover it because the job condition excluded them.

## Fix

New step: **"Ensure Fixes link in PR body"** in the `set-pending-status` job.

- Runs on both `opened` and `synchronize` events (every push to the PR)
- Only runs for `dependabot[bot]` PRs
- Searches for existing tracking issue by title
- If found and `Fixes #N` is missing from PR body, adds it
- No-op if link already present or no tracking issue exists yet

## How the two jobs now work together

| Event | `set-pending-status` | `create-tracking-issue` |
|-------|---------------------|------------------------|
| `opened` | Set status + ensure Fixes link | Create issue + add Fixes link |
| `synchronize` | Set status + ensure Fixes link | Skipped (opened only) |

The Fixes link step is idempotent — both jobs can add it, and the duplicate check prevents double-prepending.

## Test plan

- [ ] New Dependabot PR gets Fixes link on `opened` (both jobs run)
- [ ] If `create-tracking-issue` fails, next `synchronize` adds the Fixes link
- [ ] No duplicate Fixes links on subsequent pushes