### PR TITLE
fix(cooldown-scan): pass PR_DATA via env instead of piping into python3 heredoc

### DIFF
--- a/.github/workflows/dependency-cooldown-scan.yml
+++ b/.github/workflows/dependency-cooldown-scan.yml
@@ -45,9 +45,13 @@ jobs:
               {number, createdAt}
             ]")
 
-          # Filter by business days (Mon-Fri only) using Python
-          PR_NUMBERS=$(echo "$PR_DATA" | python3 << 'PYEOF'
-          import json, sys, os
+          # Filter by business days (Mon-Fri only) using Python.
+          # Pass PR_DATA via env, NOT stdin: `echo ... | python3 <<EOF` collides
+          # on stdin — the heredoc wins as the script source and the piped data
+          # is silently discarded, so json.load(sys.stdin) previously saw empty
+          # input and crashed every scheduled run with JSONDecodeError.
+          PR_NUMBERS=$(PR_DATA="$PR_DATA" python3 <<'PYEOF'
+          import json, os
           from datetime import datetime, timedelta
 
           def business_days_elapsed(created_at):
@@ -64,7 +68,7 @@ jobs:
               return count
 
           threshold = int(os.environ["COOLING_DAYS"])
-          prs = json.load(sys.stdin)
+          prs = json.loads(os.environ["PR_DATA"])
           for pr in prs:
               if business_days_elapsed(pr["createdAt"]) >= threshold:
                   print(pr["number"])

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.worktrees/


### PR DESCRIPTION
## Summary

- **Bug:** `echo "$PR_DATA" | python3 << 'PYEOF'` collides on stdin. With no script argument, `python3` reads its source from stdin, and the heredoc wins — the piped JSON is silently discarded. `json.load(sys.stdin)` then sees empty input and raises `JSONDecodeError: Expecting value: line 1 column 1 (char 0)`, killing every scheduled run before any PR is scanned.
- **Fix:** Pass `PR_DATA` through the environment (`PR_DATA="$PR_DATA" python3 <<'PYEOF'`) and read it via `os.environ["PR_DATA"]` + `json.loads(...)` inside the script. Matches the env-var pattern already used for `COOLING_DAYS` and for the second Python block later in the same workflow (line ~125).
- **Also:** Add `.gitignore` for `.worktrees/` to keep local worktree-based development out of `git status`.

## Why this broke every scheduled run

The broken step (`Find mature bot PRs`) gates the entire job, so every firing of `0 9 * * 1-5` dies at that step. Callers pinned to this workflow (e.g. `nexus-mcp`) have not been scanning PRs at all.

## Test plan

- [x] Extracted the fixed Python block and ran it locally against a synthetic `PR_DATA` containing one old PR (`2020-01-01`) and one future-dated PR (`2099-01-01`) with `COOLING_DAYS=5`. Only the old PR number was printed — confirms both `json.loads(os.environ[...])` and the business-day logic work end-to-end.
- [ ] Merge and cut `v1.2.4`; repin a caller (e.g. `nexus-mcp`) and confirm the next scheduled run reaches the scan step.