### PR TITLE
chore(tag-release): replace deprecated `app-id` input with `client-id`

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -79,7 +79,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          client-id: ${{ vars.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

- Renames the deprecated `app-id` input to `client-id` on the `actions/create-github-app-token@v3.1.1` step in `tag-release.yml`
- The existing `vars.RELEASE_BOT_APP_ID` value works unchanged — no secret rotation needed
- Eliminates the `##[warning]Input 'app-id' has been deprecated` noise on every release run

Fixes #34

## Test plan

- [ ] Trigger a `tag-release` run and verify the "Mint release-bot token" step completes without the deprecation warning
- [ ] Confirm the minted token still has the expected permissions (release pipeline tags and publishes successfully)