### PR TITLE
feat(release): make tag-release and release reusable via workflow_call

### DIFF
--- a/.github/workflows/release-self.yml
+++ b/.github/workflows/release-self.yml
@@ -14,11 +14,12 @@ on:
           - minor
           - major
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   tag:
+    permissions:
+      contents: write
     uses: ./.github/workflows/tag-release.yml
     with:
       bump: ${{ inputs.bump }}
@@ -26,6 +27,8 @@ jobs:
       RELEASE_BOT_PRIVATE_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
   publish:
+    permissions:
+      contents: write
     needs: tag
     uses: ./.github/workflows/release.yml
     with:

--- a/.github/workflows/release-self.yml
+++ b/.github/workflows/release-self.yml
@@ -1,0 +1,32 @@
+name: Release (self)
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Semver bump (auto = infer from conventional commits since last tag)"
+        type: choice
+        required: true
+        default: auto
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    uses: ./.github/workflows/tag-release.yml
+    with:
+      bump: ${{ inputs.bump }}
+    secrets:
+      RELEASE_BOT_PRIVATE_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+  publish:
+    needs: tag
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.tag.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,13 +3,25 @@ name: Publish Release
 on:
   push:
     tags: ['v*.*.*']
+  workflow_call:
+    inputs:
+      tag:
+        type: string
+        required: true
+        description: "Semver tag to publish (e.g. v1.2.3)"
 
 permissions:
   contents: write
 
+concurrency:
+  group: publish-release-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   publish-release:
     runs-on: ubuntu-latest
+    env:
+      TAG: ${{ inputs.tag || github.ref_name }}
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -19,15 +31,16 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Update floating major and minor tags
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.ref_name }}
         run: |
+          [ -n "$TAG" ] || { echo "::error::tag input is empty — caller did not pass a tag"; exit 1; }
           # Parse semver components: v1.2.3 → MAJOR=v1, MINOR=v1.2
-          MAJOR=$(echo "$TAG" | sed 's/\..*//')
-          MINOR=$(echo "$TAG" | sed 's/\.[^.]*$//')
+          MAJOR=${TAG%%.*}
+          MINOR=${TAG%.*}
 
           echo "Semver tag: $TAG (immutable)"
           echo "Minor tag:  $MINOR (floats to latest patch)"
@@ -49,7 +62,6 @@ jobs:
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.ref_name }}
         run: |
           # Idempotent: skip if a release already exists for this tag
           # (e.g. manual re-run, or backfilled during a migration).

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -13,6 +13,20 @@ on:
           - patch
           - minor
           - major
+  workflow_call:
+    inputs:
+      bump:
+        type: string
+        required: false
+        default: auto
+        description: "Semver bump (auto/patch/minor/major)"
+    secrets:
+      RELEASE_BOT_PRIVATE_KEY:
+        required: true
+    outputs:
+      tag:
+        description: "The semver tag that was created (e.g. v1.2.3)"
+        value: ${{ jobs.tag-release.outputs.tag }}
 
 permissions:
   contents: write
@@ -24,6 +38,8 @@ concurrency:
 jobs:
   tag-release:
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.compute.outputs.next_tag }}
     # Gate secret access on a named environment so a malicious workflow edit
     # can't reach RELEASE_BOT_PRIVATE_KEY without passing the environment's
     # branch-policy check (main only). Pairs with the if: below as a

--- a/README.md
+++ b/README.md
@@ -244,9 +244,9 @@ jobs:
 
 | Pin | Gets updates | Use when |
 |-----|-------------|----------|
-| `@v1` | All non-breaking changes | Default — most convenient |
-| `@v1.2` | Patch fixes only | Want patches but not new features |
-| `@v1.2.3` | Nothing (frozen) | Need exact reproducibility or rollback |
+| `@vX` | All non-breaking changes within major `X` | Default — most convenient |
+| `@vX.Y` | Patch fixes only within minor `X.Y` | Want patches but not new features |
+| `@vX.Y.Z` | Nothing (frozen) | Need exact reproducibility or rollback |
 
 Tags are managed automatically — merging a PR to this repo creates a semver tag based on conventional commit prefixes and updates the floating tags.
 
@@ -259,14 +259,14 @@ Tags are managed automatically — merging a PR to this repo creates a semver ta
 | Kind | Name | Value |
 |------|------|-------|
 | Repo variable | `RELEASE_BOT_APP_ID` | Numeric App ID |
-| Repo secret | `RELEASE_BOT_PRIVATE_KEY` | Full PEM contents including header/footer |
+| Secret | `RELEASE_BOT_PRIVATE_KEY` | Full PEM contents including header/footer |
 
 ### One-time provisioning
 
 1. Create a GitHub App (org- or user-owned) with **repository permission** `Contents: Read and write` — nothing else.
 2. Install the App on this repo (single-repo install recommended).
 3. Copy the App ID into `vars.RELEASE_BOT_APP_ID` under **Settings → Secrets and variables → Actions → Variables**.
-4. Generate a private key from the App settings and paste the PEM into `secrets.RELEASE_BOT_PRIVATE_KEY` under **Settings → Secrets and variables → Actions → Secrets**.
+4. Generate a private key from the App settings and store the PEM as `RELEASE_BOT_PRIVATE_KEY`. A repo-level Actions secret works with the sample caller below; if you scope release credentials to the `release` environment, expose the same secret name there instead.
 
 ### Verify
 
@@ -279,3 +279,77 @@ gh run list --workflow=release.yml --limit 1
 ### Rotation
 
 To rotate the key: generate a new private key in the App settings, update `secrets.RELEASE_BOT_PRIVATE_KEY`, then delete the old key in the App settings. No code change required.
+
+## Using shared-workflows for releases
+
+`tag-release.yml` and `release.yml` are reusable workflows. Downstream repos can cut and publish releases by adding a thin caller that delegates to this repo — no copy-pasted release logic.
+
+### Minimal caller (recommended)
+
+```yaml
+# .github/workflows/release.yml
+name: Release
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@v2
+    secrets:
+      RELEASE_BOT_PRIVATE_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+  publish:
+    needs: tag
+    uses: j7an/shared-workflows/.github/workflows/release.yml@v2
+    with:
+      tag: ${{ needs.tag.outputs.tag }}
+```
+
+Dispatching this workflow runs `tag-release` with the default `bump: auto` (infers the semver bump from conventional commit prefixes), then publishes the resulting tag.
+
+### Full caller (with operator bump override)
+
+Use this variant if you want to expose a picker in the Actions UI so operators can force a specific bump level.
+
+```yaml
+# .github/workflows/release.yml
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        type: choice
+        options: [auto, patch, minor, major]
+        default: auto
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@v2
+    with:
+      bump: ${{ inputs.bump }}
+    secrets:
+      RELEASE_BOT_PRIVATE_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+  publish:
+    needs: tag
+    uses: j7an/shared-workflows/.github/workflows/release.yml@v2
+    with:
+      tag: ${{ needs.tag.outputs.tag }}
+```
+
+### Required downstream setup
+
+1. **Create a `release` GitHub Environment**, restricted to the `main` branch via deployment branch policy (Settings → Environments → New environment → Deployment branches → Selected branches → `main`).
+2. **Make `RELEASE_BOT_PRIVATE_KEY` available as `secrets.RELEASE_BOT_PRIVATE_KEY`** in the caller repo. The sample snippets work with a repo-level Actions secret; if you scope release credentials to the `release` environment, keep the same secret name there so the caller can forward it unchanged.
+3. **Set `vars.RELEASE_BOT_APP_ID`** as a repo variable pointing at the Release Bot GitHub App's numeric App ID.
+4. **Install the Release Bot App on the repo** with `Contents: Read and write` permission (see [Release Bot App setup](#release-bot-app-setup) above for provisioning).
+
+The `environment: release` + `if: github.ref == 'refs/heads/main'` gate inside `tag-release.yml` runs in **your repo's** security context — `shared-workflows` cannot unilaterally enforce it across consumers. If you skip step 1, you lose the environment-side branch policy and secret protection; the in-file `if:` check still blocks non-`main` refs, but the extra GitHub-side gate is gone.
+
+### On the `@v2` pin
+
+`@v2` is the floating major tag for the current `v2.x.y` line. It always points at the latest `v2.x.y` release because `release.yml` force-updates floating majors on every publish. Pinning to `@v2` means you get all non-breaking updates automatically. Pin to `@v2.1` for patch-only updates, or `@v2.1.0` for an immutable freeze — see the [Versioning](#versioning) section above.


### PR DESCRIPTION
## Summary

- add `workflow_call` support to `tag-release.yml` and expose the created tag as a reusable output
- add `workflow_call`, tag-keyed concurrency, `fetch-tags: true`, and an empty-tag guard to `release.yml` while retaining `push: tags` as the Phase A safety net
- add `release-self.yml` as a local-path thin caller and document the downstream caller pattern in `README.md`, including required permissions and secret setup

## Verification

- `actionlint .github/workflows/tag-release.yml .github/workflows/release.yml .github/workflows/release-self.yml`
- `yq '.on | keys' .github/workflows/tag-release.yml`
- `yq '.on.workflow_call.outputs.tag.value' .github/workflows/tag-release.yml`
- `yq '.jobs.tag-release.outputs.tag' .github/workflows/tag-release.yml`
- `yq '.on | keys' .github/workflows/release.yml`
- `yq '.concurrency.group' .github/workflows/release.yml`
- `grep -c 'inputs.tag || github.ref_name' .github/workflows/release.yml`
- `grep -c 'TAG: ${{ github.ref_name }}' .github/workflows/release.yml`
- `grep '\[ -n "\$TAG" \]' .github/workflows/release.yml`
- `yq '.jobs.tag.uses' .github/workflows/release-self.yml`
- `yq '.jobs.publish.with.tag' .github/workflows/release-self.yml`
- `yq '.jobs.publish.needs' .github/workflows/release-self.yml`
- `grep -n '^## Using shared-workflows for releases' README.md`
- `grep -c '@v2' README.md`

## Follow-up

- Phase B is a manual operator checkpoint after merge: dispatch `Release (self)` from `main`, verify the new tag and GitHub Release, and confirm the concurrency behavior during the transition window.
- Phase C is a follow-up PR that removes `release.yml`'s legacy `push: tags` trigger only after Phase B passes.

Fixes #32
