### PR TITLE
fix(cooldown): add self-consumption callers for shared-workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+      time: "18:00"
+      timezone: "America/Los_Angeles"
     commit-message:
       prefix: "deps"

--- a/.github/workflows/ci-cooldown-gate.yml
+++ b/.github/workflows/ci-cooldown-gate.yml
@@ -3,6 +3,7 @@ name: Dependency Cool-Down Gate
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   contents: read

--- a/.github/workflows/ci-cooldown-gate.yml
+++ b/.github/workflows/ci-cooldown-gate.yml
@@ -1,0 +1,15 @@
+name: Dependency Cool-Down Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+  issues: write
+
+jobs:
+  gate:
+    uses: ./.github/workflows/dependency-cooldown-gate.yml

--- a/.github/workflows/ci-cooldown-scan.yml
+++ b/.github/workflows/ci-cooldown-scan.yml
@@ -1,0 +1,17 @@
+name: Dependency Cool-Down Scan
+
+on:
+  schedule:
+    - cron: "0 15 * * 1-5"  # 8am PT (PDT) / 7am PT (PST)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  scan:
+    uses: ./.github/workflows/dependency-cooldown-scan.yml
+    with:
+      auto_merge: true

--- a/.github/workflows/ci-cooldown-scan.yml
+++ b/.github/workflows/ci-cooldown-scan.yml
@@ -9,6 +9,11 @@ permissions:
   contents: write
   pull-requests: write
   statuses: write
+  issues: write
+
+concurrency:
+  group: cooldown-scan
+  cancel-in-progress: false
 
 jobs:
   scan:


### PR DESCRIPTION
## Summary

- Add gate caller workflow so shared-workflows dogfoods its own cooldown pipeline on PRs
- Add scan caller workflow with `auto_merge: true` and `workflow_dispatch` for manual triggers
- Offset Dependabot schedule to 6pm PT to prevent same-day race with 8am PT scan

Builds on PR #17 which added the `auto_merge` input (v1.3.2).

## Test plan

- [ ] Verify gate caller sets `pending` status on Dependabot PRs and `success` on non-bot PRs
- [ ] Verify gate caller creates tracking issues for new Dependabot PRs
- [ ] Trigger scan `workflow_dispatch` to verify manual scan works
- [ ] After merge: add `dependency-cooldown / gate` and `Workflow Security Analysis` as required status checks (Task 5)