### PR TITLE
fix(cooldown): add auto_merge input for clean Dependabot PRs

### DIFF
--- a/.github/workflows/dependency-cooldown-scan.yml
+++ b/.github/workflows/dependency-cooldown-scan.yml
@@ -455,26 +455,14 @@ jobs:
               echo "Posted change notification"
             fi
 
-            # Set status to success
-            if [[ "$AUTO_MERGE" == "true" ]] && [ "$TOTAL" -eq 0 ]; then
-              STATUS_DESC="Cool-down complete. Clean scan. Auto-merge enabled."
-            elif [[ "$AUTO_MERGE" == "true" ]] && [ "$TOTAL" -gt 0 ]; then
-              STATUS_DESC="Cool-down complete. Advisories found. Manual review required."
-            else
-              STATUS_DESC="Cool-down complete. Exploit scan posted. Ready for manual review."
-            fi
-
-            gh api "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
-              -f state=success \
-              -f context="dependency-cooldown / gate" \
-              -f description="$STATUS_DESC"
-
             # --- Auto-merge decision (opt-in via auto_merge input) ---
             if [[ "$AUTO_MERGE" == "true" ]]; then
               if [ "$TOTAL" -eq 0 ]; then
                 if gh pr merge --auto --squash "$PR_NUMBER" --repo "$GH_REPO"; then
+                  STATUS_DESC="Cool-down complete. Clean scan. Auto-merge enabled."
                   echo "Auto-merge enabled for PR #${PR_NUMBER} (clean scan)"
                 else
+                  STATUS_DESC="Cool-down complete. Clean scan. Auto-merge unavailable — merge manually."
                   echo "WARNING: gh pr merge failed for PR #${PR_NUMBER} — manual merge required"
                 fi
               else
@@ -485,9 +473,18 @@ jobs:
                   --force
                 gh pr edit "$PR_NUMBER" --repo "$GH_REPO" \
                   --add-label "security-review-needed"
+                STATUS_DESC="Cool-down complete. Advisories found. Manual review required."
                 echo "Skipped auto-merge for PR #${PR_NUMBER}: ${TOTAL} advisory/ies found, labeled security-review-needed"
               fi
+            else
+              STATUS_DESC="Cool-down complete. Exploit scan posted. Ready for manual review."
             fi
+
+            # Set status to success
+            gh api "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
+              -f state=success \
+              -f context="dependency-cooldown / gate" \
+              -f description="$STATUS_DESC"
 
             echo "=== Done with PR #${PR_NUMBER} ==="
           done

--- a/.github/workflows/dependency-cooldown-scan.yml
+++ b/.github/workflows/dependency-cooldown-scan.yml
@@ -381,7 +381,11 @@ jobs:
               ROW1="| GitHub Advisory (GHSA) | 0 found |"
               ROW2="| OSV.dev | 0 found |"
               RESULTS_TABLE="$(printf '%s\n%s\n%s\n%s' "$TABLE_HDR" "$TABLE_SEP" "$ROW1" "$ROW2")"
-              RESULTS_FOOTER="> This PR is now eligible for manual review and merge."
+              if [[ "$AUTO_MERGE" == "true" ]]; then
+                RESULTS_FOOTER="> Auto-merge has been enabled. This PR will merge once all status checks pass."
+              else
+                RESULTS_FOOTER="> This PR is now eligible for manual review and merge."
+              fi
             fi
 
             COMMENT_BODY="$(printf '%s\n\n%s\n%s\n\n%s\n\n%s\n\n%s\n\n%s%s' \
@@ -452,10 +456,38 @@ jobs:
             fi
 
             # Set status to success
+            if [[ "$AUTO_MERGE" == "true" ]] && [ "$TOTAL" -eq 0 ]; then
+              STATUS_DESC="Cool-down complete. Clean scan. Auto-merge enabled."
+            elif [[ "$AUTO_MERGE" == "true" ]] && [ "$TOTAL" -gt 0 ]; then
+              STATUS_DESC="Cool-down complete. Advisories found. Manual review required."
+            else
+              STATUS_DESC="Cool-down complete. Exploit scan posted. Ready for manual review."
+            fi
+
             gh api "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
               -f state=success \
               -f context="dependency-cooldown / gate" \
-              -f description="Cool-down complete. Exploit scan posted. Ready for manual review."
+              -f description="$STATUS_DESC"
+
+            # --- Auto-merge decision (opt-in via auto_merge input) ---
+            if [[ "$AUTO_MERGE" == "true" ]]; then
+              if [ "$TOTAL" -eq 0 ]; then
+                if gh pr merge --auto --squash "$PR_NUMBER" --repo "$GH_REPO"; then
+                  echo "Auto-merge enabled for PR #${PR_NUMBER} (clean scan)"
+                else
+                  echo "WARNING: gh pr merge failed for PR #${PR_NUMBER} — manual merge required"
+                fi
+              else
+                gh label create "security-review-needed" \
+                  --repo "$GH_REPO" \
+                  --color "B60205" \
+                  --description "Dependency scan found advisories — manual review required" \
+                  --force
+                gh pr edit "$PR_NUMBER" --repo "$GH_REPO" \
+                  --add-label "security-review-needed"
+                echo "Skipped auto-merge for PR #${PR_NUMBER}: ${TOTAL} advisory/ies found, labeled security-review-needed"
+              fi
+            fi
 
             echo "=== Done with PR #${PR_NUMBER} ==="
           done

--- a/.github/workflows/dependency-cooldown-scan.yml
+++ b/.github/workflows/dependency-cooldown-scan.yml
@@ -15,6 +15,10 @@ on:
         type: boolean
         default: true
         description: "Include OpenSSF Scorecard in scan results"
+      auto_merge:
+        type: boolean
+        default: false
+        description: "Auto-merge clean PRs after scan completes"
 
 jobs:
   scan:
@@ -93,6 +97,7 @@ jobs:
           PR_NUMBERS: ${{ steps.find-prs.outputs.pr_numbers }}
           BYPASS_LABEL: ${{ inputs.bypass_label }}
           ENABLE_SCORECARD: ${{ inputs.enable_scorecard }}
+          AUTO_MERGE: ${{ inputs.auto_merge }}
         run: |
           for PR_NUMBER in $PR_NUMBERS; do
             echo "=== Scanning PR #${PR_NUMBER} ==="


### PR DESCRIPTION
## Summary

- Add `auto_merge` boolean input (default: `false`) to cooldown scan workflow
- When enabled: clean scans auto-merge via `gh pr merge --auto --squash`
- When advisories found: auto-creates and applies `security-review-needed` label
- Context-aware status descriptions and comment footers
- Status description reflects actual merge outcome (not just intent)

Fixes #16

## Calling workflow changes required

Repos opting in must:
1. Add `contents: write` permission (needed for `gh pr merge`)
2. Add `pull-requests: write` permission (needed for `gh pr merge --auto` and `gh pr edit --add-label`)
3. Pass `auto_merge: true`
4. Offset scan cron and Dependabot schedule by 6-12 hours (see spec)
5. Enable "Allow auto-merge" in repo Settings > General

## Test plan

- [ ] Verify `auto_merge` defaults to `false` — no behavior change for existing callers
- [ ] Trigger `workflow_dispatch` on a repo with `auto_merge: true` and a mature clean Dependabot PR
- [ ] Verify `gh pr merge --auto --squash` is called and logged
- [ ] Verify status description says "Auto-merge enabled" on success, "Auto-merge unavailable" on failure
- [ ] Verify `security-review-needed` label is created and applied when advisories exist
- [ ] Verify status description reflects auto-merge state
- [ ] Verify comment footer reflects auto-merge state