### PR TITLE
refactor(release): remove legacy push trigger from release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Publish Release
 
 on:
-  push:
-    tags: ['v*.*.*']
   workflow_call:
     inputs:
       tag:


### PR DESCRIPTION
## Summary

- remove the legacy `push: tags` trigger from `.github/workflows/release.yml`
- keep `workflow_call` as the only entrypoint for the reusable publish workflow
- preserve the existing concurrency guard for same-tag reruns

## Why now

Phase B validation has already passed on `main`:
- `Release (self)` succeeded from `main`
- `v2.1.0` was created and published
- floating tags updated correctly (`v2` and `v2.1` -> `v2.1.0`; `v2.0` unchanged)
- the transition-window double-trigger serialized correctly and the second publish path logged `Release v2.1.0 already exists, skipping`

With that production proof in place, the legacy push path is no longer load-bearing.

## Verification

- `actionlint .github/workflows/release.yml`
- `yq '.on | keys' .github/workflows/release.yml`

Fixes #32
