### PR TITLE
fix: use github-actions (hyphen) label to match Dependabot convention

### DIFF
--- a/.github/workflows/dependency-cooldown-gate.yml
+++ b/.github/workflows/dependency-cooldown-gate.yml
@@ -234,7 +234,7 @@ jobs:
           # --- Detect ecosystem labels ---
           LABELS="dependencies"
           case "$PR_BRANCH" in
-            dependabot/github_actions/*) LABELS="dependencies,github_actions" ;;
+            dependabot/github_actions/*) LABELS="dependencies,github-actions" ;;
             dependabot/pip/*|dependabot/uv/*) LABELS="dependencies,python" ;;
           esac
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Reusable GitHub Actions workflows for dependency management and security scannin
 ## Prerequisites
 
 - **Dependabot** configured for your repo (GitHub Actions and/or pip/uv ecosystems)
-- **Labels** must exist in your repo: `dependencies`, `github_actions` (underscore, not hyphen), `python`
+- **Labels** must exist in your repo: `dependencies`, `github-actions`, `python`
 - **No Renovate** — these workflows only support `dependabot[bot]` as the PR actor
 - **Python 3** available on runner (used for business day calculation)
 


### PR DESCRIPTION
## Summary

- Workflow now emits `github-actions` (hyphen) on tracking issues for GitHub Actions Dependabot PRs, matching Dependabot's documented ecosystem label.
- README prerequisite list corrected — it no longer instructs consumers to create the underscored label.
- The `case` pattern `dependabot/github_actions/*` is unchanged because it matches Dependabot's branch path, which is a separate concern from the label value.

Fixes #9

## Test plan

- [ ] `grep -rn 'github_actions' --include='*.yml' --include='*.md' .` returns only branch-path references (never a label value)
- [ ] Workflow line 237 emits `github-actions` on the right-hand side
- [ ] README line 19 lists `github-actions` with no "underscore, not hyphen" parenthetical
- [ ] After merge, dispatch `tag-release.yml` with `bump=auto` → expect `v1.2.5`
- [ ] Confirm `release.yml` re-floats `@v1` to `v1.2.5`
- [ ] On the next GitHub Actions Dependabot PR in a consumer repo running `@v1`, the tracking issue receives the `github-actions` label and no `github_actions` label is auto-created