### PR TITLE
fix(tag-release): use GitHub App token to restore release.yml trigger

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -65,6 +65,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Compute release
         id: compute

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -24,6 +24,11 @@ concurrency:
 jobs:
   tag-release:
     runs-on: ubuntu-latest
+    # Gate secret access on a named environment so a malicious workflow edit
+    # can't reach RELEASE_BOT_PRIVATE_KEY without passing the environment's
+    # branch-policy check (main only). Pairs with the if: below as a
+    # GitHub-side enforcement of the same invariant.
+    environment: release
     # Releases must originate from main's latest commit. workflow_dispatch
     # lets the operator pick any branch in the Actions UI, so we gate
     # explicitly instead of relying on trust.

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -34,6 +34,33 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Preflight — verify Release Bot App credentials
+        env:
+          APP_ID: ${{ vars.RELEASE_BOT_APP_ID }}
+        run: |
+          if [ -z "${APP_ID}" ]; then
+            {
+              echo "### Release Bot App not configured"
+              echo ""
+              echo "\`vars.RELEASE_BOT_APP_ID\` is empty. Tag Release needs a GitHub App identity"
+              echo "to push tags so that \`release.yml\` fires (the default \`GITHUB_TOKEN\` is"
+              echo "suppressed by GitHub's recursion guard)."
+              echo ""
+              echo "See [README › Release Bot App setup](../../README.md#release-bot-app-setup)"
+              echo "for one-time provisioning steps."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::Release Bot App not configured (see README#release-bot-app-setup)"
+            exit 1
+          fi
+          echo "Release Bot App ID present: ${APP_ID}"
+
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0

--- a/README.md
+++ b/README.md
@@ -202,3 +202,33 @@ For zero-day fixes that can't wait for the cooldown:
 | `@v1.2.3` | Nothing (frozen) | Need exact reproducibility or rollback |
 
 Tags are managed automatically — merging a PR to this repo creates a semver tag based on conventional commit prefixes and updates the floating tags.
+
+## Release Bot App setup
+
+`tag-release.yml` needs a non-`GITHUB_TOKEN` identity to push new tags, otherwise GitHub's recursion guard silently suppresses the downstream `release.yml` run. We use a GitHub App for this.
+
+### Required config
+
+| Kind | Name | Value |
+|------|------|-------|
+| Repo variable | `RELEASE_BOT_APP_ID` | Numeric App ID |
+| Repo secret | `RELEASE_BOT_PRIVATE_KEY` | Full PEM contents including header/footer |
+
+### One-time provisioning
+
+1. Create a GitHub App (org- or user-owned) with **repository permission** `Contents: Read and write` — nothing else.
+2. Install the App on this repo (single-repo install recommended).
+3. Copy the App ID into `vars.RELEASE_BOT_APP_ID` under **Settings → Secrets and variables → Actions → Variables**.
+4. Generate a private key from the App settings and paste the PEM into `secrets.RELEASE_BOT_PRIVATE_KEY` under **Settings → Secrets and variables → Actions → Secrets**.
+
+### Verify
+
+Dispatch **Actions → Tag Release → Run workflow** with `bump=patch`. Within ~30 seconds, a new run of `Publish Release` should appear:
+
+```bash
+gh run list --workflow=release.yml --limit 1
+```
+
+### Rotation
+
+To rotate the key: generate a new private key in the App settings, update `secrets.RELEASE_BOT_PRIVATE_KEY`, then delete the old key in the App settings. No code change required.


### PR DESCRIPTION
## Summary

Closes #14. Replaces the default `GITHUB_TOKEN` used by `tag-release.yml` with a short-lived GitHub App installation token, so tag-push events propagate and `release.yml` (which is `on: push: tags`) fires as intended.

The reactive model in `release.yml` is preserved — it still runs on any tag push, including CLI pushes from a developer machine. Only the pusher identity in the upstream workflow changes.

## Changes

- `.github/workflows/tag-release.yml`:
  - **Preflight step** — fails fast with a README-linked error if `vars.RELEASE_BOT_APP_ID` is empty. Runs before any side effects.
  - **Mint step** — `actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1`, SHA-pinned to match the existing convention.
  - **Checkout** — now takes `token: \${{ steps.app-token.outputs.token }}`, which persists the App token as the push credential in `.git/config`. The subsequent `git push` step body is **unchanged**.
  - Compute-release logic unchanged.
- `README.md` — new `## Release Bot App setup` section documenting required config (`vars.RELEASE_BOT_APP_ID`, `secrets.RELEASE_BOT_PRIVATE_KEY`), one-time provisioning steps, verification, and rotation. The preflight error message links to this section's auto-anchor.

## How it works

GitHub's [documented recursion guard](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) prevents events caused by \`GITHUB_TOKEN\` from creating new workflow runs. That's why \`release.yml\` has been dormant since it was introduced. Switching the pusher to a GitHub App installation token bypasses the guard — App-triggered events propagate normally.

The CLI escape hatch (\`git push origin v1.4.0\` from a developer laptop) continues to work for free: laptop credentials were never \`GITHUB_TOKEN\` in the first place.

## Test plan

- [x] \`actionlint\` clean on \`tag-release.yml\`
- [ ] Zizmor workflow passes in CI
- [ ] **Post-merge positive E2E:** dispatch Tag Release with \`bump=patch\`, confirm \`release.yml\` fires within ~30s, \`gh release view\` succeeds, and \`git ls-remote origin v1 v1.3\` both point at the new patch.
- [ ] **Post-merge CLI regression:** push a disposable tag \`v1.99.0-test\` from the CLI, confirm \`release.yml\` fires normally, delete the test tag and release afterward.

## Prereqs already in place

- \`vars.RELEASE_BOT_APP_ID\` set to the App ID.
- \`secrets.RELEASE_BOT_PRIVATE_KEY\` set to the App's PEM private key.
- The App is installed on this repo with \`Contents: Read and write\` and no other permissions.

## Notes for reviewers

- The preflight step writes a markdown link in \`\$GITHUB_STEP_SUMMARY\` using a relative path (\`../../README.md#release-bot-app-setup\`). Relative links may not render as clickable in the Actions step-summary UI, but the \`::error::\` annotation text (\`see README#release-bot-app-setup\`) is self-describing — polish item, not a correctness bug.
- Job-level \`permissions: contents: write\` is retained intentionally. It's orthogonal to the App token and governs any future step that uses \`GITHUB_TOKEN\`; removing it is out of scope for this fix.