### PR TITLE
fix(cooldown): harden reusable workflows against caller-context bugs

### DIFF
--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -5,8 +5,7 @@ on:
     paths:
       - 'scripts/**'
       - 'tests/**'
-      - '.github/workflows/ci-scripts.yml'
-      - '.github/workflows/dependency-cooldown.yml'
+      - '.github/workflows/**'
 
 permissions:
   contents: read

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -42,3 +42,17 @@ jobs:
 
       - name: Verify inline bash matches scripts/*.sh
         run: ./scripts/check-inline-sync.sh
+
+  lint-workflow-call:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Lint workflow_call files for caller-context refs
+        run: ./scripts/lint-workflow-call.sh

--- a/README.md
+++ b/README.md
@@ -250,6 +250,42 @@ jobs:
 
 Tags are managed automatically — merging a PR to this repo creates a semver tag based on conventional commit prefixes and updates the floating tags.
 
+## Known caller-side constraints
+
+The reusable workflows in this repo are **self-contained at runtime**: they must
+not fetch `j7an/shared-workflows` source at runtime, and they must not reference
+caller-scoped context variables as if they were reusable-workflow-scoped.
+
+The following are forbidden inside any `workflow_call` file:
+
+| Pattern | Why it's wrong |
+|---------|---------------|
+| `ref: ${{ github.workflow_sha }}` | Resolves to the **caller's** event SHA, not this workflow's commit |
+| `ref: ${{ github.sha }}` | Same problem — resolves to caller context |
+| `ref: ${{ github.ref }}` | Same problem — resolves to caller's branch/tag ref |
+
+This policy exists because violating it caused [#29](https://github.com/j7an/shared-workflows/issues/29):
+v2.0.2 shipped with a broken `actions/checkout` step that failed deterministically
+on every cross-repo consumer PR. The CI gate that should have caught it was
+structurally incapable of doing so, because `ci-cooldown.yml` self-consumes via
+local path (`uses: ./...`), which makes the caller repo the same as the checkout
+target and masks caller-context bugs by coincidence.
+
+If a future reusable workflow needs to execute a script that's under version
+control in this repo, **inline the script into the workflow YAML**. The bats test
+suite under `tests/` provides unit-test coverage against the standalone
+`scripts/*.sh` files, and `scripts/check-inline-sync.sh` verifies the inline
+copies stay in sync — so test feedback is preserved without introducing a runtime
+source-fetch dependency.
+
+### For authors adding a new reusable workflow
+
+Before opening a PR that adds or modifies a `workflow_call` file:
+
+1. **Review the constraints above** — no runtime source fetching, no caller-context refs
+2. **The lint rule enforces this in CI** — `scripts/lint-workflow-call.sh` runs as the `lint-workflow-call` job in `ci-scripts.yml` and will fail your PR if it detects a forbidden pattern
+3. **Cross-repo smoke testing is planned** ([#30](https://github.com/j7an/shared-workflows/issues/30)) — a companion repo will exercise reusable workflows from a genuinely external caller context to catch bugs that the self-consumption harness cannot detect
+
 ## Release Bot App setup
 
 `tag-release.yml` needs a non-`GITHUB_TOKEN` identity to push new tags, otherwise GitHub's recursion guard silently suppresses the downstream `release.yml` run. We use a GitHub App for this.

--- a/scripts/lint-workflow-call.sh
+++ b/scripts/lint-workflow-call.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# lint-workflow-call.sh — fail CI if any workflow_call file uses
+# caller-scoped context variables as checkout refs.
+#
+# Forbidden patterns (see issue #29, #30):
+#   ref: ${{ github.workflow_sha }}
+#   ref: ${{ github.sha }}
+#   ref: ${{ github.ref }}
+#
+# These resolve to the *caller's* context in a reusable workflow,
+# not the workflow's own commit — causing deterministic failures
+# on every cross-repo consumer.
+#
+# Usage: ./scripts/lint-workflow-call.sh [root-dir]
+#   root-dir defaults to "." (repo root).
+# Exit: 0 if clean, 1 if any violation found.
+
+set -euo pipefail
+
+ROOT="${1:-.}"
+WORKFLOWS_DIR="$ROOT/.github/workflows"
+
+if [ ! -d "$WORKFLOWS_DIR" ]; then
+  echo "No .github/workflows/ directory found — nothing to lint."
+  exit 0
+fi
+
+FORBIDDEN='ref:.*\$\{\{[[:space:]]*github\.(workflow_sha|sha|ref)[[:space:]]*\}\}'
+
+fail=0
+
+for file in "$WORKFLOWS_DIR"/*.yml "$WORKFLOWS_DIR"/*.yaml; do
+  [ -f "$file" ] || continue
+
+  # Only lint reusable workflow files (those with workflow_call trigger)
+  if ! grep -qE '^[[:space:]]*workflow_call:' "$file"; then
+    continue
+  fi
+
+  # Check for forbidden caller-context ref patterns
+  if matches=$(grep -nE "$FORBIDDEN" "$file"); then
+    echo "FAIL: $file contains caller-context ref(s) forbidden in workflow_call files:"
+    echo "$matches"
+    echo ""
+    fail=1
+  fi
+done
+
+if [ "$fail" -eq 0 ]; then
+  echo "OK: no caller-context refs found in workflow_call files."
+fi
+
+exit $fail

--- a/tests/fixtures/lint-workflow-call/clean.yml
+++ b/tests/fixtures/lint-workflow-call/clean.yml
@@ -1,0 +1,10 @@
+name: Clean Reusable Workflow
+
+on:
+  workflow_call:
+
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6

--- a/tests/fixtures/lint-workflow-call/comment-mention.yml
+++ b/tests/fixtures/lint-workflow-call/comment-mention.yml
@@ -1,0 +1,13 @@
+name: Regular CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      # This step is for workflow_call testing
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}

--- a/tests/fixtures/lint-workflow-call/comment-mention.yml
+++ b/tests/fixtures/lint-workflow-call/comment-mention.yml
@@ -1,13 +1,13 @@
 name: Regular CI
 
 on:
-  pull_request:
+  push:
+  # workflow_call:
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      # This step is for workflow_call testing
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}

--- a/tests/fixtures/lint-workflow-call/forbidden-ref.yml
+++ b/tests/fixtures/lint-workflow-call/forbidden-ref.yml
@@ -1,0 +1,12 @@
+name: Bad Reusable Workflow
+
+on:
+  workflow_call:
+
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}

--- a/tests/fixtures/lint-workflow-call/forbidden-sha.yml
+++ b/tests/fixtures/lint-workflow-call/forbidden-sha.yml
@@ -1,0 +1,12 @@
+name: Bad Reusable Workflow
+
+on:
+  workflow_call:
+
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}

--- a/tests/fixtures/lint-workflow-call/forbidden-workflow-sha.yml
+++ b/tests/fixtures/lint-workflow-call/forbidden-workflow-sha.yml
@@ -1,0 +1,13 @@
+name: Bad Reusable Workflow
+
+on:
+  workflow_call:
+
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          repository: j7an/shared-workflows
+          ref: ${{ github.workflow_sha }}

--- a/tests/fixtures/lint-workflow-call/not-reusable.yml
+++ b/tests/fixtures/lint-workflow-call/not-reusable.yml
@@ -1,0 +1,12 @@
+name: Regular CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}

--- a/tests/lint-workflow-call.bats
+++ b/tests/lint-workflow-call.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+
+# lint-workflow-call.bats — tests for scripts/lint-workflow-call.sh
+#
+# The lint script scans .github/workflows/*.yml for workflow_call files
+# containing forbidden caller-context refs. Tests use a temp directory
+# with fixture files symlinked into .github/workflows/ to simulate
+# the real repo layout.
+
+setup() {
+  LINT="$BATS_TEST_DIRNAME/../scripts/lint-workflow-call.sh"
+  FIXTURES="$BATS_TEST_DIRNAME/fixtures/lint-workflow-call"
+  WORKDIR=$(mktemp -d)
+  mkdir -p "$WORKDIR/.github/workflows"
+}
+
+teardown() {
+  rm -rf "$WORKDIR"
+}
+
+@test "passes on clean workflow_call file" {
+  cp "$FIXTURES/clean.yml" "$WORKDIR/.github/workflows/clean.yml"
+  run bash "$LINT" "$WORKDIR"
+  [ "$status" -eq 0 ]
+}
+
+@test "fails on ref: github.workflow_sha in workflow_call file" {
+  cp "$FIXTURES/forbidden-workflow-sha.yml" "$WORKDIR/.github/workflows/bad.yml"
+  run bash "$LINT" "$WORKDIR"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "github.workflow_sha" ]]
+}
+
+@test "fails on ref: github.sha in workflow_call file" {
+  cp "$FIXTURES/forbidden-sha.yml" "$WORKDIR/.github/workflows/bad.yml"
+  run bash "$LINT" "$WORKDIR"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "github.sha" ]]
+}
+
+@test "fails on ref: github.ref in workflow_call file" {
+  cp "$FIXTURES/forbidden-ref.yml" "$WORKDIR/.github/workflows/bad.yml"
+  run bash "$LINT" "$WORKDIR"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "github.ref" ]]
+}
+
+@test "skips non-workflow_call files even if they contain forbidden refs" {
+  cp "$FIXTURES/not-reusable.yml" "$WORKDIR/.github/workflows/ci.yml"
+  run bash "$LINT" "$WORKDIR"
+  [ "$status" -eq 0 ]
+}
+
+@test "passes when .github/workflows/ has no files" {
+  run bash "$LINT" "$WORKDIR"
+  [ "$status" -eq 0 ]
+}
+
+@test "fails listing all violations when multiple bad files exist" {
+  cp "$FIXTURES/forbidden-workflow-sha.yml" "$WORKDIR/.github/workflows/bad1.yml"
+  cp "$FIXTURES/forbidden-sha.yml" "$WORKDIR/.github/workflows/bad2.yml"
+  run bash "$LINT" "$WORKDIR"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "bad1.yml" ]]
+  [[ "$output" =~ "bad2.yml" ]]
+}
+
+@test "passes when .github/workflows/ directory does not exist" {
+  empty=$(mktemp -d)
+  run bash "$LINT" "$empty"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "nothing to lint" ]]
+  rm -rf "$empty"
+}
+
+@test "skips files that mention workflow_call only in comments" {
+  cp "$FIXTURES/comment-mention.yml" "$WORKDIR/.github/workflows/ci.yml"
+  run bash "$LINT" "$WORKDIR"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/lint-workflow-call.sh` — a CI lint rule that fails any `workflow_call` file using `ref: ${{ github.workflow_sha }}`, `ref: ${{ github.sha }}`, or `ref: ${{ github.ref }}` (the exact bug class from #29)
- Adds 9 bats tests with 6 fixture YAML files covering clean/forbidden/skip/edge cases
- Adds `lint-workflow-call` job to `ci-scripts.yml` alongside existing `bats` and `inline-sync` jobs
- Adds "Known caller-side constraints" section to README with policy, forbidden patterns table, #29 link, and author checklist

## Test plan

- [ ] `bats tests/` passes all 17 tests (8 existing + 9 new)
- [ ] `./scripts/lint-workflow-call.sh` exits 0 on the current repo
- [ ] `./scripts/check-inline-sync.sh` still passes (no regression)
- [ ] CI runs all three jobs (`bats`, `inline-sync`, `lint-workflow-call`) on this PR
- [ ] README section renders correctly between "Versioning" and "Release Bot App setup"

Fixes #30