### PR TITLE
fix(cooldown): filter advisories already patched in target version

### DIFF
--- a/.github/workflows/dependency-cooldown-scan.yml
+++ b/.github/workflows/dependency-cooldown-scan.yml
@@ -162,17 +162,36 @@ jobs:
             FILTERED_RESULTS=""
             FILTERED_TOTAL=0
 
-            # --- Parse GitHub Actions dependencies ---
-            ACTIONS=$(echo "$DIFF" | grep -E '^\+\s+uses:' | \
-              sed -E 's/^\+\s+uses:\s+//' | \
-              sed -E 's/@.*//' | \
-              sed -E 's/\s*#.*//' | \
-              grep -v -E '^(\.\/|docker://)' | \
-              sort -u || true)
+            # --- Parse GitHub Actions dependencies (with version extraction) ---
+            ACTIONS=""
+            while IFS= read -r _uses_line; do
+              [ -z "$_uses_line" ] && continue
+              _action_name=$(echo "$_uses_line" | sed -E 's/^\+\s+uses:\s+//' | sed -E 's/@.*//' | sed -E 's/\s*$//')
+              echo "$_action_name" | grep -qE '^(\./|docker://)' && continue
+              echo "$ACTIONS" | grep -qxF "$_action_name" 2>/dev/null && continue
+              _action_ver=$(echo "$_uses_line" | grep -oE '#\s*v[0-9][0-9.]*' | sed -E 's/#\s*v//' || true)
+              ACTIONS="$(printf '%s\n%s' "$ACTIONS" "$_action_name")"
+              ACTION_VERSIONS["$_action_name"]="$_action_ver"
+            done <<< "$(echo "$DIFF" | grep -E '^\+\s+uses:' || true)"
+            ACTIONS=$(echo "$ACTIONS" | sed '/^$/d' | sort -u)
+
+            # Fallback: extract versions from Dependabot PR body for actions without inline comment
+            for ACTION in $ACTIONS; do
+              [ -z "$ACTION" ] && continue
+              if [ -z "${ACTION_VERSIONS[$ACTION]}" ]; then
+                _dep_ver=$(echo "$PR_BODY" | grep -F "[$ACTION]" | grep -oE 'to [0-9][0-9.]*' | head -1 | sed 's/^to //' || true)
+                ACTION_VERSIONS["$ACTION"]="$_dep_ver"
+              fi
+            done
 
             for ACTION in $ACTIONS; do
               [ -z "$ACTION" ] && continue
-              DEPS="${DEPS}\`${ACTION}\`, "
+              _ver="${ACTION_VERSIONS[$ACTION]}"
+              if [ -n "$_ver" ]; then
+                DEPS="${DEPS}\`${ACTION}\` (v${_ver}), "
+              else
+                DEPS="${DEPS}\`${ACTION}\`, "
+              fi
 
               # Query GHSA via GraphQL
               GHSA_RESULT=$(gh api graphql -f query='

--- a/.github/workflows/dependency-cooldown-scan.yml
+++ b/.github/workflows/dependency-cooldown-scan.yml
@@ -264,20 +264,41 @@ jobs:
               fi
             done
 
-            # --- Parse Python dependencies ---
-            PY_DEPS=$(echo "$DIFF" | grep -E '^\+.*=' | \
+            # --- Parse Python dependencies (with version extraction) ---
+            PY_DEPS=""
+            while IFS= read -r _py_line; do
+              [ -z "$_py_line" ] && continue
+              _pkg_name=$(echo "$_py_line" | sed -E 's/[>=<~!].*//' | sed -E 's/\s*$//')
+              [ -z "$_pkg_name" ] && continue
+              echo "$PY_DEPS" | grep -qxF "$_pkg_name" 2>/dev/null && continue
+              _pkg_ver=$(echo "$_py_line" | grep -oE '[>=<~!]+[0-9][0-9.]*' | head -1 | sed -E 's/^[>=<~!]+//' || true)
+              PY_DEPS="$(printf '%s\n%s' "$PY_DEPS" "$_pkg_name")"
+              PY_VERSIONS["$_pkg_name"]="$_pkg_ver"
+            done <<< "$(echo "$DIFF" | grep -E '^\+.*=' | \
               grep -v '^\+\+\+' | \
               grep -v '^\+#' | \
               grep -v 'uses:' | \
               sed -E 's/^\+\s*//' | \
-              grep -E '^[a-zA-Z].*[>=<~!]' | \
-              sed -E 's/[>=<~!].*//' | \
-              sed -E 's/\s*$//' | \
-              sort -u || true)
+              grep -E '^[a-zA-Z].*[>=<~!]' || true)"
+            PY_DEPS=$(echo "$PY_DEPS" | sed '/^$/d' | sort -u)
+
+            # Fallback: extract versions from Dependabot PR body for packages without version
+            for PKG in $PY_DEPS; do
+              [ -z "$PKG" ] && continue
+              if [ -z "${PY_VERSIONS[$PKG]}" ]; then
+                _dep_ver=$(echo "$PR_BODY" | grep -Fi "[$PKG]" | grep -oE 'to [0-9][0-9.]*' | head -1 | sed 's/^to //' || true)
+                PY_VERSIONS["$PKG"]="$_dep_ver"
+              fi
+            done
 
             for PKG in $PY_DEPS; do
               [ -z "$PKG" ] && continue
-              DEPS="${DEPS}\`${PKG}\`, "
+              _ver="${PY_VERSIONS[$PKG]}"
+              if [ -n "$_ver" ]; then
+                DEPS="${DEPS}\`${PKG}\` (v${_ver}), "
+              else
+                DEPS="${DEPS}\`${PKG}\`, "
+              fi
 
               # Query GHSA for PyPI
               GHSA_RESULT=$(gh api graphql -f query='

--- a/.github/workflows/dependency-cooldown-scan.yml
+++ b/.github/workflows/dependency-cooldown-scan.yml
@@ -247,7 +247,7 @@ jobs:
                     GHSA_TOTAL=$((GHSA_TOTAL + 1))
                   done <<< "$(echo "$GHSA_RESULT" | jq -r '
                     .data.securityVulnerabilities.nodes[] |
-                    [.advisory.ghsaId, .advisory.severity, .advisory.summary, (.firstPatchedVersion.identifier // "")] |
+                    [.advisory.ghsaId, .advisory.severity, .advisory.summary, ((.firstPatchedVersion.identifier // "") | ltrimstr("v"))] |
                     @tsv
                   ' 2>/dev/null || true)"
                 else
@@ -386,7 +386,7 @@ jobs:
                     GHSA_TOTAL=$((GHSA_TOTAL + 1))
                   done <<< "$(echo "$GHSA_RESULT" | jq -r '
                     .data.securityVulnerabilities.nodes[] |
-                    [.advisory.ghsaId, .advisory.severity, .advisory.summary, (.firstPatchedVersion.identifier // "")] |
+                    [.advisory.ghsaId, .advisory.severity, .advisory.summary, ((.firstPatchedVersion.identifier // "") | ltrimstr("v"))] |
                     @tsv
                   ' 2>/dev/null || true)"
                 else

--- a/.github/workflows/dependency-cooldown-scan.yml
+++ b/.github/workflows/dependency-cooldown-scan.yml
@@ -167,6 +167,7 @@ jobs:
             while IFS= read -r _uses_line; do
               [ -z "$_uses_line" ] && continue
               _action_name=$(echo "$_uses_line" | sed -E 's/^\+\s+uses:\s+//' | sed -E 's/@.*//' | sed -E 's/\s*$//')
+              [ -z "$_action_name" ] && continue
               echo "$_action_name" | grep -qE '^(\./|docker://)' && continue
               echo "$ACTIONS" | grep -qxF "$_action_name" 2>/dev/null && continue
               _action_ver=$(echo "$_uses_line" | grep -oE '#\s*v[0-9][0-9.]*' | sed -E 's/#\s*v//' || true)
@@ -271,7 +272,7 @@ jobs:
               _pkg_name=$(echo "$_py_line" | sed -E 's/[>=<~!].*//' | sed -E 's/\s*$//')
               [ -z "$_pkg_name" ] && continue
               echo "$PY_DEPS" | grep -qxF "$_pkg_name" 2>/dev/null && continue
-              _pkg_ver=$(echo "$_py_line" | grep -oE '[>=<~!]+[0-9][0-9.]*' | head -1 | sed -E 's/^[>=<~!]+//' || true)
+              _pkg_ver=$(echo "$_py_line" | grep -oE '[>=<~]+[0-9][0-9.]*' | head -1 | sed -E 's/^[>=<~]+//' || true)
               PY_DEPS="$(printf '%s\n%s' "$PY_DEPS" "$_pkg_name")"
               PY_VERSIONS["$_pkg_name"]="$_pkg_ver"
             done <<< "$(echo "$DIFF" | grep -E '^\+.*=' | \

--- a/.github/workflows/dependency-cooldown-scan.yml
+++ b/.github/workflows/dependency-cooldown-scan.yml
@@ -99,15 +99,17 @@ jobs:
           ENABLE_SCORECARD: ${{ inputs.enable_scorecard }}
           AUTO_MERGE: ${{ inputs.auto_merge }}
         run: |
+          declare -A ACTION_VERSIONS PY_VERSIONS
           for PR_NUMBER in $PR_NUMBERS; do
             echo "=== Scanning PR #${PR_NUMBER} ==="
 
             # Get PR metadata including labels for bypass check
             PR_META=$(gh pr view "$PR_NUMBER" \
               --repo "$GH_REPO" \
-              --json createdAt,headRefOid,labels)
+              --json createdAt,headRefOid,labels,body)
             CREATED_AT=$(echo "$PR_META" | jq -r '.createdAt')
             HEAD_SHA=$(echo "$PR_META" | jq -r '.headRefOid')
+            PR_BODY=$(echo "$PR_META" | jq -r '.body // ""')
 
             # Check for bypass label
             HAS_BYPASS=$(echo "$PR_META" | jq -r \
@@ -155,6 +157,10 @@ jobs:
             GHSA_TOTAL=0
             OSV_TOTAL=0
             HAS_ERROR=""
+            ACTION_VERSIONS=()
+            PY_VERSIONS=()
+            FILTERED_RESULTS=""
+            FILTERED_TOTAL=0
 
             # --- Parse GitHub Actions dependencies ---
             ACTIONS=$(echo "$DIFF" | grep -E '^\+\s+uses:' | \

--- a/.github/workflows/dependency-cooldown-scan.yml
+++ b/.github/workflows/dependency-cooldown-scan.yml
@@ -238,9 +238,15 @@ jobs:
                 fi
               fi
 
-              # Query OSV
-              OSV_BODY=$(jq -n --arg name "$ACTION" --arg eco "GitHub Actions" \
-                '{"package":{"name":$name,"ecosystem":$eco}}')
+              # Query OSV (version-filtered when target version is known)
+              _target_ver="${ACTION_VERSIONS[$ACTION]}"
+              if [ -n "$_target_ver" ]; then
+                OSV_BODY=$(jq -n --arg name "$ACTION" --arg eco "GitHub Actions" --arg ver "$_target_ver" \
+                  '{"package":{"name":$name,"ecosystem":$eco},"version":$ver}')
+              else
+                OSV_BODY=$(jq -n --arg name "$ACTION" --arg eco "GitHub Actions" \
+                  '{"package":{"name":$name,"ecosystem":$eco}}')
+              fi
               OSV_RESULT=$(curl -sf --max-time 30 \
                 -X POST "https://api.osv.dev/v1/query" \
                 -H "Content-Type: application/json" \
@@ -345,9 +351,15 @@ jobs:
                 fi
               fi
 
-              # Query OSV for PyPI
-              OSV_BODY=$(jq -n --arg name "$PKG" --arg eco "PyPI" \
-                '{"package":{"name":$name,"ecosystem":$eco}}')
+              # Query OSV for PyPI (version-filtered when target version is known)
+              _target_ver="${PY_VERSIONS[$PKG]}"
+              if [ -n "$_target_ver" ]; then
+                OSV_BODY=$(jq -n --arg name "$PKG" --arg eco "PyPI" --arg ver "$_target_ver" \
+                  '{"package":{"name":$name,"ecosystem":$eco},"version":$ver}')
+              else
+                OSV_BODY=$(jq -n --arg name "$PKG" --arg eco "PyPI" \
+                  '{"package":{"name":$name,"ecosystem":$eco}}')
+              fi
               OSV_RESULT=$(curl -sf --max-time 30 \
                 -X POST "https://api.osv.dev/v1/query" \
                 -H "Content-Type: application/json" \

--- a/.github/workflows/dependency-cooldown-scan.yml
+++ b/.github/workflows/dependency-cooldown-scan.yml
@@ -194,7 +194,7 @@ jobs:
                 DEPS="${DEPS}\`${ACTION}\`, "
               fi
 
-              # Query GHSA via GraphQL
+              # Query GHSA via GraphQL (includes version data for filtering)
               GHSA_RESULT=$(gh api graphql -f query='
                 query($name: String!) {
                   securityVulnerabilities(
@@ -207,6 +207,10 @@ jobs:
                         ghsaId
                         severity
                         summary
+                      }
+                      vulnerableVersionRange
+                      firstPatchedVersion {
+                        identifier
                       }
                     }
                   }
@@ -226,15 +230,37 @@ jobs:
               fi
 
               if [ -n "$GHSA_RESULT" ]; then
-                GHSA_VULNS=$(echo "$GHSA_RESULT" | jq -r '
-                  .data.securityVulnerabilities.nodes[] |
-                  "| \(.advisory.ghsaId) | \(.advisory.severity) | \(.advisory.summary) | GHSA |"
-                ' 2>/dev/null || true)
+                _target_ver="${ACTION_VERSIONS[$ACTION]}"
 
-                if [ -n "$GHSA_VULNS" ]; then
-                  GHSA_COUNT=$(echo "$GHSA_VULNS" | wc -l | tr -d ' ')
-                  GHSA_TOTAL=$((GHSA_TOTAL + GHSA_COUNT))
-                  SCAN_RESULTS="${SCAN_RESULTS}${GHSA_VULNS}"$'\n'
+                if [ -n "$_target_ver" ]; then
+                  while IFS=$'\t' read -r _g_id _g_sev _g_sum _g_patched; do
+                    [ -z "$_g_id" ] && continue
+                    if [ -n "$_g_patched" ]; then
+                      _lowest=$(printf '%s\n' "$_g_patched" "$_target_ver" | sort -V | head -1)
+                      if [ "$_lowest" = "$_g_patched" ]; then
+                        FILTERED_RESULTS="${FILTERED_RESULTS}| ${_g_id} | ${_g_sev} | ${_g_sum} | GHSA | ${_g_patched} |"$'\n'
+                        FILTERED_TOTAL=$((FILTERED_TOTAL + 1))
+                        continue
+                      fi
+                    fi
+                    SCAN_RESULTS="${SCAN_RESULTS}| ${_g_id} | ${_g_sev} | ${_g_sum} | GHSA |"$'\n'
+                    GHSA_TOTAL=$((GHSA_TOTAL + 1))
+                  done <<< "$(echo "$GHSA_RESULT" | jq -r '
+                    .data.securityVulnerabilities.nodes[] |
+                    [.advisory.ghsaId, .advisory.severity, .advisory.summary, (.firstPatchedVersion.identifier // "")] |
+                    @tsv
+                  ' 2>/dev/null || true)"
+                else
+                  GHSA_VULNS=$(echo "$GHSA_RESULT" | jq -r '
+                    .data.securityVulnerabilities.nodes[] |
+                    "| \(.advisory.ghsaId) | \(.advisory.severity) | \(.advisory.summary) | GHSA |"
+                  ' 2>/dev/null || true)
+
+                  if [ -n "$GHSA_VULNS" ]; then
+                    GHSA_COUNT=$(echo "$GHSA_VULNS" | wc -l | tr -d ' ')
+                    GHSA_TOTAL=$((GHSA_TOTAL + GHSA_COUNT))
+                    SCAN_RESULTS="${SCAN_RESULTS}${GHSA_VULNS}"$'\n'
+                  fi
                 fi
               fi
 
@@ -307,7 +333,7 @@ jobs:
                 DEPS="${DEPS}\`${PKG}\`, "
               fi
 
-              # Query GHSA for PyPI
+              # Query GHSA for PyPI (includes version data for filtering)
               GHSA_RESULT=$(gh api graphql -f query='
                 query($name: String!) {
                   securityVulnerabilities(
@@ -320,6 +346,10 @@ jobs:
                         ghsaId
                         severity
                         summary
+                      }
+                      vulnerableVersionRange
+                      firstPatchedVersion {
+                        identifier
                       }
                     }
                   }
@@ -339,15 +369,37 @@ jobs:
               fi
 
               if [ -n "$GHSA_RESULT" ]; then
-                GHSA_VULNS=$(echo "$GHSA_RESULT" | jq -r '
-                  .data.securityVulnerabilities.nodes[] |
-                  "| \(.advisory.ghsaId) | \(.advisory.severity) | \(.advisory.summary) | GHSA |"
-                ' 2>/dev/null || true)
+                _target_ver="${PY_VERSIONS[$PKG]}"
 
-                if [ -n "$GHSA_VULNS" ]; then
-                  GHSA_COUNT=$(echo "$GHSA_VULNS" | wc -l | tr -d ' ')
-                  GHSA_TOTAL=$((GHSA_TOTAL + GHSA_COUNT))
-                  SCAN_RESULTS="${SCAN_RESULTS}${GHSA_VULNS}"$'\n'
+                if [ -n "$_target_ver" ]; then
+                  while IFS=$'\t' read -r _g_id _g_sev _g_sum _g_patched; do
+                    [ -z "$_g_id" ] && continue
+                    if [ -n "$_g_patched" ]; then
+                      _lowest=$(printf '%s\n' "$_g_patched" "$_target_ver" | sort -V | head -1)
+                      if [ "$_lowest" = "$_g_patched" ]; then
+                        FILTERED_RESULTS="${FILTERED_RESULTS}| ${_g_id} | ${_g_sev} | ${_g_sum} | GHSA | ${_g_patched} |"$'\n'
+                        FILTERED_TOTAL=$((FILTERED_TOTAL + 1))
+                        continue
+                      fi
+                    fi
+                    SCAN_RESULTS="${SCAN_RESULTS}| ${_g_id} | ${_g_sev} | ${_g_sum} | GHSA |"$'\n'
+                    GHSA_TOTAL=$((GHSA_TOTAL + 1))
+                  done <<< "$(echo "$GHSA_RESULT" | jq -r '
+                    .data.securityVulnerabilities.nodes[] |
+                    [.advisory.ghsaId, .advisory.severity, .advisory.summary, (.firstPatchedVersion.identifier // "")] |
+                    @tsv
+                  ' 2>/dev/null || true)"
+                else
+                  GHSA_VULNS=$(echo "$GHSA_RESULT" | jq -r '
+                    .data.securityVulnerabilities.nodes[] |
+                    "| \(.advisory.ghsaId) | \(.advisory.severity) | \(.advisory.summary) | GHSA |"
+                  ' 2>/dev/null || true)
+
+                  if [ -n "$GHSA_VULNS" ]; then
+                    GHSA_COUNT=$(echo "$GHSA_VULNS" | wc -l | tr -d ' ')
+                    GHSA_TOTAL=$((GHSA_TOTAL + GHSA_COUNT))
+                    SCAN_RESULTS="${SCAN_RESULTS}${GHSA_VULNS}"$'\n'
+                  fi
                 fi
               fi
 

--- a/.github/workflows/dependency-cooldown-scan.yml
+++ b/.github/workflows/dependency-cooldown-scan.yml
@@ -532,7 +532,8 @@ jobs:
             if [ -n "$EXISTING_COMMENT_ID" ]; then
               PREV_BODY=$(echo "$COMMENTS_JSON" | jq -r "
                 [.[] | select(.id == ${EXISTING_COMMENT_ID})][0].body")
-              PREV_IDS=$(echo "$PREV_BODY" | \
+              PREV_ACTIVE=$(echo "$PREV_BODY" | sed '/<details>/,$d')
+              PREV_IDS=$(echo "$PREV_ACTIVE" | \
                 grep -oE '(GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}|PYSEC-[0-9]+-[0-9]+)' | \
                 sort -u | tr '\n' ',' | sed 's/,$//' || true)
             fi
@@ -578,10 +579,10 @@ jobs:
             if [[ "$AUTO_MERGE" == "true" ]]; then
               if [ "$TOTAL" -eq 0 ]; then
                 if gh pr merge --auto --squash "$PR_NUMBER" --repo "$GH_REPO"; then
-                  STATUS_DESC="Cool-down complete. Clean scan. Auto-merge enabled."
+                  STATUS_DESC="Cool-down complete. Clean scan (version-filtered). Auto-merge enabled."
                   echo "Auto-merge enabled for PR #${PR_NUMBER} (clean scan)"
                 else
-                  STATUS_DESC="Cool-down complete. Clean scan. Auto-merge unavailable — merge manually."
+                  STATUS_DESC="Cool-down complete. Clean scan (version-filtered). Auto-merge unavailable — merge manually."
                   echo "WARNING: gh pr merge failed for PR #${PR_NUMBER} — manual merge required"
                 fi
               else
@@ -592,11 +593,11 @@ jobs:
                   --force
                 gh pr edit "$PR_NUMBER" --repo "$GH_REPO" \
                   --add-label "security-review-needed"
-                STATUS_DESC="Cool-down complete. Advisories found. Manual review required."
+                STATUS_DESC="Cool-down complete. Advisories found (version-filtered). Manual review required."
                 echo "Skipped auto-merge for PR #${PR_NUMBER}: ${TOTAL} advisory/ies found, labeled security-review-needed"
               fi
             else
-              STATUS_DESC="Cool-down complete. Exploit scan posted. Ready for manual review."
+              STATUS_DESC="Cool-down complete. Exploit scan posted (version-filtered). Ready for manual review."
             fi
 
             # Set status to success

--- a/.github/workflows/dependency-cooldown-scan.yml
+++ b/.github/workflows/dependency-cooldown-scan.yml
@@ -475,22 +475,20 @@ jobs:
             # to avoid bare | at column 0 which breaks YAML block scalar parsing
             TOTAL=$((GHSA_TOTAL + OSV_TOTAL))
             if [ "$TOTAL" -gt 0 ]; then
-              RESULTS_HEADER="**${TOTAL} advisory/ies found** — review before merging."
+              RESULTS_HEADER="**${TOTAL} advisory/ies found** affecting target versions — review before merging."
               TABLE_HDR="| ID | Severity | Summary | Source |"
               TABLE_SEP="|----|----------|---------|--------|"
               RESULTS_TABLE="$(printf '%s\n%s\n%s' "$TABLE_HDR" "$TABLE_SEP" "$SCAN_RESULTS")"
               RESULTS_FOOTER="> Review the advisories above before deciding to merge."
             elif [ -n "$HAS_ERROR" ]; then
-              # Do NOT post comment or update status on errors.
-              # This allows the next scheduled run to retry the scan.
               echo "Scan had API errors for PR #${PR_NUMBER} — skipping comment and status. Will retry next cycle."
               continue
             else
-              RESULTS_HEADER="No known exploits found in GHSA or OSV databases."
+              RESULTS_HEADER="No known exploits found affecting the target versions."
               TABLE_HDR="| Source | Vulnerabilities |"
               TABLE_SEP="|--------|----------------|"
-              ROW1="| GitHub Advisory (GHSA) | 0 found |"
-              ROW2="| OSV.dev | 0 found |"
+              ROW1="| GitHub Advisory (GHSA) | 0 affecting target |"
+              ROW2="| OSV.dev | 0 affecting target |"
               RESULTS_TABLE="$(printf '%s\n%s\n%s\n%s' "$TABLE_HDR" "$TABLE_SEP" "$ROW1" "$ROW2")"
               if [[ "$AUTO_MERGE" == "true" ]]; then
                 RESULTS_FOOTER="> Auto-merge has been enabled. This PR will merge once all status checks pass."
@@ -499,7 +497,16 @@ jobs:
               fi
             fi
 
-            COMMENT_BODY="$(printf '%s\n\n%s\n%s\n\n%s\n\n%s\n\n%s\n\n%s%s' \
+            # Build collapsed historical section (non-blocking, for transparency)
+            HISTORICAL_SECTION=""
+            if [ "$FILTERED_TOTAL" -gt 0 ]; then
+              HIST_HDR="| ID | Severity | Summary | Source | Patched In |"
+              HIST_SEP="|----|----------|---------|--------|------------|"
+              HISTORICAL_SECTION="$(printf '\n<details>\n<summary>%d historical advisory/ies (patched before target version — not blocking)</summary>\n\n%s\n%s\n%s\n\n</details>' \
+                "$FILTERED_TOTAL" "$HIST_HDR" "$HIST_SEP" "$FILTERED_RESULTS")"
+            fi
+
+            COMMENT_BODY="$(printf '%s\n\n%s\n%s\n\n%s\n\n%s\n\n%s\n\n%s%s%s' \
               "## Dependency Security Scan (Cool-Down Complete)" \
               "**PR age:** ${AGE_DAYS} days, ${AGE_HOURS} hours (${BIZ_DAYS} business days)" \
               "**Packages scanned:** ${DEPS}" \
@@ -507,6 +514,7 @@ jobs:
               "$RESULTS_HEADER" \
               "$RESULTS_TABLE" \
               "$RESULTS_FOOTER" \
+              "$HISTORICAL_SECTION" \
               "$SCORECARD_SECTION")"
 
             # --- Comment management: update-or-create with change detection ---


### PR DESCRIPTION
## Summary

Fixes #21 — the dependency cooldown scan was reporting **all historical security advisories** for scanned packages, including ones already patched in the version being updated to. This caused false positives that blocked auto-merge and required unnecessary manual review.

**Root causes fixed:**
- Diff parsing discarded the target version (`sed -E 's/@.*//'` stripped the `# vX.Y.Z` comment)
- GHSA GraphQL query returned all advisories without filtering by `firstPatchedVersion`
- OSV REST query omitted the `"version"` field the API supports for server-side filtering

**Changes:**
- Extract target version from PR diff for both GitHub Actions (`# vX.Y.Z` comment) and Python (`==`/`>=` operators), with Dependabot PR body fallback
- Add `"version"` field to OSV queries for server-side filtering
- Expand GHSA GraphQL query to include `firstPatchedVersion`, filter client-side via `sort -V` — advisories patched at or below the target version are excluded from the active count
- Show filtered advisories in a collapsed `<details>` section for transparency (non-blocking)
- Fix change detection to scope `PREV_IDS` to the active section only (before `<details>` tag)
- Update status descriptions to reflect version-filtered scanning

## Test plan

- [ ] Trigger scan on a Dependabot PR updating `step-security/harden-runner` to v2.16.1 — verify the 5 historical advisories from issue #21 appear in the collapsed section, not the active results
- [ ] Verify auto-merge proceeds when all advisories are historical (TOTAL=0)
- [ ] Verify a PR with a genuine unpatched advisory still blocks auto-merge
- [ ] Verify fallback: if version extraction fails, scan reports all advisories (unfiltered behavior)
- [ ] Verify Python dependency PRs extract version from `==`/`>=` operators
- [ ] Verify YAML validity: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/dependency-cooldown-scan.yml'))"`