### PR TITLE
fix(cooldown): close silent-bypass regressions from #25, #26, #27

### DIFF
--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -1,0 +1,29 @@
+name: Script Tests
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/**'
+      - 'tests/**'
+      - '.github/workflows/ci-scripts.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  bats:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install bats
+        uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # v4.0.0
+
+      - name: Run bats
+        run: bats tests/

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -6,6 +6,7 @@ on:
       - 'scripts/**'
       - 'tests/**'
       - '.github/workflows/ci-scripts.yml'
+      - '.github/workflows/dependency-cooldown.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/dependency-cooldown.yml
+++ b/.github/workflows/dependency-cooldown.yml
@@ -482,6 +482,36 @@ jobs:
             echo "Posted change notification"
           fi
 
+          # --- Label reconciliation (Task 10 — fixes #26: every scan is authoritative) ---
+          LABEL_COLOR_security_review_needed="B60205"
+          LABEL_DESC_security_review_needed="Dependency scan found advisories — manual review required"
+          LABEL_COLOR_cooldown_pending="FBCA04"
+          LABEL_DESC_cooldown_pending="One or more target versions are within the configured cooldown window"
+
+          reconcile_label() {
+            local label="$1"
+            local should_be_present="$2"
+            local color="$3"
+            local desc="$4"
+            local current has_it
+            current=$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json labels --jq '[.labels[].name]')
+            has_it=$(echo "$current" | jq -e --arg l "$label" 'contains([$l])' >/dev/null && echo true || echo false)
+
+            if [ "$should_be_present" = "true" ] && [ "$has_it" = "false" ]; then
+              gh label create "$label" --repo "$GH_REPO" --color "$color" --description "$desc" --force >/dev/null 2>&1 || true
+              gh pr edit "$PR_NUMBER" --repo "$GH_REPO" --add-label "$label" || true
+              echo "Applied label: $label"
+            elif [ "$should_be_present" = "false" ] && [ "$has_it" = "true" ]; then
+              gh pr edit "$PR_NUMBER" --repo "$GH_REPO" --remove-label "$label" || true
+              echo "Removed stale label: $label"
+            fi
+          }
+
+          _needs_security=$([ "$TOTAL" -gt 0 ] && echo true || echo false)
+          _needs_cooldown=$([ "$COOLDOWN_FAILURES" -gt 0 ] && echo true || echo false)
+          reconcile_label "security-review-needed" "$_needs_security" "$LABEL_COLOR_security_review_needed" "$LABEL_DESC_security_review_needed"
+          reconcile_label "cooldown-pending"       "$_needs_cooldown" "$LABEL_COLOR_cooldown_pending"       "$LABEL_DESC_cooldown_pending"
+
           # --- Auto-merge decision ---
           if [[ "$AUTO_MERGE" == "true" ]]; then
             if [ "$TOTAL" -eq 0 ]; then
@@ -493,13 +523,6 @@ jobs:
                 echo "WARNING: gh pr merge failed for PR #${PR_NUMBER} — manual merge required"
               fi
             else
-              gh label create "security-review-needed" \
-                --repo "$GH_REPO" \
-                --color "B60205" \
-                --description "Dependency scan found advisories — manual review required" \
-                --force
-              gh pr edit "$PR_NUMBER" --repo "$GH_REPO" \
-                --add-label "security-review-needed"
               STATUS_DESC="Advisories found (version-filtered). Manual review required."
               echo "Skipped auto-merge for PR #${PR_NUMBER}: ${TOTAL} advisory/ies found, labeled security-review-needed"
             fi

--- a/.github/workflows/dependency-cooldown.yml
+++ b/.github/workflows/dependency-cooldown.yml
@@ -11,6 +11,14 @@ on:
         type: boolean
         default: false
         description: "Auto-merge clean PRs after scan completes"
+      cooldown_days:
+        type: number
+        default: 7
+        description: "Minimum release age in days before auto-merge is allowed. 0 disables the release-age gate entirely (pre-v2.0.2 behavior)."
+      fail_on_cooldown:
+        type: boolean
+        default: false
+        description: "If true, cooldown blocks set the gate to failure instead of pending. Use when branch protection requires a hard-red blocker."
 
 jobs:
   scan:
@@ -52,6 +60,8 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           ENABLE_SCORECARD: ${{ inputs.enable_scorecard }}
           AUTO_MERGE: ${{ inputs.auto_merge }}
+          COOLDOWN_DAYS: ${{ inputs.cooldown_days }}
+          FAIL_ON_COOLDOWN: ${{ inputs.fail_on_cooldown }}
         run: |
           DIFF=$(gh pr diff "$PR_NUMBER" --repo "$GH_REPO")
 
@@ -112,6 +122,14 @@ jobs:
           EXTRACTION_WARNING=""
           if [ "$EXPECTED_ACTIONS" != "$EXTRACTED_ACTIONS" ]; then
             EXTRACTION_WARNING="⚠️ Extraction mismatch: diff has ${EXPECTED_ACTIONS} action bumps, extractor returned ${EXTRACTED_ACTIONS}. This may indicate a silent parsing failure. Please report."
+          fi
+
+          # --- Check release age via standalone script (Task 9 — phase 2) ---
+          COOLDOWN_FAILURES=0
+          AGE_TSV=""
+          if [ "$COOLDOWN_DAYS" -gt 0 ]; then
+            AGE_TSV=$(echo "$DEPS_TSV" | bash "${GITHUB_WORKSPACE}/scripts/check-release-age.sh")
+            COOLDOWN_FAILURES=$(echo "$AGE_TSV" | awk -F'\t' '$6=="fail" || $6=="error"' | wc -l | tr -d ' ')
           fi
 
           for ACTION in $ACTIONS; do

--- a/.github/workflows/dependency-cooldown.yml
+++ b/.github/workflows/dependency-cooldown.yml
@@ -512,26 +512,39 @@ jobs:
           reconcile_label "security-review-needed" "$_needs_security" "$LABEL_COLOR_security_review_needed" "$LABEL_DESC_security_review_needed"
           reconcile_label "cooldown-pending"       "$_needs_cooldown" "$LABEL_COLOR_cooldown_pending"       "$LABEL_DESC_cooldown_pending"
 
-          # --- Auto-merge decision ---
-          if [[ "$AUTO_MERGE" == "true" ]]; then
-            if [ "$TOTAL" -eq 0 ]; then
-              if gh pr merge --auto --squash "$PR_NUMBER" --repo "$GH_REPO"; then
-                STATUS_DESC="Clean scan (version-filtered). Auto-merge enabled."
-                echo "Auto-merge enabled for PR #${PR_NUMBER} (clean scan)"
-              else
-                STATUS_DESC="Clean scan (version-filtered). Auto-merge unavailable — merge manually."
-                echo "WARNING: gh pr merge failed for PR #${PR_NUMBER} — manual merge required"
-              fi
+          # --- Gate state machine (Task 11 — combines advisory + cooldown verdicts) ---
+          if [ "$TOTAL" -gt 0 ]; then
+            # Advisory failure wins — strictest signal (existing v2.0.1 semantic: gate=success with "review needed")
+            GATE_STATE="success"
+            STATUS_DESC="${TOTAL} advisory/ies found (version-filtered). Manual review required."
+            AUTO_MERGE_OK=false
+          elif [ "$COOLDOWN_FAILURES" -gt 0 ]; then
+            if [ "$FAIL_ON_COOLDOWN" = "true" ]; then
+              GATE_STATE="failure"
             else
-              STATUS_DESC="Advisories found (version-filtered). Manual review required."
-              echo "Skipped auto-merge for PR #${PR_NUMBER}: ${TOTAL} advisory/ies found, labeled security-review-needed"
+              GATE_STATE="pending"
             fi
+            STATUS_DESC="${COOLDOWN_FAILURES} package(s) within ${COOLDOWN_DAYS}-day cooldown window. Waiting for age."
+            AUTO_MERGE_OK=false
           else
-            STATUS_DESC="Exploit scan posted (version-filtered). Ready for manual review."
+            GATE_STATE="success"
+            STATUS_DESC="Clean scan (version-filtered, cooldown ≥ ${COOLDOWN_DAYS}d). Ready for merge."
+            AUTO_MERGE_OK=true
+          fi
+
+          # --- Conditional auto-merge ---
+          if [ "$AUTO_MERGE" = "true" ] && [ "$AUTO_MERGE_OK" = "true" ]; then
+            if gh pr merge --auto --squash "$PR_NUMBER" --repo "$GH_REPO"; then
+              STATUS_DESC="${STATUS_DESC} Auto-merge enabled."
+              echo "Auto-merge enabled for PR #${PR_NUMBER}"
+            else
+              STATUS_DESC="${STATUS_DESC} Auto-merge unavailable — merge manually."
+              echo "WARNING: gh pr merge failed for PR #${PR_NUMBER}"
+            fi
           fi
 
           # --- Set final status ---
           gh api "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
-            -f state=success \
+            -f state="$GATE_STATE" \
             -f context="dependency-cooldown / gate" \
             -f description="$STATUS_DESC"

--- a/.github/workflows/dependency-cooldown.yml
+++ b/.github/workflows/dependency-cooldown.yml
@@ -67,28 +67,52 @@ jobs:
           # Fetch PR body for Dependabot version fallback
           PR_BODY=$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json body --jq '.body // ""')
 
-          # --- Parse GitHub Actions dependencies (with version extraction) ---
-          ACTIONS=""
-          while IFS= read -r _uses_line; do
-            [ -z "$_uses_line" ] && continue
-            _action_name=$(echo "$_uses_line" | sed -E 's/^\+\s+uses:\s+//' | sed -E 's/@.*//' | sed -E 's/\s*$//')
-            [ -z "$_action_name" ] && continue
-            echo "$_action_name" | grep -qE '^(\./|docker://)' && continue
-            echo "$ACTIONS" | grep -qxF "$_action_name" 2>/dev/null && continue
-            _action_ver=$(echo "$_uses_line" | grep -oE '#\s*v[0-9][0-9.]*' | sed -E 's/#\s*v//' || true)
-            ACTIONS="$(printf '%s\n%s' "$ACTIONS" "$_action_name")"
-            ACTION_VERSIONS["$_action_name"]="$_action_ver"
-          done <<< "$(echo "$DIFF" | grep -E '^\+\s+uses:' || true)"
-          ACTIONS=$(echo "$ACTIONS" | sed '/^$/d' | sort -u)
+          # --- Extract dependencies via standalone script (Task 8) ---
+          DEPS_TSV=$(echo "$DIFF" | bash "${GITHUB_WORKSPACE}/scripts/extract-deps.sh")
 
-          # Fallback: extract versions from Dependabot PR body for actions without inline comment
+          # Populate ACTIONS, PY_DEPS, ACTION_VERSIONS, PY_VERSIONS from DEPS_TSV
+          # so the existing advisory-scan loops below can consume them unchanged.
+          ACTIONS=""
+          PY_DEPS=""
+          while IFS=$'\t' read -r _name _ver _eco; do
+            [ -z "$_name" ] && continue
+            case "$_eco" in
+              actions)
+                ACTIONS="$(printf '%s\n%s' "$ACTIONS" "$_name")"
+                ACTION_VERSIONS["$_name"]="$_ver"
+                ;;
+              pypi)
+                PY_DEPS="$(printf '%s\n%s' "$PY_DEPS" "$_name")"
+                PY_VERSIONS["$_name"]="$_ver"
+                ;;
+            esac
+          done <<< "$DEPS_TSV"
+          ACTIONS=$(echo "$ACTIONS" | sed '/^$/d' | sort -u)
+          PY_DEPS=$(echo "$PY_DEPS" | sed '/^$/d' | sort -u)
+
+          # PR-body version fallback for deps without inline version (preserved from v2.0.1)
           for ACTION in $ACTIONS; do
             [ -z "$ACTION" ] && continue
-            if [ -z "${ACTION_VERSIONS[$ACTION]}" ]; then
+            if [ -z "${ACTION_VERSIONS[$ACTION]:-}" ]; then
               _dep_ver=$(echo "$PR_BODY" | grep -F "[$ACTION]" | grep -oE 'to [0-9][0-9.]*' | head -1 | sed 's/^to //' || true)
               ACTION_VERSIONS["$ACTION"]="$_dep_ver"
             fi
           done
+          for PKG in $PY_DEPS; do
+            [ -z "$PKG" ] && continue
+            if [ -z "${PY_VERSIONS[$PKG]:-}" ]; then
+              _dep_ver=$(echo "$PR_BODY" | grep -Fi "[$PKG]" | grep -oE 'to [0-9][0-9.]*' | head -1 | sed 's/^to //' || true)
+              PY_VERSIONS["$PKG"]="$_dep_ver"
+            fi
+          done
+
+          # Sanity-check: count +uses lines in diff vs extracted actions (Task 8 — fixes #27 regression defense)
+          EXPECTED_ACTIONS=$(echo "$DIFF" | grep -cE '^\+[[:space:]]+(- )?uses:' || true)
+          EXTRACTED_ACTIONS=$(echo "$ACTIONS" | sed '/^$/d' | wc -l | tr -d ' ')
+          EXTRACTION_WARNING=""
+          if [ "$EXPECTED_ACTIONS" != "$EXTRACTED_ACTIONS" ]; then
+            EXTRACTION_WARNING="⚠️ Extraction mismatch: diff has ${EXPECTED_ACTIONS} action bumps, extractor returned ${EXTRACTED_ACTIONS}. This may indicate a silent parsing failure. Please report."
+          fi
 
           for ACTION in $ACTIONS; do
             [ -z "$ACTION" ] && continue
@@ -196,33 +220,6 @@ jobs:
                 OSV_TOTAL=$((OSV_TOTAL + OSV_COUNT))
                 SCAN_RESULTS="${SCAN_RESULTS}${OSV_VULNS}"$'\n'
               fi
-            fi
-          done
-
-          # --- Parse Python dependencies (with version extraction) ---
-          PY_DEPS=""
-          while IFS= read -r _py_line; do
-            [ -z "$_py_line" ] && continue
-            _pkg_name=$(echo "$_py_line" | sed -E 's/[>=<~!].*//' | sed -E 's/\s*$//')
-            [ -z "$_pkg_name" ] && continue
-            echo "$PY_DEPS" | grep -qxF "$_pkg_name" 2>/dev/null && continue
-            _pkg_ver=$(echo "$_py_line" | grep -oE '[>=<~]+[0-9][0-9.]*' | head -1 | sed -E 's/^[>=<~]+//' || true)
-            PY_DEPS="$(printf '%s\n%s' "$PY_DEPS" "$_pkg_name")"
-            PY_VERSIONS["$_pkg_name"]="$_pkg_ver"
-          done <<< "$(echo "$DIFF" | grep -E '^\+.*=' | \
-            grep -v '^\+\+\+' | \
-            grep -v '^\+#' | \
-            grep -v 'uses:' | \
-            sed -E 's/^\+\s*//' | \
-            grep -E '^[a-zA-Z].*[>=<~!]' || true)"
-          PY_DEPS=$(echo "$PY_DEPS" | sed '/^$/d' | sort -u)
-
-          # Fallback: extract versions from Dependabot PR body for packages without version
-          for PKG in $PY_DEPS; do
-            [ -z "$PKG" ] && continue
-            if [ -z "${PY_VERSIONS[$PKG]}" ]; then
-              _dep_ver=$(echo "$PR_BODY" | grep -Fi "[$PKG]" | grep -oE 'to [0-9][0-9.]*' | head -1 | sed 's/^to //' || true)
-              PY_VERSIONS["$PKG"]="$_dep_ver"
             fi
           done
 

--- a/.github/workflows/dependency-cooldown.yml
+++ b/.github/workflows/dependency-cooldown.yml
@@ -29,6 +29,15 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Checkout shared-workflows scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: j7an/shared-workflows
+          ref: ${{ github.workflow_sha }}
+          path: shared-workflows
+          sparse-checkout: scripts
+          persist-credentials: false
+
       - name: Set initial status
         id: gate
         env:
@@ -78,7 +87,7 @@ jobs:
           PR_BODY=$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json body --jq '.body // ""')
 
           # --- Extract dependencies via standalone script (Task 8) ---
-          DEPS_TSV=$(echo "$DIFF" | bash "${GITHUB_WORKSPACE}/scripts/extract-deps.sh")
+          DEPS_TSV=$(echo "$DIFF" | bash "${GITHUB_WORKSPACE}/shared-workflows/scripts/extract-deps.sh")
 
           # Populate ACTIONS, PY_DEPS, ACTION_VERSIONS, PY_VERSIONS from DEPS_TSV
           # so the existing advisory-scan loops below can consume them unchanged.
@@ -116,19 +125,26 @@ jobs:
             fi
           done
 
-          # Sanity-check: count +uses lines in diff vs extracted actions (Task 8 — fixes #27 regression defense)
-          EXPECTED_ACTIONS=$(echo "$DIFF" | grep -cE '^\+[[:space:]]+(- )?uses:' || true)
+          # Sanity-check: count UNIQUE action names in the diff vs extracted actions
+          # (Task 13b — fixes false-positive on diffs with repeated actions across files)
+          # Uses the same regex shape as scripts/extract-deps.sh so drift cannot produce
+          # spurious warnings. Deduplicates via sort -u before counting so that an action
+          # referenced in N files counts once, matching the extractor's dedup semantic.
+          EXPECTED_ACTIONS=$(echo "$DIFF" \
+            | grep -oE '^\+[[:space:]]+(-[[:space:]]+)?uses:[[:space:]]+[^[:space:]@]+' \
+            | sed -E 's/^\+[[:space:]]+(-[[:space:]]+)?uses:[[:space:]]+//' \
+            | sort -u | wc -l | tr -d ' ')
           EXTRACTED_ACTIONS=$(echo "$ACTIONS" | sed '/^$/d' | wc -l | tr -d ' ')
           EXTRACTION_WARNING=""
           if [ "$EXPECTED_ACTIONS" != "$EXTRACTED_ACTIONS" ]; then
-            EXTRACTION_WARNING="⚠️ Extraction mismatch: diff has ${EXPECTED_ACTIONS} action bumps, extractor returned ${EXTRACTED_ACTIONS}. This may indicate a silent parsing failure. Please report."
+            EXTRACTION_WARNING="⚠️ Extraction mismatch: diff contains ${EXPECTED_ACTIONS} unique action(s), extractor returned ${EXTRACTED_ACTIONS}. This may indicate a silent parsing failure. Please report."
           fi
 
           # --- Check release age via standalone script (Task 9 — phase 2) ---
           COOLDOWN_FAILURES=0
           AGE_TSV=""
           if [ "$COOLDOWN_DAYS" -gt 0 ]; then
-            AGE_TSV=$(echo "$DEPS_TSV" | bash "${GITHUB_WORKSPACE}/scripts/check-release-age.sh")
+            AGE_TSV=$(echo "$DEPS_TSV" | bash "${GITHUB_WORKSPACE}/shared-workflows/scripts/check-release-age.sh")
             COOLDOWN_FAILURES=$(echo "$AGE_TSV" | awk -F'\t' '$6=="fail" || $6=="error"' | wc -l | tr -d ' ')
           fi
 
@@ -387,7 +403,7 @@ jobs:
           # --- Build comment body ---
           TOTAL=$((GHSA_TOTAL + OSV_TOTAL))
 
-          # --- Label reconciliation (Task 13a — runs BEFORE HAS_ERROR exit so error-path re-scans still reconcile) ---
+          # --- Label reconciliation (Task 13b — authoritative on clean runs, additive-only on HAS_ERROR paths) ---
           LABEL_COLOR_security_review_needed="B60205"
           LABEL_DESC_security_review_needed="Dependency scan found advisories — manual review required"
           LABEL_COLOR_cooldown_pending="FBCA04"
@@ -406,9 +422,11 @@ jobs:
               gh label create "$label" --repo "$GH_REPO" --color "$color" --description "$desc" --force >/dev/null 2>&1 || true
               gh pr edit "$PR_NUMBER" --repo "$GH_REPO" --add-label "$label" || true
               echo "Applied label: $label"
-            elif [ "$should_be_present" = "false" ] && [ "$has_it" = "true" ]; then
+            elif [ "$should_be_present" = "false" ] && [ "$has_it" = "true" ] && [ -z "${HAS_ERROR:-}" ]; then
               gh pr edit "$PR_NUMBER" --repo "$GH_REPO" --remove-label "$label" || true
               echo "Removed stale label: $label"
+            elif [ "$should_be_present" = "false" ] && [ "$has_it" = "true" ]; then
+              echo "Preserving label $label: scan had API errors, verdict is unreliable"
             fi
           }
 

--- a/.github/workflows/dependency-cooldown.yml
+++ b/.github/workflows/dependency-cooldown.yml
@@ -386,6 +386,37 @@ jobs:
 
           # --- Build comment body ---
           TOTAL=$((GHSA_TOTAL + OSV_TOTAL))
+
+          # --- Label reconciliation (Task 13a — runs BEFORE HAS_ERROR exit so error-path re-scans still reconcile) ---
+          LABEL_COLOR_security_review_needed="B60205"
+          LABEL_DESC_security_review_needed="Dependency scan found advisories — manual review required"
+          LABEL_COLOR_cooldown_pending="FBCA04"
+          LABEL_DESC_cooldown_pending="One or more target versions are within the configured cooldown window"
+
+          reconcile_label() {
+            local label="$1"
+            local should_be_present="$2"
+            local color="$3"
+            local desc="$4"
+            local current has_it
+            current=$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json labels --jq '[.labels[].name]')
+            has_it=$(echo "$current" | jq -e --arg l "$label" 'contains([$l])' >/dev/null && echo true || echo false)
+
+            if [ "$should_be_present" = "true" ] && [ "$has_it" = "false" ]; then
+              gh label create "$label" --repo "$GH_REPO" --color "$color" --description "$desc" --force >/dev/null 2>&1 || true
+              gh pr edit "$PR_NUMBER" --repo "$GH_REPO" --add-label "$label" || true
+              echo "Applied label: $label"
+            elif [ "$should_be_present" = "false" ] && [ "$has_it" = "true" ]; then
+              gh pr edit "$PR_NUMBER" --repo "$GH_REPO" --remove-label "$label" || true
+              echo "Removed stale label: $label"
+            fi
+          }
+
+          _needs_security=$([ "$TOTAL" -gt 0 ] && echo true || echo false)
+          _needs_cooldown=$([ "$COOLDOWN_FAILURES" -gt 0 ] && echo true || echo false)
+          reconcile_label "security-review-needed" "$_needs_security" "$LABEL_COLOR_security_review_needed" "$LABEL_DESC_security_review_needed"
+          reconcile_label "cooldown-pending"       "$_needs_cooldown" "$LABEL_COLOR_cooldown_pending"       "$LABEL_DESC_cooldown_pending"
+
           if [ "$TOTAL" -gt 0 ]; then
             RESULTS_HEADER="**${TOTAL} advisory/ies found** affecting target versions — review before merging."
             TABLE_HDR="| ID | Severity | Summary | Source |"
@@ -537,36 +568,6 @@ jobs:
               --body "$CHANGE_NOTE"
             echo "Posted change notification"
           fi
-
-          # --- Label reconciliation (Task 10 — fixes #26: every scan is authoritative) ---
-          LABEL_COLOR_security_review_needed="B60205"
-          LABEL_DESC_security_review_needed="Dependency scan found advisories — manual review required"
-          LABEL_COLOR_cooldown_pending="FBCA04"
-          LABEL_DESC_cooldown_pending="One or more target versions are within the configured cooldown window"
-
-          reconcile_label() {
-            local label="$1"
-            local should_be_present="$2"
-            local color="$3"
-            local desc="$4"
-            local current has_it
-            current=$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json labels --jq '[.labels[].name]')
-            has_it=$(echo "$current" | jq -e --arg l "$label" 'contains([$l])' >/dev/null && echo true || echo false)
-
-            if [ "$should_be_present" = "true" ] && [ "$has_it" = "false" ]; then
-              gh label create "$label" --repo "$GH_REPO" --color "$color" --description "$desc" --force >/dev/null 2>&1 || true
-              gh pr edit "$PR_NUMBER" --repo "$GH_REPO" --add-label "$label" || true
-              echo "Applied label: $label"
-            elif [ "$should_be_present" = "false" ] && [ "$has_it" = "true" ]; then
-              gh pr edit "$PR_NUMBER" --repo "$GH_REPO" --remove-label "$label" || true
-              echo "Removed stale label: $label"
-            fi
-          }
-
-          _needs_security=$([ "$TOTAL" -gt 0 ] && echo true || echo false)
-          _needs_cooldown=$([ "$COOLDOWN_FAILURES" -gt 0 ] && echo true || echo false)
-          reconcile_label "security-review-needed" "$_needs_security" "$LABEL_COLOR_security_review_needed" "$LABEL_DESC_security_review_needed"
-          reconcile_label "cooldown-pending"       "$_needs_cooldown" "$LABEL_COLOR_cooldown_pending"       "$LABEL_DESC_cooldown_pending"
 
           # --- Gate state machine (Task 11 — combines advisory + cooldown verdicts) ---
           if [ "$TOTAL" -gt 0 ]; then

--- a/.github/workflows/dependency-cooldown.yml
+++ b/.github/workflows/dependency-cooldown.yml
@@ -421,14 +421,70 @@ jobs:
               "$FILTERED_TOTAL" "$HIST_HDR" "$HIST_SEP" "$FILTERED_RESULTS")"
           fi
 
-          COMMENT_BODY="$(printf '%s\n\n%s\n\n%s\n\n%s\n\n%s\n\n%s%s%s' \
+          # --- Release Age section (Task 12 — fixes #25 UX) ---
+          RELEASE_AGE_SECTION=""
+          if [ -n "$AGE_TSV" ]; then
+            AGE_TABLE_HDR="| Package | Version | Published | Age | Status |"
+            AGE_TABLE_SEP="|---------|---------|-----------|-----|--------|"
+            AGE_ROWS=""
+            MAX_FAIL_EPOCH=0
+            while IFS=$'\t' read -r _name _ver _eco _iso _days _verdict _reason; do
+              [ -z "$_name" ] && continue
+              case "$_verdict" in
+                pass)  _status="✅ passed" ;;
+                fail)  if [ -n "$_reason" ]; then _status="❌ blocked (${_reason})"; else _status="❌ blocked"; fi ;;
+                error) _status="⚠️ error (${_reason})" ;;
+                *)     _status="?" ;;
+              esac
+              if [ "$_iso" = "-" ]; then
+                _published_short="-"
+              else
+                _published_short="${_iso%T*}"
+              fi
+              AGE_ROWS="${AGE_ROWS}| \`${_name}\` | v${_ver} | ${_published_short} | ${_days}d | ${_status} |"$'\n'
+
+              # Track max fail epoch for "earliest unblock" footer
+              if [ "$_verdict" = "fail" ] && [ "$_iso" != "-" ]; then
+                _pub_epoch=$(date -u -d "$_iso" +%s 2>/dev/null \
+                  || date -u -d "${_iso}Z" +%s 2>/dev/null \
+                  || date -u -jf '%Y-%m-%dT%H:%M:%SZ' "$_iso" +%s 2>/dev/null \
+                  || date -u -jf '%Y-%m-%dT%H:%M:%S' "${_iso%Z}" +%s 2>/dev/null \
+                  || echo 0)
+                if [ "$_pub_epoch" -gt "$MAX_FAIL_EPOCH" ]; then
+                  MAX_FAIL_EPOCH="$_pub_epoch"
+                fi
+              fi
+            done <<< "$AGE_TSV"
+
+            AGE_FOOTER=""
+            if [ "$COOLDOWN_FAILURES" -gt 0 ] && [ "$MAX_FAIL_EPOCH" -gt 0 ]; then
+              _unblock_epoch=$(( MAX_FAIL_EPOCH + COOLDOWN_DAYS * 86400 ))
+              _unblock_iso=$(date -u -r "$_unblock_epoch" '+%Y-%m-%d' 2>/dev/null \
+                || date -u -d "@$_unblock_epoch" '+%Y-%m-%d' 2>/dev/null \
+                || echo "unknown")
+              AGE_FOOTER="$(printf '\n> %d package(s) within cooldown window. Earliest unblock: %s.' "$COOLDOWN_FAILURES" "$_unblock_iso")"
+            fi
+
+            RELEASE_AGE_SECTION="$(printf '\n### Release Age (cooldown: %s days)\n\n%s\n%s\n%s%s' \
+              "$COOLDOWN_DAYS" "$AGE_TABLE_HDR" "$AGE_TABLE_SEP" "$AGE_ROWS" "$AGE_FOOTER")"
+          fi
+
+          # --- Extraction warning section (Task 12 — surfaces #27 silent drops) ---
+          EXTRACTION_WARNING_SECTION=""
+          if [ -n "$EXTRACTION_WARNING" ]; then
+            EXTRACTION_WARNING_SECTION="$(printf '\n> %s\n' "$EXTRACTION_WARNING")"
+          fi
+
+          COMMENT_BODY="$(printf '%s%s\n\n%s\n\n%s\n\n%s\n\n%s\n\n%s%s%s%s' \
             "## Dependency Security Scan" \
+            "$EXTRACTION_WARNING_SECTION" \
             "**Packages scanned:** ${DEPS}" \
             "### Results" \
             "$RESULTS_HEADER" \
             "$RESULTS_TABLE" \
             "$RESULTS_FOOTER" \
             "$HISTORICAL_SECTION" \
+            "$RELEASE_AGE_SECTION" \
             "$SCORECARD_SECTION")"
 
           # --- Comment management: update-or-create with change detection ---

--- a/.github/workflows/dependency-cooldown.yml
+++ b/.github/workflows/dependency-cooldown.yml
@@ -125,14 +125,16 @@ jobs:
             fi
           done
 
-          # Sanity-check: count UNIQUE action names in the diff vs extracted actions
-          # (Task 13b — fixes false-positive on diffs with repeated actions across files)
-          # Uses the same regex shape as scripts/extract-deps.sh so drift cannot produce
-          # spurious warnings. Deduplicates via sort -u before counting so that an action
-          # referenced in N files counts once, matching the extractor's dedup semantic.
+          # Sanity-check: count UNIQUE action names in the diff vs extracted actions.
+          # Filters ./ (local) and docker:// actions because the extractor at
+          # scripts/extract-deps.sh:51-52 intentionally skips them — counting them
+          # here would produce a false-positive extraction-mismatch warning on any
+          # PR adding a local or docker action reference.
+          # (Task 13c — fixes regression introduced by Task 13b)
           EXPECTED_ACTIONS=$(echo "$DIFF" \
             | grep -oE '^\+[[:space:]]+(-[[:space:]]+)?uses:[[:space:]]+[^[:space:]@]+' \
             | sed -E 's/^\+[[:space:]]+(-[[:space:]]+)?uses:[[:space:]]+//' \
+            | grep -vE '^(\./|docker://)' \
             | sort -u | wc -l | tr -d ' ')
           EXTRACTED_ACTIONS=$(echo "$ACTIONS" | sed '/^$/d' | wc -l | tr -d ' ')
           EXTRACTION_WARNING=""
@@ -508,8 +510,8 @@ jobs:
             AGE_FOOTER=""
             if [ "$COOLDOWN_FAILURES" -gt 0 ] && [ "$MAX_FAIL_EPOCH" -gt 0 ]; then
               _unblock_epoch=$(( MAX_FAIL_EPOCH + COOLDOWN_DAYS * 86400 ))
-              _unblock_iso=$(date -u -r "$_unblock_epoch" '+%Y-%m-%d' 2>/dev/null \
-                || date -u -d "@$_unblock_epoch" '+%Y-%m-%d' 2>/dev/null \
+              _unblock_iso=$(date -u -d "@$_unblock_epoch" '+%Y-%m-%d' 2>/dev/null \
+                || date -u -r "$_unblock_epoch" '+%Y-%m-%d' 2>/dev/null \
                 || echo "unknown")
               AGE_FOOTER="$(printf '\n> %d package(s) within cooldown window. Earliest unblock: %s.' "$COOLDOWN_FAILURES" "$_unblock_iso")"
             fi

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Reusable GitHub Actions workflows for dependency management and security scannin
 
 ## Features
 
-- **Native Dependabot cool-down** — configure the waiting period in `dependabot.yml`; Dependabot holds PRs until they mature
+- **Dual-layer cool-down enforcement** — Dependabot's native `cooldown.default-days` gates PR creation; the workflow's `cooldown_days` input enforces release age on every scan, closing the rebase-bypass path that native cool-down alone leaves open
 - **Version-aware advisory filtering** — advisories already patched at or below the PR's target version are collapsed into a non-blocking "historical" section
 - **GHSA + OSV dual-source scan** — every package is queried against both GitHub Advisory and OSV.dev; mismatches surface both
 - **OpenSSF Scorecard integration** — Scorecard results for each GitHub Action appear in the scan comment
@@ -77,6 +77,8 @@ jobs:
 |-------|------|---------|-------------|
 | `enable_scorecard` | boolean | `true` | Include OpenSSF Scorecard results for GitHub Actions in the scan comment |
 | `auto_merge` | boolean | `false` | On clean scans, enable `gh pr merge --auto`; on dirty scans, apply the `security-review-needed` label |
+| `cooldown_days` | number | `7` | Minimum release age in days before auto-merge is allowed. Set to `0` to disable workflow-side release-age enforcement (pre-v2.0.2 behavior — relies entirely on Dependabot's native cooldown) |
+| `fail_on_cooldown` | boolean | `false` | If `true`, cooldown blocks set the gate status to `failure` instead of `pending`. Use when branch protection requires a hard-red blocker rather than a self-healing pending state |
 
 ## Supported Ecosystems
 
@@ -129,9 +131,65 @@ PR #23 added filtering so that advisories Dependabot has already fixed don't blo
 
 ## Cool-down configuration
 
-All cool-down timing lives in `.github/dependabot.yml` and is enforced by Dependabot itself. There is no bypass label — to ship a zero-day fix immediately, lower `cooldown.default-days` (or remove it for the affected ecosystem) and let Dependabot re-run. Commit history on `dependabot.yml` is the audit trail.
+The workflow enforces cool-down at two layers, each independently configurable:
+
+### Layer 1 — Dependabot native cool-down (PR creation)
+
+Configured in `.github/dependabot.yml`. Dependabot holds new PRs until the target version is at least `cooldown.default-days` old. This gate runs once, at PR creation. **It does NOT re-check on `@dependabot rebase`** — a rebase re-resolves to the latest version and skips this gate entirely.
+
+```yaml
+# .github/dependabot.yml
+updates:
+  - package-ecosystem: "github-actions"
+    cooldown:
+      default-days: 7
+```
 
 See the [cool-down options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown--) for per-severity (`semver-major-days`, `semver-minor-days`, `semver-patch-days`) and package include/exclude lists.
+
+### Layer 2 — Workflow-side release-age gate (every scan)
+
+Configured via the `cooldown_days` input on the caller workflow (default `7`). The workflow re-evaluates release age on every scan, including after `@dependabot rebase`. If any target version is younger than `cooldown_days`, the workflow:
+
+- Applies the `cooldown-pending` label
+- Sets the `dependency-cooldown / gate` status to `pending` (or `failure` if `fail_on_cooldown: true`)
+- Skips `gh pr merge --auto` even if the advisory scan is clean
+
+Once the next scan finds all versions past the threshold, the label is removed and the gate flips to `success`. To disable workflow-side enforcement entirely (pre-v2.0.2 behavior), set `cooldown_days: 0` in the caller workflow.
+
+### Bypass
+
+There is no per-PR bypass label. To ship a zero-day fix immediately:
+
+- Lower `cooldown.default-days` in `.github/dependabot.yml` for the affected ecosystem, OR
+- Set `cooldown_days: 0` in the caller workflow temporarily, OR
+- Merge manually (the gate state is informational; you control your branch protection rules)
+
+Commit history on `dependabot.yml` and your caller workflow is the audit trail.
+
+## Labels
+
+The workflow manages two labels on Dependabot PRs. **Both are reconciled on every scan** — applied when the condition is true, removed when it becomes false.
+
+| Label | Color | Applied when | Removed when |
+|-------|-------|--------------|--------------|
+| `security-review-needed` | red (`B60205`) | Advisory scan finds vulnerabilities affecting target versions | Re-scan finds zero applicable advisories |
+| `cooldown-pending` | amber (`FBCA04`) | Any target version is younger than `cooldown_days` | Re-scan finds all versions past the threshold |
+
+The reconciliation is authoritative — a PR that was dirty at first scan and clean after rebase will have neither label at merge time.
+
+## Recommended: scheduled re-scan for long-pending PRs
+
+If a PR sits in `cooldown-pending` for multiple days, it will unblock automatically on the next push or `@dependabot rebase`. Consumers wanting time-based automatic re-scan (without waiting for a push) can add a `schedule:` trigger to their caller workflow:
+
+```yaml
+on:
+  pull_request:
+  schedule:
+    - cron: '0 */6 * * *'   # every 6 hours
+```
+
+This is intentionally not shipped in the reusable workflow itself — cadence preferences vary per consumer. A 6-hour cadence handles a 7-day cooldown comfortably; tune as needed.
 
 ## Security Analysis (Zizmor)
 

--- a/scripts/check-release-age.sh
+++ b/scripts/check-release-age.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Placeholder — real implementation in Task 5; tests/check-release-age.bats will fail until then
+exit 0

--- a/scripts/check-release-age.sh
+++ b/scripts/check-release-age.sh
@@ -1,3 +1,146 @@
 #!/usr/bin/env bash
-# Placeholder — real implementation in Task 5; tests/check-release-age.bats will fail until then
+# check-release-age.sh — read dep TSV on stdin, emit verdict TSV on stdout
+#
+# Schema:
+#   in:  <name>\t<version>\t<ecosystem>
+#   out: <name>\t<version>\t<ecosystem>\t<published_iso>\t<age_days>\t<verdict>\t<reason>
+#
+# Verdicts: pass | fail | error
+# Exit: always 0; failures are per-row.
+#
+# Bash 3.2 compatible (macOS system bash).
+
+set -uo pipefail
+
+: "${COOLDOWN_DAYS:?COOLDOWN_DAYS env var is required}"
+: "${NOW_EPOCH:=$(date +%s)}"
+
+# iso_to_epoch <iso> — print unix epoch on stdout, return 1 on parse failure.
+# Handles both GitHub ("2026-03-29T12:00:00Z") and PyPI ("2026-03-29T12:00:00")
+# ISO variants across GNU and BSD date.
+iso_to_epoch() {
+  local iso="$1"
+  # GNU date: accepts the ISO string as-is (with or without Z).
+  date -u -d "$iso" +%s 2>/dev/null && return 0
+  # GNU date: append Z for naive PyPI upload_time.
+  date -u -d "${iso}Z" +%s 2>/dev/null && return 0
+  # BSD date (macOS): strip trailing Z and parse via -jf.
+  local stripped="${iso%Z}"
+  date -u -jf '%Y-%m-%dT%H:%M:%S' "$stripped" +%s 2>/dev/null && return 0
+  return 1
+}
+
+# fetch_github <owner> <repo> <version> — print published_at ISO on stdout, return 1 on failure.
+fetch_github() {
+  local owner="$1" repo="$2" version="$3"
+  if [ -n "${AGE_FIXTURE_DIR:-}" ]; then
+    local fx="$AGE_FIXTURE_DIR/github/$owner/$repo/releases/tags/v$version.json"
+    [ -f "$fx" ] || return 1
+    jq -r '.published_at // empty' "$fx"
+    return 0
+  fi
+  local resp
+  if ! resp=$(gh api "repos/$owner/$repo/releases/tags/v$version" 2>/dev/null); then
+    sleep 2
+    if ! resp=$(gh api "repos/$owner/$repo/releases/tags/v$version" 2>/dev/null); then
+      return 1
+    fi
+  fi
+  printf '%s' "$resp" | jq -r '.published_at // empty'
+}
+
+# fetch_pypi <pkg> <version> — print "<upload_time>\t<yanked_bool>" on stdout, return 1 on failure.
+fetch_pypi() {
+  local pkg="$1" version="$2"
+  local upload yanked
+  if [ -n "${AGE_FIXTURE_DIR:-}" ]; then
+    local fx="$AGE_FIXTURE_DIR/pypi/$pkg/$version.json"
+    [ -f "$fx" ] || return 1
+    upload=$(jq -r '.urls[0].upload_time // empty' "$fx")
+    yanked=$(jq -r '.urls[0].yanked // false' "$fx")
+    printf '%s\t%s\n' "$upload" "$yanked"
+    return 0
+  fi
+  local resp
+  if ! resp=$(curl -sf --max-time 30 "https://pypi.org/pypi/$pkg/$version/json" 2>/dev/null); then
+    sleep 2
+    if ! resp=$(curl -sf --max-time 30 "https://pypi.org/pypi/$pkg/$version/json" 2>/dev/null); then
+      return 1
+    fi
+  fi
+  upload=$(printf '%s' "$resp" | jq -r '.urls[0].upload_time // empty')
+  yanked=$(printf '%s' "$resp" | jq -r '.urls[0].yanked // false')
+  printf '%s\t%s\n' "$upload" "$yanked"
+}
+
+# emit name version ecosystem published age verdict reason
+emit() {
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5" "$6" "$7"
+}
+
+while IFS=$'\t' read -r name version ecosystem || [ -n "${name:-}" ]; do
+  [ -z "${name:-}" ] && continue
+
+  # Escape hatch: COOLDOWN_DAYS=0 → all pass without lookup.
+  if [ "$COOLDOWN_DAYS" -eq 0 ]; then
+    emit "$name" "$version" "$ecosystem" "-" "-" "pass" ""
+    continue
+  fi
+
+  case "$ecosystem" in
+    actions)
+      owner="${name%%/*}"
+      remainder="${name#*/}"
+      repo="${remainder%%/*}"
+      if ! iso=$(fetch_github "$owner" "$repo" "$version"); then
+        emit "$name" "$version" "$ecosystem" "-" "-" "error" "tier-1-404"
+        continue
+      fi
+      if [ -z "$iso" ]; then
+        emit "$name" "$version" "$ecosystem" "-" "-" "error" "transient-failure"
+        continue
+      fi
+      if ! pub_epoch=$(iso_to_epoch "$iso"); then
+        emit "$name" "$version" "$ecosystem" "-" "-" "error" "parse-failure"
+        continue
+      fi
+      age_days=$(( (NOW_EPOCH - pub_epoch) / 86400 ))
+      if [ "$age_days" -ge "$COOLDOWN_DAYS" ]; then
+        emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "pass" ""
+      else
+        emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "fail" ""
+      fi
+      ;;
+
+    pypi)
+      if ! result=$(fetch_pypi "$name" "$version"); then
+        emit "$name" "$version" "$ecosystem" "-" "-" "error" "pypi-404"
+        continue
+      fi
+      iso="${result%%$'\t'*}"
+      yanked="${result##*$'\t'}"
+      if [ -z "$iso" ]; then
+        emit "$name" "$version" "$ecosystem" "-" "-" "error" "transient-failure"
+        continue
+      fi
+      if ! pub_epoch=$(iso_to_epoch "$iso"); then
+        emit "$name" "$version" "$ecosystem" "-" "-" "error" "parse-failure"
+        continue
+      fi
+      age_days=$(( (NOW_EPOCH - pub_epoch) / 86400 ))
+      if [ "$yanked" = "true" ]; then
+        emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "fail" "yanked"
+      elif [ "$age_days" -ge "$COOLDOWN_DAYS" ]; then
+        emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "pass" ""
+      else
+        emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "fail" ""
+      fi
+      ;;
+
+    *)
+      emit "$name" "$version" "$ecosystem" "-" "-" "error" "unknown-ecosystem"
+      ;;
+  esac
+done
+
 exit 0

--- a/scripts/extract-deps.sh
+++ b/scripts/extract-deps.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Placeholder — will be implemented in Task 2
+exit 0

--- a/scripts/extract-deps.sh
+++ b/scripts/extract-deps.sh
@@ -1,3 +1,85 @@
 #!/usr/bin/env bash
-# Placeholder — will be implemented in Task 2
-exit 0
+# extract-deps.sh — parse unified diff on stdin, emit dependency TSV on stdout
+#
+# Output: <name>\t<version>\t<ecosystem>  where ecosystem ∈ {actions, pypi}
+# Exit:   0 on success (possibly zero rows), 2 on malformed input
+#
+# Handles BOTH GitHub Actions shapes observed in real PR diffs:
+#   +        uses: owner/repo@sha # vX.Y.Z        (no list marker)
+#   +      - uses: owner/repo@sha # vX.Y.Z        (YAML list marker)
+#
+# The missing list-marker support in the v2.0.1 regex `^\+\s+uses:` is the
+# root cause of issue #27 (astral-sh/setup-uv silently dropped from
+# nexus-mcp#160's cooldown scan).
+
+set -euo pipefail
+
+# Dedup sentinel: newline-delimited list of "ecosystem:name" keys.
+# Using a plain string (not `declare -A`) for bash 3.2 compatibility, since
+# macOS's system bash is still 3.2 and the bats test invokes `bash` directly.
+seen=$'\n'
+rows=()
+
+input=$(cat)
+
+# Empty input → exit 0 with no output
+if [ -z "$input" ]; then
+  exit 0
+fi
+
+# Malformed input detection: if non-empty and has none of the unified-diff
+# markers, reject with exit 2.
+if ! printf '%s\n' "$input" | grep -qE '^(\+\+\+|---|@@|diff --git)'; then
+  echo "extract-deps.sh: input is not a unified diff" >&2
+  exit 2
+fi
+
+while IFS= read -r line; do
+  # Strip CR for CRLF-encoded diffs
+  line="${line%$'\r'}"
+
+  # Skip diff file headers (+++ b/path)
+  [[ "$line" == +++* ]] && continue
+
+  # --- GitHub Actions parser ---
+  # Matches both "+ uses: foo@..." and "+ - uses: foo@..."
+  if [[ "$line" =~ ^\+[[:space:]]+(-[[:space:]]+)?uses:[[:space:]]+([^[:space:]@]+)@[^[:space:]]+(.*)$ ]]; then
+    name="${BASH_REMATCH[2]}"
+    rest="${BASH_REMATCH[3]}"
+
+    # Skip local and docker actions
+    [[ "$name" == ./* ]] && continue
+    [[ "$name" == docker://* ]] && continue
+
+    version=""
+    # Capture version from trailing comment: " # v1.2.3" or " # 1.2.3"
+    # The `v?` is OUTSIDE the capture group so we strip the leading v.
+    if [[ "$rest" =~ \#[[:space:]]*v?([0-9][0-9.]*) ]]; then
+      version="${BASH_REMATCH[1]}"
+    fi
+
+    key="actions:$name"
+    case "$seen" in *$'\n'"$key"$'\n'*) continue ;; esac
+    seen="${seen}${key}"$'\n'
+    rows+=("$name"$'\t'"$version"$'\t'"actions")
+    continue
+  fi
+
+  # --- Python deps parser ---
+  # Skip Python-style comment lines first
+  [[ "$line" =~ ^\+[[:space:]]*# ]] && continue
+
+  if [[ "$line" =~ ^\+[[:space:]]*([a-zA-Z][a-zA-Z0-9_.\-]*)[[:space:]]*(==|\>=|\<=|~=|\!=|\>|\<)[[:space:]]*([0-9][0-9a-zA-Z.\-]*) ]]; then
+    name="${BASH_REMATCH[1]}"
+    version="${BASH_REMATCH[3]}"
+    key="pypi:$name"
+    case "$seen" in *$'\n'"$key"$'\n'*) continue ;; esac
+    seen="${seen}${key}"$'\n'
+    rows+=("$name"$'\t'"$version"$'\t'"pypi")
+    continue
+  fi
+done <<< "$input"
+
+if [ ${#rows[@]} -gt 0 ]; then
+  printf '%s\n' "${rows[@]}" | sort -t$'\t' -k1,1
+fi

--- a/tests/check-release-age.bats
+++ b/tests/check-release-age.bats
@@ -11,3 +11,31 @@ setup() {
   [ "$status" -eq 0 ]
   diff <(echo "$output") tests/fixtures/check-release-age/nexus-mcp-160-cooldown-7.tsv
 }
+
+@test "passes everything at COOLDOWN_DAYS=0 (escape hatch)" {
+  export COOLDOWN_DAYS=0
+  run bash scripts/check-release-age.sh < tests/fixtures/check-release-age/nexus-mcp-160.tsv
+  [ "$status" -eq 0 ]
+  diff <(echo "$output") tests/fixtures/check-release-age/nexus-mcp-160-cooldown-0.tsv
+}
+
+@test "PyPI happy path returns pass for aged release" {
+  export COOLDOWN_DAYS=7
+  run bash -c 'printf "requests\t2.32.5\tpypi\n" | bash scripts/check-release-age.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^requests$'\t'2\.32\.5$'\t'pypi$'\t'.+$'\t'[0-9]+$'\t'pass$'\t'$ ]]
+}
+
+@test "yanked PyPI release fails regardless of age" {
+  export COOLDOWN_DAYS=7
+  run bash -c 'printf "yanked-pkg\t1.0.0\tpypi\n" | bash scripts/check-release-age.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^yanked-pkg$'\t'1\.0\.0$'\t'pypi$'\t'.+$'\t'[0-9]+$'\t'fail$'\t'yanked$ ]]
+}
+
+@test "missing fixture (simulates 404) produces error verdict" {
+  export COOLDOWN_DAYS=7
+  run bash -c 'printf "no-such-action/does-not-exist\t1.0.0\tactions\n" | bash scripts/check-release-age.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^no-such-action/does-not-exist$'\t'1\.0\.0$'\t'actions$'\t'-$'\t'-$'\t'error$'\t'tier-1-404$ ]]
+}

--- a/tests/check-release-age.bats
+++ b/tests/check-release-age.bats
@@ -1,0 +1,13 @@
+#!/usr/bin/env bats
+
+setup() {
+  export AGE_FIXTURE_DIR="tests/fixtures/check-release-age"
+  export NOW_EPOCH=1775995200   # 2026-04-12T12:00:00Z — verify with: date -u -r 1775995200
+}
+
+@test "blocks sub-cooldown actions at COOLDOWN_DAYS=7 (regression for #25)" {
+  export COOLDOWN_DAYS=7
+  run bash scripts/check-release-age.sh < tests/fixtures/check-release-age/nexus-mcp-160.tsv
+  [ "$status" -eq 0 ]
+  diff <(echo "$output") tests/fixtures/check-release-age/nexus-mcp-160-cooldown-7.tsv
+}

--- a/tests/extract-deps.bats
+++ b/tests/extract-deps.bats
@@ -1,0 +1,7 @@
+#!/usr/bin/env bats
+
+@test "extracts all three actions from nexus-mcp#160 diff (regression for #27)" {
+  run bash scripts/extract-deps.sh < tests/fixtures/extract-deps/nexus-mcp-160.diff
+  [ "$status" -eq 0 ]
+  diff <(echo "$output") tests/fixtures/extract-deps/nexus-mcp-160.tsv
+}

--- a/tests/extract-deps.bats
+++ b/tests/extract-deps.bats
@@ -5,3 +5,15 @@
   [ "$status" -eq 0 ]
   diff <(echo "$output") tests/fixtures/extract-deps/nexus-mcp-160.tsv
 }
+
+@test "extracts Python deps from requirements.txt diff" {
+  run bash scripts/extract-deps.sh < tests/fixtures/extract-deps/python-requirements.diff
+  [ "$status" -eq 0 ]
+  diff <(echo "$output") tests/fixtures/extract-deps/python-requirements.tsv
+}
+
+@test "empty diff produces empty output with exit 0" {
+  run bash scripts/extract-deps.sh < tests/fixtures/extract-deps/empty.diff
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}

--- a/tests/fixtures/check-release-age/github/astral-sh/setup-uv/releases/tags/v8.0.0.json
+++ b/tests/fixtures/check-release-age/github/astral-sh/setup-uv/releases/tags/v8.0.0.json
@@ -1,0 +1,7 @@
+{
+  "tag_name": "v8.0.0",
+  "name": "v8.0.0",
+  "published_at": "2026-03-29T12:00:00Z",
+  "draft": false,
+  "prerelease": false
+}

--- a/tests/fixtures/check-release-age/github/step-security/harden-runner/releases/tags/v2.16.1.json
+++ b/tests/fixtures/check-release-age/github/step-security/harden-runner/releases/tags/v2.16.1.json
@@ -1,0 +1,7 @@
+{
+  "tag_name": "v2.16.1",
+  "name": "v2.16.1",
+  "published_at": "2026-03-31T12:00:00Z",
+  "draft": false,
+  "prerelease": false
+}

--- a/tests/fixtures/check-release-age/github/step-security/harden-runner/releases/tags/v2.17.0.json
+++ b/tests/fixtures/check-release-age/github/step-security/harden-runner/releases/tags/v2.17.0.json
@@ -1,0 +1,7 @@
+{
+  "tag_name": "v2.17.0",
+  "name": "v2.17.0",
+  "published_at": "2026-04-09T12:00:00Z",
+  "draft": false,
+  "prerelease": false
+}

--- a/tests/fixtures/check-release-age/github/trufflesecurity/trufflehog/releases/tags/v3.94.3.json
+++ b/tests/fixtures/check-release-age/github/trufflesecurity/trufflehog/releases/tags/v3.94.3.json
@@ -1,0 +1,7 @@
+{
+  "tag_name": "v3.94.3",
+  "name": "v3.94.3",
+  "published_at": "2026-04-08T12:00:00Z",
+  "draft": false,
+  "prerelease": false
+}

--- a/tests/fixtures/check-release-age/nexus-mcp-160-cooldown-0.tsv
+++ b/tests/fixtures/check-release-age/nexus-mcp-160-cooldown-0.tsv
@@ -1,0 +1,3 @@
+astral-sh/setup-uv	8.0.0	actions	-	-	pass	
+step-security/harden-runner	2.17.0	actions	-	-	pass	
+trufflesecurity/trufflehog	3.94.3	actions	-	-	pass	

--- a/tests/fixtures/check-release-age/nexus-mcp-160-cooldown-7.tsv
+++ b/tests/fixtures/check-release-age/nexus-mcp-160-cooldown-7.tsv
@@ -1,0 +1,3 @@
+astral-sh/setup-uv	8.0.0	actions	2026-03-29T12:00:00Z	14	pass	
+step-security/harden-runner	2.17.0	actions	2026-04-09T12:00:00Z	3	fail	
+trufflesecurity/trufflehog	3.94.3	actions	2026-04-08T12:00:00Z	4	fail	

--- a/tests/fixtures/check-release-age/nexus-mcp-160.tsv
+++ b/tests/fixtures/check-release-age/nexus-mcp-160.tsv
@@ -1,0 +1,3 @@
+astral-sh/setup-uv	8.0.0	actions
+step-security/harden-runner	2.17.0	actions
+trufflesecurity/trufflehog	3.94.3	actions

--- a/tests/fixtures/check-release-age/pypi/requests/2.32.5.json
+++ b/tests/fixtures/check-release-age/pypi/requests/2.32.5.json
@@ -1,0 +1,9 @@
+{
+  "info": {"name": "requests", "version": "2.32.5"},
+  "urls": [
+    {
+      "upload_time": "2026-04-01T12:00:00",
+      "yanked": false
+    }
+  ]
+}

--- a/tests/fixtures/check-release-age/pypi/yanked-pkg/1.0.0.json
+++ b/tests/fixtures/check-release-age/pypi/yanked-pkg/1.0.0.json
@@ -1,0 +1,9 @@
+{
+  "info": {"name": "yanked-pkg", "version": "1.0.0"},
+  "urls": [
+    {
+      "upload_time": "2025-01-01T00:00:00",
+      "yanked": true
+    }
+  ]
+}

--- a/tests/fixtures/extract-deps/nexus-mcp-160.diff
+++ b/tests/fixtures/extract-deps/nexus-mcp-160.diff
@@ -1,0 +1,163 @@
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index 287aedd..beeed56 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -19,13 +19,13 @@ jobs:
+       contents: write
+     steps:
+       - name: Harden runner
+-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
++        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+         with:
+           egress-policy: audit
+       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+         with:
+           ref: ${{ github.head_ref }}
+-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
++      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+       - run: uv lock
+       - name: Commit updated lockfile
+         env:
+@@ -64,7 +64,7 @@ jobs:
+         python-version: ["3.13", "3.14"]
+     steps:
+       - name: Harden runner
+-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
++        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+         with:
+           egress-policy: audit
+       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+@@ -88,7 +88,7 @@ jobs:
+       contents: read
+     steps:
+       - name: Harden runner
+-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
++        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+         with:
+           egress-policy: audit
+       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+@@ -108,7 +108,7 @@ jobs:
+       contents: read
+     steps:
+       - name: Harden runner
+-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
++        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+         with:
+           egress-policy: audit
+       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+diff --git a/.github/workflows/pre-commit-autoupdate.yml b/.github/workflows/pre-commit-autoupdate.yml
+index 8b6f926..ffeba44 100644
+--- a/.github/workflows/pre-commit-autoupdate.yml
++++ b/.github/workflows/pre-commit-autoupdate.yml
+@@ -14,11 +14,11 @@ jobs:
+     runs-on: ubuntu-latest
+     steps:
+       - name: Harden runner
+-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
++        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+         with:
+           egress-policy: audit
+       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
++      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+       - name: Install pre-commit
+         run: uv run pre-commit --version
+       - name: Run pre-commit autoupdate
+diff --git a/.github/workflows/release.yml b/.github/workflows/release.yml
+index 13086fc..9611160 100644
+--- a/.github/workflows/release.yml
++++ b/.github/workflows/release.yml
+@@ -14,7 +14,7 @@ jobs:
+     runs-on: ubuntu-latest
+     steps:
+       - name: Harden runner
+-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
++        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+         with:
+           egress-policy: audit
+       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+@@ -63,7 +63,7 @@ jobs:
+       attestations: write
+     steps:
+       - name: Harden runner
+-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
++        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+         with:
+           egress-policy: audit
+       - name: Download build artifacts
+@@ -112,7 +112,7 @@ jobs:
+       attestations: write
+     steps:
+       - name: Harden runner
+-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
++        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+         with:
+           egress-policy: audit
+       - name: Download build artifacts
+@@ -133,7 +133,7 @@ jobs:
+       contents: write
+     steps:
+       - name: Harden runner
+-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
++        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+         with:
+           egress-policy: audit
+       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+@@ -163,7 +163,7 @@ jobs:
+       id-token: write
+     steps:
+       - name: Harden runner
+-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
++        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+         with:
+           egress-policy: audit
+       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+diff --git a/.github/workflows/security.yml b/.github/workflows/security.yml
+index 42f56fc..041b415 100644
+--- a/.github/workflows/security.yml
++++ b/.github/workflows/security.yml
+@@ -23,7 +23,7 @@ jobs:
+     runs-on: ubuntu-latest
+     steps:
+       - name: Harden runner
+-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
++        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+         with:
+           egress-policy: audit
+       - name: Checkout repository
+@@ -43,7 +43,7 @@ jobs:
+     runs-on: ubuntu-latest
+     steps:
+       - name: Harden runner
+-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
++        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+         with:
+           egress-policy: audit
+       - name: Checkout repository
+@@ -53,7 +53,7 @@ jobs:
+ 
+       - name: TruffleHog secret scan
+         id: trufflehog
+-        uses: trufflesecurity/trufflehog@586f66d7886cd0b037c7c245d4a6e34ef357ab10 # v3.94.1
++        uses: trufflesecurity/trufflehog@47e7b7cd74f578e1e3145d48f669f22fd1330ca6 # v3.94.3
+         continue-on-error: true
+         with:
+           path: ./
+@@ -72,7 +72,7 @@ jobs:
+     runs-on: ubuntu-latest
+     steps:
+       - name: Harden runner
+-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
++        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+         with:
+           egress-policy: audit
+ 
+@@ -91,7 +91,7 @@ jobs:
+     runs-on: ubuntu-latest
+     steps:
+       - name: Harden runner
+-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
++        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+         with:
+           egress-policy: audit
+       - name: Checkout repository

--- a/tests/fixtures/extract-deps/nexus-mcp-160.tsv
+++ b/tests/fixtures/extract-deps/nexus-mcp-160.tsv
@@ -1,0 +1,3 @@
+astral-sh/setup-uv	8.0.0	actions
+step-security/harden-runner	2.17.0	actions
+trufflesecurity/trufflehog	3.94.3	actions

--- a/tests/fixtures/extract-deps/python-requirements.diff
+++ b/tests/fixtures/extract-deps/python-requirements.diff
@@ -1,0 +1,11 @@
+diff --git a/requirements.txt b/requirements.txt
+index abc1234..def5678 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -1,4 +1,4 @@
+-requests==2.31.0
+-urllib3==2.0.7
++requests==2.32.5
++urllib3==2.2.3
+ certifi==2024.2.2
+ charset-normalizer==3.3.2

--- a/tests/fixtures/extract-deps/python-requirements.tsv
+++ b/tests/fixtures/extract-deps/python-requirements.tsv
@@ -1,0 +1,2 @@
+requests	2.32.5	pypi
+urllib3	2.2.3	pypi


### PR DESCRIPTION
## Summary

Closes three regressions in `dependency-cooldown.yml` observed on [j7an/nexus-mcp#160](https://github.com/j7an/nexus-mcp/pull/160) on 2026-04-12:

- **#25** — silent cooldown bypass via `@dependabot rebase`
- **#26** — stale `security-review-needed` label not removed on dirty-then-clean re-scan
- **#27** — `astral-sh/setup-uv` silently dropped from extractor due to YAML list-marker shape

## ⚠️ Behavior Changes (read before merging)

- **Default auto-merge now enforces a 7-day release-age gate.** Consumers on `@v2` with `auto_merge: true` will see Dependabot PRs sit in `pending` for up to 7 days instead of auto-merging immediately on day 0. Set `cooldown_days: 0` in your caller workflow to restore pre-v2.0.2 behavior.
- **`security-review-needed` label is now reconciled on every scan.** Automation that treated this label as persistent will now see it removed when a re-scan finds zero applicable advisories. Labels are preserved (not removed) when a scan encounters API errors, so transient failures don't silently clear warnings.
- **New `cooldown-pending` label (amber)** applied when target versions are within the configured cooldown window.
- **New gate terminal states** — the `dependency-cooldown / gate` context can now end at `pending` (cooldown-only block, default) or `failure` (cooldown-only block with `fail_on_cooldown: true`) in addition to the existing `success` and `error` states.

## New Inputs

| Input | Type | Default | Description |
|---|---|---|---|
| `cooldown_days` | number | `7` | Minimum release age in days before auto-merge is allowed. Set to `0` to disable workflow-side release-age enforcement. |
| `fail_on_cooldown` | boolean | `false` | If `true`, cooldown blocks set the gate to `failure` instead of `pending`. Use when branch protection requires a hard-red blocker. |

## Architecture

Extracted two standalone scripts from the inline workflow bash:

- `scripts/extract-deps.sh` — parses PR diff, emits TSV (`name\tversion\tecosystem`). Rewritten with bash-native regex to fix #27 (handles YAML list-marker `- uses:` form). Bash 3.2 compatible.
- `scripts/check-release-age.sh` — takes dep TSV, queries GitHub Releases + PyPI APIs, emits verdict TSV with per-row pass/fail/error verdicts. Two-attempt retry, fixture mode for tests, yanked detection.

The workflow itself (`dependency-cooldown.yml`) was restructured with:
- New `actions/checkout` step pulling `j7an/shared-workflows@github.workflow_sha` with sparse-checkout
- Three-branch gate state machine (advisory > cooldown > clean)
- `reconcile_label()` helper that authoritatively adds/removes both labels on every scan (HAS_ERROR-aware — labels are preserved on API-error re-scans)
- Release Age table in the scan comment with per-package age and earliest-unblock footer
- Extraction Warning banner when the sanity-check detects a drift between raw diff count and extractor output

## Test Coverage

New bats test suite with 8 tests (all passing):

```
1..8
ok 1 blocks sub-cooldown actions at COOLDOWN_DAYS=7 (regression for #25)
ok 2 passes everything at COOLDOWN_DAYS=0 (escape hatch)
ok 3 PyPI happy path returns pass for aged release
ok 4 yanked PyPI release fails regardless of age
ok 5 missing fixture (simulates 404) produces error verdict
ok 6 extracts all three actions from nexus-mcp#160 diff (regression for #27)
ok 7 extracts Python deps from requirements.txt diff
ok 8 empty diff produces empty output with exit 0
```

- `tests/extract-deps.bats` — 3 tests against hand-crafted and real-captured diffs
- `tests/check-release-age.bats` — 5 tests with fixture-mode API responses, fixed `NOW_EPOCH` for determinism
- `tests/fixtures/extract-deps/nexus-mcp-160.diff` — real captured diff from j7an/nexus-mcp#160 (the regression fixture)
- `.github/workflows/ci-scripts.yml` — new CI runner that triggers bats on `scripts/**`, `tests/**`, `ci-scripts.yml`, or `dependency-cooldown.yml` changes

## Root Cause of #27

The v2.0.1 regex `^\+\s+uses:` did not match YAML list-marker-prefixed lines of the form `+      - uses: foo@sha # v1.0.0`, which is exactly how `astral-sh/setup-uv` appears in nexus-mcp#160's diff (17 raw `+...uses:` lines, 2 of them `- uses:` shape for setup-uv, 15 plain `uses:` for the other two actions). The new regex `^\+[[:space:]]+(-[[:space:]]+)?uses:` accepts both shapes.

## Commits

17 `fix:` commits (all patch-bump under tag-release.yml's conventional-commit analyzer):

1. `1f3f981` — extract-deps regression fixture for nexus-mcp#160
2. `998554a` — implement extract-deps.sh with bash-native parser
3. `96dcc5e` — add Python and empty-diff extract-deps tests
4. `9ca390a` — add check-release-age regression fixture
5. `8beeb3d` — implement check-release-age.sh with tier-1 GitHub/PyPI lookups
6. `747ce1f` — add edge-case tests for check-release-age
7. `94f40fe` — add bats test runner workflow
8. `aab2e50` — wire extract-deps.sh into dependency-cooldown.yml
9. `fc3f140` — add cooldown_days input and wire check-release-age.sh
10. `d09b8fa` — reconcile labels on every scan to fix stale-label bug
11. `22120ca` — combine advisory and cooldown gates in state machine
12. `2790d8d` — add Release Age and Extraction Warning comment sections
13. `9c3fe65` — document cooldown_days, fail_on_cooldown, and cooldown-pending label
14. `9afccfd` — run reconcile_label before HAS_ERROR early-exit
15. `053996e` — add checkout, fix sanity-check dedup, guard reconcile removal on error
16. `1ae4585` — filter local/docker in sanity check, fix date fallback order
17. `df5d327` — also run bats on dependency-cooldown.yml changes

## Test Plan

- [x] `bats tests/` — 8/8 passing locally
- [x] YAML parses — `python3 -c 'import yaml; yaml.safe_load(...)'` clean on both `dependency-cooldown.yml` and `ci-scripts.yml`
- [x] shellcheck clean on both scripts
- [x] Commit prefix audit — all 17 commits use `fix:` prefix
- [ ] CI green on this PR (ci-scripts.yml should run on this PR because it touches `dependency-cooldown.yml`)
- [ ] Self-consumption smoke test — wait for the next Dependabot PR against shared-workflows to run the new workflow end-to-end
- [ ] Replay verification — craft a test PR with nexus-mcp#160's bump list against a throwaway repo, confirm `cooldown-pending` label applied, gate `pending`, auto-merge not enabled

## Deferred to Follow-ups (not blocking)

- Release notes polish (callout for default behavior change, reconcile semantic)
- Action name regex hardening (markdown-metacharacter rejection)
- Negative `age_days` clamp on clock skew
- Extract reconcile_label and sanity-check to testable shims
- Add actionlint/shellcheck CI on `.github/workflows/**` changes

## Review

This PR was developed under an extensive 3-pass parallel review process across 5 domains (security, correctness, API contract, portability, test quality). Final score: Security 9/10, Correctness 9/10, API Contract 8/10, Portability 9/10, Test Quality 6/10 → naive average 8.2/10, no remaining blockers.

---

Fixes #25
Fixes #26
Fixes #27