### PR TITLE
fix(cooldown): unblock v2.0.2 consumers by inlining scripts and reordering gate

### DIFF
--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -28,3 +28,17 @@ jobs:
 
       - name: Run bats
         run: bats tests/
+
+  inline-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Verify inline bash matches scripts/*.sh
+        run: ./scripts/check-inline-sync.sh

--- a/.github/workflows/dependency-cooldown.yml
+++ b/.github/workflows/dependency-cooldown.yml
@@ -72,6 +72,95 @@ jobs:
           COOLDOWN_DAYS: ${{ inputs.cooldown_days }}
           FAIL_ON_COOLDOWN: ${{ inputs.fail_on_cooldown }}
         run: |
+          # --- BEGIN inline:scripts/extract-deps.sh ---
+          extract_deps() (
+          # extract-deps.sh — parse unified diff on stdin, emit dependency TSV on stdout
+          #
+          # Output: <name>\t<version>\t<ecosystem>  where ecosystem ∈ {actions, pypi}
+          # Exit:   0 on success (possibly zero rows), 2 on malformed input
+          #
+          # Handles BOTH GitHub Actions shapes observed in real PR diffs:
+          #   +        uses: owner/repo@sha # vX.Y.Z        (no list marker)
+          #   +      - uses: owner/repo@sha # vX.Y.Z        (YAML list marker)
+          #
+          # The missing list-marker support in the v2.0.1 regex `^\+\s+uses:` is the
+          # root cause of issue #27 (astral-sh/setup-uv silently dropped from
+          # nexus-mcp#160's cooldown scan).
+
+          set -euo pipefail
+
+          # Dedup sentinel: newline-delimited list of "ecosystem:name" keys.
+          # Using a plain string (not `declare -A`) for bash 3.2 compatibility, since
+          # macOS's system bash is still 3.2 and the bats test invokes `bash` directly.
+          seen=$'\n'
+          rows=()
+
+          input=$(cat)
+
+          # Empty input → exit 0 with no output
+          if [ -z "$input" ]; then
+            exit 0
+          fi
+
+          # Malformed input detection: if non-empty and has none of the unified-diff
+          # markers, reject with exit 2.
+          if ! printf '%s\n' "$input" | grep -qE '^(\+\+\+|---|@@|diff --git)'; then
+            echo "extract-deps.sh: input is not a unified diff" >&2
+            exit 2
+          fi
+
+          while IFS= read -r line; do
+            # Strip CR for CRLF-encoded diffs
+            line="${line%$'\r'}"
+
+            # Skip diff file headers (+++ b/path)
+            [[ "$line" == +++* ]] && continue
+
+            # --- GitHub Actions parser ---
+            # Matches both "+ uses: foo@..." and "+ - uses: foo@..."
+            if [[ "$line" =~ ^\+[[:space:]]+(-[[:space:]]+)?uses:[[:space:]]+([^[:space:]@]+)@[^[:space:]]+(.*)$ ]]; then
+              name="${BASH_REMATCH[2]}"
+              rest="${BASH_REMATCH[3]}"
+
+              # Skip local and docker actions
+              [[ "$name" == ./* ]] && continue
+              [[ "$name" == docker://* ]] && continue
+
+              version=""
+              # Capture version from trailing comment: " # v1.2.3" or " # 1.2.3"
+              # The `v?` is OUTSIDE the capture group so we strip the leading v.
+              if [[ "$rest" =~ \#[[:space:]]*v?([0-9][0-9.]*) ]]; then
+                version="${BASH_REMATCH[1]}"
+              fi
+
+              key="actions:$name"
+              case "$seen" in *$'\n'"$key"$'\n'*) continue ;; esac
+              seen="${seen}${key}"$'\n'
+              rows+=("$name"$'\t'"$version"$'\t'"actions")
+              continue
+            fi
+
+            # --- Python deps parser ---
+            # Skip Python-style comment lines first
+            [[ "$line" =~ ^\+[[:space:]]*# ]] && continue
+
+            if [[ "$line" =~ ^\+[[:space:]]*([a-zA-Z][a-zA-Z0-9_.\-]*)[[:space:]]*(==|\>=|\<=|~=|\!=|\>|\<)[[:space:]]*([0-9][0-9a-zA-Z.\-]*) ]]; then
+              name="${BASH_REMATCH[1]}"
+              version="${BASH_REMATCH[3]}"
+              key="pypi:$name"
+              case "$seen" in *$'\n'"$key"$'\n'*) continue ;; esac
+              seen="${seen}${key}"$'\n'
+              rows+=("$name"$'\t'"$version"$'\t'"pypi")
+              continue
+            fi
+          done <<< "$input"
+
+          if [ ${#rows[@]} -gt 0 ]; then
+            printf '%s\n' "${rows[@]}" | sort -t$'\t' -k1,1
+          fi
+          )
+          # --- END inline:scripts/extract-deps.sh ---
+
           DIFF=$(gh pr diff "$PR_NUMBER" --repo "$GH_REPO")
 
           DEPS=""
@@ -87,7 +176,7 @@ jobs:
           PR_BODY=$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json body --jq '.body // ""')
 
           # --- Extract dependencies via standalone script (Task 8) ---
-          DEPS_TSV=$(echo "$DIFF" | bash "${GITHUB_WORKSPACE}/shared-workflows/scripts/extract-deps.sh")
+          DEPS_TSV=$(echo "$DIFF" | extract_deps)
 
           # Populate ACTIONS, PY_DEPS, ACTION_VERSIONS, PY_VERSIONS from DEPS_TSV
           # so the existing advisory-scan loops below can consume them unchanged.

--- a/.github/workflows/dependency-cooldown.yml
+++ b/.github/workflows/dependency-cooldown.yml
@@ -382,6 +382,10 @@ jobs:
           COOLDOWN_FAILURES=0
           AGE_TSV=""
           if [ "$COOLDOWN_DAYS" -gt 0 ]; then
+            # check_release_age must be invoked via command substitution so
+            # bash's parent -e is dropped — this preserves per-row error
+            # tolerance (404s, parse failures, etc. emit error verdicts
+            # instead of killing the step). Do not convert to a direct call.
             AGE_TSV=$(echo "$DEPS_TSV" | check_release_age)
             COOLDOWN_FAILURES=$(echo "$AGE_TSV" | awk -F'\t' '$6=="fail" || $6=="error"' | wc -l | tr -d ' ')
           fi

--- a/.github/workflows/dependency-cooldown.yml
+++ b/.github/workflows/dependency-cooldown.yml
@@ -161,6 +161,156 @@ jobs:
           )
           # --- END inline:scripts/extract-deps.sh ---
 
+          # --- BEGIN inline:scripts/check-release-age.sh ---
+          check_release_age() (
+          # check-release-age.sh — read dep TSV on stdin, emit verdict TSV on stdout
+          #
+          # Schema:
+          #   in:  <name>\t<version>\t<ecosystem>
+          #   out: <name>\t<version>\t<ecosystem>\t<published_iso>\t<age_days>\t<verdict>\t<reason>
+          #
+          # Verdicts: pass | fail | error
+          # Exit: always 0; failures are per-row.
+          #
+          # Bash 3.2 compatible (macOS system bash).
+
+          set -uo pipefail
+
+          : "${COOLDOWN_DAYS:?COOLDOWN_DAYS env var is required}"
+          : "${NOW_EPOCH:=$(date +%s)}"
+
+          # iso_to_epoch <iso> — print unix epoch on stdout, return 1 on parse failure.
+          # Handles both GitHub ("2026-03-29T12:00:00Z") and PyPI ("2026-03-29T12:00:00")
+          # ISO variants across GNU and BSD date.
+          iso_to_epoch() {
+            local iso="$1"
+            # GNU date: accepts the ISO string as-is (with or without Z).
+            date -u -d "$iso" +%s 2>/dev/null && return 0
+            # GNU date: append Z for naive PyPI upload_time.
+            date -u -d "${iso}Z" +%s 2>/dev/null && return 0
+            # BSD date (macOS): strip trailing Z and parse via -jf.
+            local stripped="${iso%Z}"
+            date -u -jf '%Y-%m-%dT%H:%M:%S' "$stripped" +%s 2>/dev/null && return 0
+            return 1
+          }
+
+          # fetch_github <owner> <repo> <version> — print published_at ISO on stdout, return 1 on failure.
+          fetch_github() {
+            local owner="$1" repo="$2" version="$3"
+            if [ -n "${AGE_FIXTURE_DIR:-}" ]; then
+              local fx="$AGE_FIXTURE_DIR/github/$owner/$repo/releases/tags/v$version.json"
+              [ -f "$fx" ] || return 1
+              jq -r '.published_at // empty' "$fx"
+              return 0
+            fi
+            local resp
+            if ! resp=$(gh api "repos/$owner/$repo/releases/tags/v$version" 2>/dev/null); then
+              sleep 2
+              if ! resp=$(gh api "repos/$owner/$repo/releases/tags/v$version" 2>/dev/null); then
+                return 1
+              fi
+            fi
+            printf '%s' "$resp" | jq -r '.published_at // empty'
+          }
+
+          # fetch_pypi <pkg> <version> — print "<upload_time>\t<yanked_bool>" on stdout, return 1 on failure.
+          fetch_pypi() {
+            local pkg="$1" version="$2"
+            local upload yanked
+            if [ -n "${AGE_FIXTURE_DIR:-}" ]; then
+              local fx="$AGE_FIXTURE_DIR/pypi/$pkg/$version.json"
+              [ -f "$fx" ] || return 1
+              upload=$(jq -r '.urls[0].upload_time // empty' "$fx")
+              yanked=$(jq -r '.urls[0].yanked // false' "$fx")
+              printf '%s\t%s\n' "$upload" "$yanked"
+              return 0
+            fi
+            local resp
+            if ! resp=$(curl -sf --max-time 30 "https://pypi.org/pypi/$pkg/$version/json" 2>/dev/null); then
+              sleep 2
+              if ! resp=$(curl -sf --max-time 30 "https://pypi.org/pypi/$pkg/$version/json" 2>/dev/null); then
+                return 1
+              fi
+            fi
+            upload=$(printf '%s' "$resp" | jq -r '.urls[0].upload_time // empty')
+            yanked=$(printf '%s' "$resp" | jq -r '.urls[0].yanked // false')
+            printf '%s\t%s\n' "$upload" "$yanked"
+          }
+
+          # emit name version ecosystem published age verdict reason
+          emit() {
+            printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5" "$6" "$7"
+          }
+
+          while IFS=$'\t' read -r name version ecosystem || [ -n "${name:-}" ]; do
+            [ -z "${name:-}" ] && continue
+
+            # Escape hatch: COOLDOWN_DAYS=0 → all pass without lookup.
+            if [ "$COOLDOWN_DAYS" -eq 0 ]; then
+              emit "$name" "$version" "$ecosystem" "-" "-" "pass" ""
+              continue
+            fi
+
+            case "$ecosystem" in
+              actions)
+                owner="${name%%/*}"
+                remainder="${name#*/}"
+                repo="${remainder%%/*}"
+                if ! iso=$(fetch_github "$owner" "$repo" "$version"); then
+                  emit "$name" "$version" "$ecosystem" "-" "-" "error" "tier-1-404"
+                  continue
+                fi
+                if [ -z "$iso" ]; then
+                  emit "$name" "$version" "$ecosystem" "-" "-" "error" "transient-failure"
+                  continue
+                fi
+                if ! pub_epoch=$(iso_to_epoch "$iso"); then
+                  emit "$name" "$version" "$ecosystem" "-" "-" "error" "parse-failure"
+                  continue
+                fi
+                age_days=$(( (NOW_EPOCH - pub_epoch) / 86400 ))
+                if [ "$age_days" -ge "$COOLDOWN_DAYS" ]; then
+                  emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "pass" ""
+                else
+                  emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "fail" ""
+                fi
+                ;;
+
+              pypi)
+                if ! result=$(fetch_pypi "$name" "$version"); then
+                  emit "$name" "$version" "$ecosystem" "-" "-" "error" "pypi-404"
+                  continue
+                fi
+                iso="${result%%$'\t'*}"
+                yanked="${result##*$'\t'}"
+                if [ -z "$iso" ]; then
+                  emit "$name" "$version" "$ecosystem" "-" "-" "error" "transient-failure"
+                  continue
+                fi
+                if ! pub_epoch=$(iso_to_epoch "$iso"); then
+                  emit "$name" "$version" "$ecosystem" "-" "-" "error" "parse-failure"
+                  continue
+                fi
+                age_days=$(( (NOW_EPOCH - pub_epoch) / 86400 ))
+                if [ "$yanked" = "true" ]; then
+                  emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "fail" "yanked"
+                elif [ "$age_days" -ge "$COOLDOWN_DAYS" ]; then
+                  emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "pass" ""
+                else
+                  emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "fail" ""
+                fi
+                ;;
+
+              *)
+                emit "$name" "$version" "$ecosystem" "-" "-" "error" "unknown-ecosystem"
+                ;;
+            esac
+          done
+
+          exit 0
+          )
+          # --- END inline:scripts/check-release-age.sh ---
+
           DIFF=$(gh pr diff "$PR_NUMBER" --repo "$GH_REPO")
 
           DEPS=""
@@ -235,7 +385,7 @@ jobs:
           COOLDOWN_FAILURES=0
           AGE_TSV=""
           if [ "$COOLDOWN_DAYS" -gt 0 ]; then
-            AGE_TSV=$(echo "$DEPS_TSV" | bash "${GITHUB_WORKSPACE}/shared-workflows/scripts/check-release-age.sh")
+            AGE_TSV=$(echo "$DEPS_TSV" | check_release_age)
             COOLDOWN_FAILURES=$(echo "$AGE_TSV" | awk -F'\t' '$6=="fail" || $6=="error"' | wc -l | tr -d ' ')
           fi
 

--- a/.github/workflows/dependency-cooldown.yml
+++ b/.github/workflows/dependency-cooldown.yml
@@ -23,20 +23,17 @@ on:
 jobs:
   scan:
     runs-on: ubuntu-latest
+    # Gate discipline (see #29): `Set initial status` must be the first
+    # step after `Harden runner`. Every subsequent step must carry
+    # `if: steps.gate.outputs.skip == 'false'` unless it is itself part
+    # of the gate. This avoids making non-bot PRs pay for fallible work
+    # (cross-repo fetches, API calls, script execution) that would only
+    # be used for Dependabot PRs.
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
-
-      - name: Checkout shared-workflows scripts
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: j7an/shared-workflows
-          ref: ${{ github.workflow_sha }}
-          path: shared-workflows
-          sparse-checkout: scripts
-          persist-credentials: false
 
       - name: Set initial status
         id: gate

--- a/scripts/check-inline-sync.sh
+++ b/scripts/check-inline-sync.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# check-inline-sync.sh — verify inline bash in dependency-cooldown.yml
+# matches scripts/*.sh byte-for-byte after the known normalization rules
+# (YAML indent strip, function wrapper strip, shebang strip).
+#
+# Usage: ./scripts/check-inline-sync.sh
+# Exit:  0 on success, 1 on any drift, missing sentinel, or residual
+#        runtime checkout reference.
+
+set -euo pipefail
+
+WORKFLOW=".github/workflows/dependency-cooldown.yml"
+SCRIPTS=(
+  "scripts/extract-deps.sh"
+  "scripts/check-release-age.sh"
+)
+YAML_INDENT="          "  # exactly 10 spaces — matches the `run: |` indent
+
+fail=0
+
+extract_inline_body() {
+  local script_path="$1"
+  local begin_marker="# --- BEGIN inline:${script_path} ---"
+  local end_marker="# --- END inline:${script_path} ---"
+
+  awk -v begin="$begin_marker" -v end="$end_marker" '
+    index($0, begin) { inside=1; next }
+    index($0, end)   { inside=0; next }
+    inside { print }
+  ' "$WORKFLOW"
+}
+
+for script in "${SCRIPTS[@]}"; do
+  if ! grep -qF "# --- BEGIN inline:${script} ---" "$WORKFLOW"; then
+    echo "FAIL: no inline sentinel for '${script}' found in ${WORKFLOW}"
+    fail=1
+    continue
+  fi
+
+  # Strip first and last lines (the `fn() (` opener and the `)` closer),
+  # then strip the 10-space YAML indent from every remaining line.
+  inline_body=$(extract_inline_body "$script" | sed -E '1d;$d' | sed -E "s/^${YAML_INDENT}//")
+  standalone_body=$(tail -n +2 "$script")
+
+  if ! diff <(printf '%s\n' "$inline_body") <(printf '%s\n' "$standalone_body") > /dev/null 2>&1; then
+    echo "FAIL: inline copy of '${script}' in ${WORKFLOW} does not match source:"
+    diff <(printf '%s\n' "$inline_body") <(printf '%s\n' "$standalone_body") || true
+    fail=1
+  else
+    echo "OK:   ${script} inline copy matches source"
+  fi
+done
+
+# Safety net: residual runtime source-fetch references must not exist.
+if grep -qF '${GITHUB_WORKSPACE}/shared-workflows/scripts/' "$WORKFLOW"; then
+  echo "FAIL: residual runtime source-fetch reference in ${WORKFLOW}:"
+  grep -nF '${GITHUB_WORKSPACE}/shared-workflows/scripts/' "$WORKFLOW" || true
+  fail=1
+fi
+
+exit $fail


### PR DESCRIPTION
## Summary

- Removes the runtime `actions/checkout` of `j7an/shared-workflows` from `dependency-cooldown.yml` — the root cause of #29 (caller-context `${{ github.workflow_sha }}` resolved to the consumer's PR merge SHA, which doesn't exist in `shared-workflows`)
- Inlines `scripts/extract-deps.sh` and `scripts/check-release-age.sh` as **subshell functions** in the workflow body, preserving the subprocess scope semantics via paren function syntax (`fn() ( ... )`) so the standalone `set -e[uo] pipefail` options stay contained
- Reorders the step sequence so `Set initial status` runs immediately after `Harden runner`, before any fallible step. Adds a 6-line gate-discipline policy comment above `jobs.scan.steps` codifying the invariant for future authors
- Adds `scripts/check-inline-sync.sh` and a new `inline-sync` CI job in `ci-scripts.yml` that enforces byte-for-byte parity between the inline copies and the standalone scripts on every PR — any future drift fails CI loudly
- Adds a tripwire comment near the `check_release_age` call site documenting that command-substitution invocation is load-bearing for per-row error tolerance (a refactor to a direct call would silently kill the step on the first 404/parse failure)

## Test plan

- [x] `bats tests/extract-deps.bats tests/check-release-age.bats` — green (8/8)
- [x] `./scripts/check-inline-sync.sh` — green (both inline copies match standalone byte-for-byte)
- [x] `python3 -c 'yaml.safe_load(...)'` on both touched workflow files — green
- [x] `grep -nE '(shared-workflows/scripts|github\.workflow_sha|j7an/shared-workflows)' .github/workflows/dependency-cooldown.yml` — zero matches
- [ ] shared-workflows CI: `Script Tests / bats` — green
- [ ] shared-workflows CI: `Script Tests / inline-sync` — green
- [ ] shared-workflows CI: `Dependency Cool-Down / cooldown / scan` (self-consumption via `ci-cooldown.yml`) — green
- [ ] **Cross-repo non-bot validation:** a non-bot-author PR on a real consumer repo pinned at this PR's head SHA ends at `dependency-cooldown / gate = success` with description \`Non-bot PR — no cool-down required\`
- [ ] **Cross-repo Dependabot validation:** a `dependabot[bot]`-author PR on the same consumer pinned at this PR's head SHA reaches \`success\` or \`pending\`, never \`error\`, with the inlined functions visibly executing in the scan logs

## Why cross-repo validation is non-negotiable

Per #29's post-mortem, the self-consumption caller at \`.github/workflows/ci-cooldown.yml\` uses a local-path \`uses: ./...\` reference, which makes the caller repo the same as the checkout target repo and masks caller-context bugs by structural coincidence. PR #28 went green here on shared-workflows CI and still shipped broken to every cross-repo consumer. This PR's CI passing is necessary but not sufficient — the cross-repo checkbox above is the actual proof. Companion smoke-test infrastructure to close this gap is tracked in #30.

## Post-merge operator checklist

This repo's release pipeline is intentionally not auto-reactive on merge:

1. **Squash-merge this PR** to \`main\` (the title \`fix(cooldown): ...\` becomes the squash commit subject — load-bearing for the patch bump)
2. **Manually dispatch \`Tag Release\`** workflow on \`main\` with \`bump=auto\` — this analyzes commit subjects, computes \`v2.0.2 → v2.0.3\` patch bump, and pushes the tag
3. **\`release.yml\` fires reactively** on the tag push, force-updates floating \`v2.0\` and \`v2\` tags, and publishes the GitHub release with autogenerated notes
4. **Watch the next Dependabot bump cycle** — consumers pinned to \`v2.0.2\` will receive a PR bumping to \`v2.0.3\`. The first such PR's \`dependency-cooldown / gate\` must reach \`success\` or \`pending\` for the release to be considered validated end-to-end

If step 4 reveals a regression, the rollback is: \`git tag -d v2.0.3 && git push --delete origin v2.0.3\`, then revert the merge commit on \`main\` via a new revert PR (do not force-push). Detail in the spec at \`docs/superpowers/specs/2026-04-12-issue-29-v2.0.3-emergency-fix-design.md\` section 9.

## Out of scope (tracked in #30)

Companion durability work that explicitly does NOT belong in this emergency fix:

- Cross-repo smoke test repo (\`shared-workflows-e2e\` or equivalent)
- Caller-context lint rule (\`ast-grep\`/\`actionlint\`-based check forbidding \`ref: \${{ github.workflow_sha }}\` in \`workflow_call\` files)
- README "Known caller-side constraints" section documenting which GitHub context variables this workflow does and does not rely on
- \`tests/fixtures/\` canonical caller workflow YAML for the lint rule and smoke test to consume

These three layers of defense compose to make #29's bug class structurally impossible to reintroduce. v2.0.3 ships the immediate fix; #30 ships the durability infrastructure as a follow-up.

## Pre-existing findings surfaced by parallel review (NOT blocking)

Four parallel pr-reviewer agents (security, correctness, CI/release, consumer-compat) reviewed this branch and surfaced several Info/Low findings that pre-date this PR and are explicitly not introduced by it:

- \`jq\` filter interpolation for \`EXISTING_COMMENT_ID\` could use \`--argjson\` for defense-in-depth (already-in-repo pattern)
- Unquoted \`for ACTION in \$ACTIONS\` loops would benefit from \`while read\` (already-in-repo pattern)
- \`egress-policy: audit\` could be tightened to \`block\` with an allowlist on the \`ci-scripts.yml\` jobs (not a regression)
- \`persist-credentials: false\` could be added to \`ci-scripts.yml\` checkout steps (consistency with \`security.yml\`)

None of these block the v2.0.3 release. They are candidate hardening for a separate follow-up PR or for #30.

Fixes #29.