### PR TITLE
feat: add tag-prefix to tag-release.yml and new publish-pypi.yml (v2.3)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,118 @@
+# Reusable Workflows
+
+This directory hosts reusable workflows under `j7an/shared-workflows`. Consumers reference them via `uses: j7an/shared-workflows/.github/workflows/<file>@v2`.
+
+## `tag-release.yml`
+
+Computes the next semver tag from Conventional Commits since the last tag, optionally bumps version files, and pushes the new tag (which typically triggers a downstream release workflow).
+
+### Inputs
+
+| Input | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `bump` | string | no | `auto` | Semver bump (`auto` / `patch` / `minor` / `major`). `auto` infers from Conventional Commits. |
+| `tag-prefix` | string | no | `"v"` | Tag prefix. Use `"v"` for `v1.2.3`, `"tools/v"` for `tools/v1.2.3`, etc. Allowed chars: `[A-Za-z0-9._/-]`. |
+
+### Secrets
+
+| Secret | Required | Purpose |
+|---|---|---|
+| `RELEASE_BOT_PRIVATE_KEY` | yes | GitHub App private key. App ID is read from `vars.RELEASE_BOT_APP_ID`. |
+
+### Monorepo example (two release streams)
+
+```yaml
+# .github/workflows/release-plugin.yml — plugin stream (v*.*.*)
+on:
+  workflow_dispatch:
+    inputs:
+      bump: { type: choice, options: [auto, patch, minor, major], default: auto }
+
+jobs:
+  tag:
+    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@v2
+    with:
+      bump: ${{ inputs.bump }}
+      # tag-prefix omitted → defaults to "v" → produces v1.2.3
+    secrets:
+      RELEASE_BOT_PRIVATE_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+```
+
+```yaml
+# .github/workflows/release-tools.yml — tools stream (tools/v*.*.*)
+on:
+  workflow_dispatch:
+    inputs:
+      bump: { type: choice, options: [auto, patch, minor, major], default: auto }
+
+jobs:
+  tag:
+    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@v2
+    with:
+      bump: ${{ inputs.bump }}
+      tag-prefix: "tools/v"   # produces tools/v0.1.0
+    secrets:
+      RELEASE_BOT_PRIVATE_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+```
+
+The two streams compute next-version independently — `tools/v` callers see only `tools/v*.*.*` tags when looking up the previous version, never `v*.*.*`.
+
+## `publish-pypi.yml`
+
+Builds a Python package with `uv build`, stages on TestPyPI with install verification, promotes to production PyPI via OIDC trusted publishing, and creates a GitHub Release.
+
+### Inputs
+
+| Input | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `tag` | string | yes | — | Semver tag to publish (e.g. `tools/v0.1.0`). |
+| `package-dir` | string | no | `.` | Directory containing `pyproject.toml` (relative to repo root). |
+| `testpypi-package` | string | yes | — | Distribution name on TestPyPI for install verification. |
+| `draft-release` | boolean | no | `false` | Create the GitHub release as a draft. |
+| `attach-assets` | boolean | no | `true` | Attach wheel + sdist to the GitHub release. |
+
+### Secrets
+
+None. OIDC handles publishing; `GITHUB_TOKEN` handles the release.
+
+### Pipeline
+
+1. **build** — `uv build` produces wheel + sdist; uploaded as `pypi-dist` artifact. Includes a tag-on-main guard.
+2. **publish-testpypi** (`environment: testpypi`) — publishes to TestPyPI; verifies install in a clean venv with exponential backoff (5 attempts at 30/60/90/120/150s).
+3. **publish-pypi** (`environment: pypi`) — publishes to production PyPI.
+4. **github-release** — creates a GitHub release with auto-generated notes; attaches artifacts; auto-detects prerelease from `-` in tag.
+
+### Caller example
+
+```yaml
+# .github/workflows/release-tools.yml — tag-driven publish
+on:
+  push:
+    tags:
+      - 'tools/v*.*.*'
+
+jobs:
+  publish:
+    uses: j7an/shared-workflows/.github/workflows/publish-pypi.yml@v2
+    with:
+      tag: ${{ github.ref_name }}
+      package-dir: tools
+      testpypi-package: epiphany-tools
+```
+
+### Per-package onboarding checklist
+
+For each new PyPI package that uses this workflow, complete **once**:
+
+- [ ] Claim the package name on [PyPI](https://pypi.org/) and [TestPyPI](https://test.pypi.org/).
+- [ ] On PyPI, configure trusted publisher: workflow `j7an/shared-workflows/.github/workflows/publish-pypi.yml`, ref `v2`, environment `pypi`.
+- [ ] On TestPyPI, configure the same trusted publisher with environment `testpypi`.
+- [ ] Confirm GitHub Environments `testpypi` and `pypi` exist in `j7an/shared-workflows` repo settings.
+
+### Recovery from a failed publish
+
+PyPI never lets you re-publish the same version, even after deletion. If a publish fails:
+
+- **TestPyPI fail, PyPI not yet attempted:** the workflow halts; recover by tagging a new prerelease (`tools/v0.1.0-rc2`) once the underlying issue is fixed.
+- **PyPI fail after TestPyPI success:** rare; usually a transient GitHub→PyPI handshake problem. Re-run the failed job from the Actions UI. If it persists, tag a new patch.
+- **GitHub release fail after PyPI success:** the package is live on PyPI; manually create the release with `gh release create` against the same tag, or re-run the `github-release` job (note: `gh release create` is not idempotent — if a release already exists for the tag, the re-run will fail with "release already exists" and you'll need to use `gh release edit` to update it).

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -164,3 +164,44 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
+
+  github-release:
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout at tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+
+      - name: Download dist artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pypi-dist
+          path: dist/
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+          DRAFT_RELEASE: ${{ inputs.draft-release }}
+          ATTACH_ASSETS: ${{ inputs.attach-assets }}
+        run: |
+          ARGS=( "$TAG" --generate-notes --title "$TAG" )
+          if [[ "$TAG" == *-* ]]; then
+            ARGS+=( --prerelease )
+          fi
+          if [[ "$DRAFT_RELEASE" == "true" ]]; then
+            ARGS+=( --draft )
+          fi
+          if [[ "$ATTACH_ASSETS" == "true" ]]; then
+            ARGS+=( dist/*.whl dist/*.tar.gz )
+          fi
+          echo "Creating release: gh release create ${ARGS[*]}"
+          gh release create "${ARGS[@]}"

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -82,3 +82,64 @@ jobs:
           path: ${{ inputs.package-dir }}/dist/
           if-no-files-found: error
           retention-days: 7
+
+  publish-testpypi:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: testpypi
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Download dist artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pypi-dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/
+
+      - name: Set up uv (for install verification venv)
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Verify install from TestPyPI
+        env:
+          TAG: ${{ inputs.tag }}
+          TESTPYPI_PACKAGE: ${{ inputs.testpypi-package }}
+        run: |
+          # Parse semver from the tail of TAG, prefix-agnostic.
+          # Matches: 1.2.3, 1.2.3-rc1, 1.2.3-alpha.1
+          VERSION=$(printf '%s' "$TAG" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$' || true)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not parse semver version from tag '$TAG'"
+            exit 1
+          fi
+          echo "Verifying TestPyPI install of ${TESTPYPI_PACKAGE}==${VERSION}"
+
+          SLEEPS="30 60 90 120 150"
+          ATTEMPT=0
+          for s in $SLEEPS; do
+            ATTEMPT=$((ATTEMPT + 1))
+            echo "Attempt ${ATTEMPT}/5: sleeping ${s}s before install..."
+            sleep "$s"
+            rm -rf .verify
+            uv venv .verify
+            # shellcheck disable=SC1091
+            . .verify/bin/activate
+            if uv pip install \
+                 --index-url https://test.pypi.org/simple/ \
+                 --extra-index-url https://pypi.org/simple/ \
+                 "${TESTPYPI_PACKAGE}==${VERSION}"; then
+              echo "TestPyPI install verified for ${TESTPYPI_PACKAGE}==${VERSION} on attempt ${ATTEMPT}"
+              exit 0
+            fi
+            echo "Attempt ${ATTEMPT} failed — will retry."
+          done
+          echo "::error::TestPyPI install verification failed after 5 attempts"
+          exit 1

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -28,9 +28,7 @@ on:
         description: "Attach wheel + sdist to the GitHub release"
 
 permissions:
-  contents: write       # create GitHub release, upload assets
-  id-token: write       # OIDC for trusted publishing
-  attestations: write   # supply-chain provenance
+  contents: read
 
 concurrency:
   group: publish-pypi-${{ inputs.tag }}
@@ -87,6 +85,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment: testpypi
+    permissions:
+      id-token: write       # OIDC for trusted publishing
+      attestations: write   # supply-chain provenance
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -148,6 +149,9 @@ jobs:
     needs: publish-testpypi
     runs-on: ubuntu-latest
     environment: pypi
+    permissions:
+      id-token: write
+      attestations: write
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -168,6 +172,8 @@ jobs:
   github-release:
     needs: publish-pypi
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # create GitHub release, upload assets
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -187,6 +187,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download dist artifact
+        if: inputs.attach-assets
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pypi-dist

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -101,7 +101,7 @@ jobs:
           path: dist/
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: dist/
@@ -165,7 +165,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: dist/
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -54,7 +54,7 @@ jobs:
           TAG: ${{ inputs.tag }}
         run: |
           TAG_SHA=$(git rev-list -n1 "$TAG")
-          git fetch origin main --depth=0 2>/dev/null || git fetch origin main
+          git fetch origin main
           if ! git merge-base --is-ancestor "$TAG_SHA" origin/main; then
             echo "::error::Tag ${TAG} (${TAG_SHA}) is not an ancestor of origin/main — refusing to publish"
             exit 1

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,43 @@
+name: Publish PyPI
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        type: string
+        required: true
+        description: "Semver tag to publish (e.g. 'tools/v0.1.0' or 'v1.2.3')"
+      package-dir:
+        type: string
+        required: false
+        default: "."
+        description: "Directory containing pyproject.toml (relative to repo root)"
+      testpypi-package:
+        type: string
+        required: true
+        description: "Distribution name on TestPyPI for install verification"
+      draft-release:
+        type: boolean
+        required: false
+        default: false
+        description: "Create the GitHub release as a draft"
+      attach-assets:
+        type: boolean
+        required: false
+        default: true
+        description: "Attach wheel + sdist to the GitHub release"
+
+permissions:
+  contents: write       # create GitHub release, upload assets
+  id-token: write       # OIDC for trusted publishing
+  attestations: write   # supply-chain provenance
+
+concurrency:
+  group: publish-pypi-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "scaffold — real jobs added in later tasks"

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -37,7 +37,48 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  noop:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "scaffold — real jobs added in later tasks"
+      - name: Harden runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout at tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+
+      - name: Verify tag is ancestor of main
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          TAG_SHA=$(git rev-list -n1 "$TAG")
+          git fetch origin main --depth=0 2>/dev/null || git fetch origin main
+          if ! git merge-base --is-ancestor "$TAG_SHA" origin/main; then
+            echo "::error::Tag ${TAG} (${TAG_SHA}) is not an ancestor of origin/main — refusing to publish"
+            exit 1
+          fi
+          echo "Tag ${TAG} (${TAG_SHA}) is an ancestor of main — proceeding."
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Build wheel + sdist
+        working-directory: ${{ inputs.package-dir }}
+        run: |
+          uv build
+          ls dist/*.whl >/dev/null
+          ls dist/*.tar.gz >/dev/null
+          echo "Built artifacts:"
+          ls -lh dist/
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pypi-dist
+          path: ${{ inputs.package-dir }}/dist/
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -143,3 +143,24 @@ jobs:
           done
           echo "::error::TestPyPI install verification failed after 5 attempts"
           exit 1
+
+  publish-pypi:
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Download dist artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pypi-dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -102,13 +102,23 @@ jobs:
         id: compute
         env:
           CHOICE: ${{ inputs.bump }}
+          TAG_PREFIX: ${{ inputs.tag-prefix }}
         run: |
+          PREFIX="${TAG_PREFIX:-v}"
+
+          # Reject prefixes containing characters that would break `git tag -l`
+          # globbing or shell expansion. Allow alnum, '/', '-', '_', '.'.
+          if ! printf '%s' "$PREFIX" | grep -qE '^[A-Za-z0-9._/-]+$'; then
+            echo "::error::Invalid tag-prefix '$PREFIX' (must match [A-Za-z0-9._/-]+)"
+            exit 1
+          fi
+
           # --- Find previous tag ---
-          LATEST=$(git tag -l 'v*.*.*' --sort=-version:refname | head -1)
+          LATEST=$(git tag -l "${PREFIX}*.*.*" --sort=-version:refname | head -1)
           if [ -z "$LATEST" ]; then
-            LATEST="v0.0.0"
+            LATEST="${PREFIX}0.0.0"
             FIRST_RELEASE="true"
-            echo "No existing semver tags — bootstrapping from v0.0.0"
+            echo "No existing semver tags — bootstrapping from ${LATEST}"
           else
             FIRST_RELEASE="false"
             echo "Latest tag: $LATEST"
@@ -172,7 +182,7 @@ jobs:
           fi
 
           # --- Compute next version ---
-          VERSION="${LATEST#v}"
+          VERSION="${LATEST#"${PREFIX}"}"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
 
           case "$CHOSEN" in
@@ -185,7 +195,7 @@ jobs:
               ;;
           esac
 
-          NEXT_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+          NEXT_TAG="${PREFIX}${MAJOR}.${MINOR}.${PATCH}"
           echo "Next tag: $NEXT_TAG"
           echo "next_tag=$NEXT_TAG" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -13,6 +13,11 @@ on:
           - patch
           - minor
           - major
+      tag-prefix:
+        description: "Tag prefix (e.g. 'v' for v1.2.3, 'tools/v' for tools/v1.2.3)"
+        type: string
+        required: false
+        default: "v"
   workflow_call:
     inputs:
       bump:
@@ -20,6 +25,11 @@ on:
         required: false
         default: auto
         description: "Semver bump (auto/patch/minor/major)"
+      tag-prefix:
+        type: string
+        required: false
+        default: "v"
+        description: "Tag prefix (e.g. 'v' for v1.2.3, 'tools/v' for tools/v1.2.3)"
     secrets:
       RELEASE_BOT_PRIVATE_KEY:
         required: true

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -219,6 +219,7 @@ jobs:
       - name: Bump version files
         env:
           NEXT_TAG: ${{ steps.compute.outputs.next_tag }}
+          TAG_PREFIX: ${{ inputs.tag-prefix }}
         run: |
           # --- Bump version files (opt-in via .version-bump.json) ---
           CONFIG=".version-bump.json"
@@ -232,7 +233,8 @@ jobs:
             exit 1
           fi
 
-          VERSION="${NEXT_TAG#v}"   # v0.2.0 -> 0.2.0
+          PREFIX="${TAG_PREFIX:-v}"
+          VERSION="${NEXT_TAG#"${PREFIX}"}"   # tools/v0.2.0 -> 0.2.0, v0.2.0 -> 0.2.0
           CHANGED=false
           SUMMARY=""
 


### PR DESCRIPTION
## Summary
- Add optional `tag-prefix` input to `tag-release.yml` (default `"v"`) so monorepos can compute next-version against non-`v` tag namespaces (e.g. `tools/v1.2.3`). Plumbed through both compute and bump steps, with charset validation `[A-Za-z0-9._/-]`.
- New reusable `publish-pypi.yml` workflow: `uv build` → TestPyPI publish + install verify (5 attempts, 30/60/90/120/150s backoff) → PyPI publish → GitHub Release. OIDC trusted publishing throughout, no API tokens. Per-job least-privilege permissions.
- Document both in `.github/workflows/README.md` including the per-package PyPI trusted-publisher onboarding checklist and recovery guidance.

Both changes are purely additive. The floating `v2` alias will advance after merge — existing `@v2` consumers pick up both capabilities transparently on their next workflow run. See spec for the strict-semver rationale (additive change → minor bump, not major).

## Test plan
- [ ] `actionlint` clean on both workflow files (verified locally)
- [ ] Create GitHub Environments `testpypi` (no protection) and `pypi` (required reviewer) in this repo's settings
- [ ] In `j7an/epiphany`, pin `release-tools.yml` to this branch's SHA, claim `epiphany-tools` on PyPI/TestPyPI, configure trusted publishers for both indexes pointing at this workflow
- [ ] Publish `tools/v0.1.0-rc1` end-to-end via `epiphany`: build → TestPyPI → install-verify → PyPI → GitHub Release with assets attached
- [ ] Verify `tag-prefix: "v"` (default) caller behavior is byte-for-byte identical to v2.2 by computing the next plugin tag and confirming the result matches expectation
- [ ] On green: merge, manually run `tag-release.yml` with `bump: minor` to produce `v2.3.0`, then advance the `v2` floating alias

Fixes #40