### PR TITLE
feat(cooldown): add cooldown-rescan scheduled rescan workflow

### DIFF
--- a/.github/workflows/cooldown-rescan.yml
+++ b/.github/workflows/cooldown-rescan.yml
@@ -1,0 +1,146 @@
+name: Dependency Cooldown Rescan
+
+on:
+  workflow_call:
+    inputs:
+      dry_run:
+        type: boolean
+        default: false
+        description: "When true, log decisions to the step summary but do not call `gh run rerun`. Use for initial-rollout validation and incident diagnostics."
+
+concurrency:
+  group: cooldown-rescan-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  rescan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: write
+      statuses: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Rerun pending cooldown scans
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -uo pipefail
+
+          # Sweep open Dependabot PRs and rerun any whose `dependency-cooldown / gate`
+          # commit status is `pending`. Per-PR work uses `set +e` so one PR's failure
+          # never aborts the sweep.
+
+          {
+            echo "## Cooldown Rescan Sweep"
+            echo ""
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "_Dry-run mode: no \`gh run rerun\` calls will be made._"
+              echo ""
+            fi
+            echo "| PR | Head SHA | Gate | Action | Result |"
+            echo "|----|----------|------|--------|--------|"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # 1) List open Dependabot PRs (loud failure on outer error).
+          if ! PRS_JSON=$(gh pr list \
+              --repo "$GH_REPO" \
+              --author app/dependabot \
+              --state open \
+              --json number,headRefName,headRefOid 2>&1); then
+            echo "FATAL: gh pr list failed: $PRS_JSON" >&2
+            exit 1
+          fi
+
+          PR_COUNT=$(echo "$PRS_JSON" | jq 'length')
+          if [ "$PR_COUNT" -eq 0 ]; then
+            echo "| — | — | — | no-prs | no Dependabot PRs to sweep |" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # 2) Per-PR loop. Pipe-to-while runs in a subshell, which is fine
+          # since we don't need to carry state out of the loop.
+          echo "$PRS_JSON" | jq -c '.[]' | while read -r PR; do
+            PR_NUM=$(echo "$PR" | jq -r '.number')
+            HEAD_REF=$(echo "$PR" | jq -r '.headRefName')
+            HEAD_SHA=$(echo "$PR" | jq -r '.headRefOid')
+            HEAD_SHA_SHORT="${HEAD_SHA:0:7}"
+
+            set +e
+
+            # 2a) Combined commit status — find the cooldown gate context.
+            STATUS_JSON=$(gh api "repos/${GH_REPO}/commits/${HEAD_SHA}/status" 2>&1)
+            if [ $? -ne 0 ]; then
+              echo "| #${PR_NUM} | ${HEAD_SHA_SHORT} | — | skip | status-fetch-failed |" >> "$GITHUB_STEP_SUMMARY"
+              set -e
+              continue
+            fi
+
+            GATE=$(echo "$STATUS_JSON" | jq -r \
+              '.statuses[] | select(.context == "dependency-cooldown / gate") | .state' \
+              | head -1)
+
+            if [ -z "$GATE" ]; then
+              echo "| #${PR_NUM} | ${HEAD_SHA_SHORT} | — | skip | no-gate-status |" >> "$GITHUB_STEP_SUMMARY"
+              set -e
+              continue
+            fi
+
+            if [ "$GATE" != "pending" ]; then
+              echo "| #${PR_NUM} | ${HEAD_SHA_SHORT} | ${GATE} | skip | gate-not-pending |" >> "$GITHUB_STEP_SUMMARY"
+              set -e
+              continue
+            fi
+
+            # 2b) Find the most recent dependency-cooldown.yml run for this branch.
+            RUN_JSON=$(gh run list \
+              --repo "$GH_REPO" \
+              --workflow=.github/workflows/dependency-cooldown.yml \
+              --branch="$HEAD_REF" \
+              --limit 1 \
+              --json databaseId,status,conclusion 2>&1)
+            if [ $? -ne 0 ]; then
+              echo "| #${PR_NUM} | ${HEAD_SHA_SHORT} | pending | skip | run-list-failed |" >> "$GITHUB_STEP_SUMMARY"
+              set -e
+              continue
+            fi
+
+            RUN_ID=$(echo "$RUN_JSON" | jq -r '.[0].databaseId // empty')
+            RUN_STATUS=$(echo "$RUN_JSON" | jq -r '.[0].status // empty')
+
+            if [ -z "$RUN_ID" ]; then
+              echo "| #${PR_NUM} | ${HEAD_SHA_SHORT} | pending | skip | no-prior-run |" >> "$GITHUB_STEP_SUMMARY"
+              set -e
+              continue
+            fi
+
+            if [ "$RUN_STATUS" != "completed" ]; then
+              echo "| #${PR_NUM} | ${HEAD_SHA_SHORT} | pending | skip | run-in-progress |" >> "$GITHUB_STEP_SUMMARY"
+              set -e
+              continue
+            fi
+
+            # 2c) Rerun (or echo in dry-run).
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "| #${PR_NUM} | ${HEAD_SHA_SHORT} | pending | dry-run | would-rerun-${RUN_ID} |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              RERUN_OUT=$(gh run rerun "$RUN_ID" --repo "$GH_REPO" 2>&1)
+              if [ $? -eq 0 ]; then
+                echo "| #${PR_NUM} | ${HEAD_SHA_SHORT} | pending | rerun | run-${RUN_ID}-rerun |" >> "$GITHUB_STEP_SUMMARY"
+              else
+                echo "| #${PR_NUM} | ${HEAD_SHA_SHORT} | pending | rerun | rerun-failed |" >> "$GITHUB_STEP_SUMMARY"
+                echo "rerun failure detail for PR #${PR_NUM}: ${RERUN_OUT}" >&2
+              fi
+            fi
+
+            set -e
+          done
+
+          exit 0

--- a/README.md
+++ b/README.md
@@ -178,18 +178,57 @@ The workflow manages two labels on Dependabot PRs. **Both are reconciled on ever
 
 The reconciliation is authoritative — a PR that was dirty at first scan and clean after rebase will have neither label at merge time.
 
-## Recommended: scheduled re-scan for long-pending PRs
+## Scheduled re-scan for long-pending PRs (v2.4.0+)
 
-If a PR sits in `cooldown-pending` for multiple days, it will unblock automatically on the next push or `@dependabot rebase`. Consumers wanting time-based automatic re-scan (without waiting for a push) can add a `schedule:` trigger to their caller workflow:
+A Dependabot PR that opens *during* its dependency's cooldown window scans once and then sits in the `pending` gate state until either Dependabot rebases or a human prods `@dependabot recreate`. To rescan automatically on a schedule, consumers can add a thin caller workflow that invokes `cooldown-rescan.yml`:
 
 ```yaml
+# .github/workflows/dependency-cooldown-rescan.yml
+name: Dependency Cooldown Rescan
+
 on:
-  pull_request:
   schedule:
-    - cron: '0 */6 * * *'   # every 6 hours
+    - cron: "0 6 * * *"   # daily at 06:00 UTC; tune per consumer
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+  actions: write
+  statuses: read
+
+jobs:
+  rescan:
+    uses: j7an/shared-workflows/.github/workflows/cooldown-rescan.yml@v2
 ```
 
-This is intentionally not shipped in the reusable workflow itself — cadence preferences vary per consumer. A 6-hour cadence handles a 7-day cooldown comfortably; tune as needed.
+How it works: on each invocation, the rescan workflow lists open Dependabot PRs in the caller repo, finds those whose `dependency-cooldown / gate` commit status is `pending`, and reruns the most recent `dependency-cooldown.yml` workflow run for each via `gh run rerun`. The replayed run uses the original `pull_request` payload (so the head SHA is stable) but with the current runtime clock — release-age gates re-evaluate freshly.
+
+The workflow only triggers PRs with a `pending` gate. PRs in `success` or `failure` are left alone.
+
+### Cadence
+
+Cadence is owned by the caller. Sweep at least once per cooldown-window step (e.g., a 7-day cooldown is comfortably handled by a daily sweep; a 1-day cooldown wants every-few-hours). GitHub may delay scheduled runs by up to ~30 minutes under load, so use `workflow_dispatch:` as the manual escape hatch.
+
+### Dry-run rollout
+
+For initial validation, pass `dry_run: true` so the sweep logs decisions without calling `gh run rerun`:
+
+```yaml
+jobs:
+  rescan:
+    uses: j7an/shared-workflows/.github/workflows/cooldown-rescan.yml@v2
+    with:
+      dry_run: true
+```
+
+Trigger via `workflow_dispatch`, inspect the `$GITHUB_STEP_SUMMARY` table, then remove the `with:` block once the filter logic looks right.
+
+### Inputs
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `dry_run` | boolean | `false` | When `true`, log decisions to `$GITHUB_STEP_SUMMARY` but do not call `gh run rerun`. Use for initial-rollout validation and incident diagnostics. |
 
 ## Security Analysis (Zizmor)
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/cooldown-rescan.yml` — a `workflow_call`-only reusable workflow that sweeps open Dependabot PRs and reruns the most recent `dependency-cooldown.yml` run for any PR whose gate is still `pending`.
- Updates `README.md` to replace the broken "Recommended: scheduled re-scan" section (which advised `schedule:` on a `pull_request:` workflow — silently broken because schedule events have no PR context) with a generic caller pattern.
- Single optional input `dry_run: boolean = false` for safe rollout and incident diagnostics. Per-PR isolation via `set +e`; outer `gh pr list` failure is loud.

## Why

The existing `dependency-cooldown.yml` only fires on `pull_request: [opened, synchronize, reopened]`. A Dependabot PR that opens *during* its dependency's cooldown window scans once, posts a `pending` gate, and then never re-evaluates without manual `@dependabot recreate` or rebase. Real incident: `j7an/nexus-mcp#163` — scan ran on 2026-04-14 with `Earliest unblock: 2026-04-14`; on 2026-04-17 the gate was still pending despite cooldown having expired the day of scan.

`gh run rerun` is the only mechanism that re-evaluates cooldown without duplicating scan logic: it replays the original `pull_request` payload (head SHA stable) with current runtime clock (age-gates re-evaluate).

## Release shape

Both commits use `feat(cooldown):` so `tag-release.yml` minor-bumps to `v2.4.0`.

## Reviewer notes (from local two-stage review)

Both spec and code-quality reviews passed locally. Two `APPROVED WITH NITS` items worth weighing here, neither blocking:

- **`actions: write` permission scope** (flagged by both reviewers): the README example doesn't acknowledge that `actions: write` grants caller-repo-wide rerun capability — broader than `gh run rerun` strictly needs, but no narrower GitHub permission exists. Consider a 1-2 line note.
- **Workflow `set -e` inside the per-PR loop** (workflow reviewer): the script opens with `set -uo pipefail` (no `-e`); the inner `set -e`/`set +e` pairs technically activate strict mode for ~5 lines of jq extraction at the top of the next iteration. Practical risk near zero (jq input is already validated), but the comment "Per-PR work uses `set +e`" doesn't fully match the actual semantics. Easy follow-up: replace inner `set -e` with no-ops.

## Test plan

- [x] `yq '.' .github/workflows/cooldown-rescan.yml` parses successfully (verified locally)
- [x] `./scripts/lint-workflow-call.sh` exits 0 (verified locally; CI re-runs)
- [x] `zizmor --min-severity medium --min-confidence medium` produces no findings (verified locally; CI re-runs)
- [ ] PR description renders the new README section correctly (preview tab)
- [ ] Post-merge: `tag-release.yml` cuts `v2.4.0`; `release.yml` publishes the GitHub release; floating `@v2` updates
- [ ] Acceptance: `nexus-mcp` ships its caller (separate PR, separate repo), runs once with `dry_run: true`, then enables for real and confirms PR #163 unblocks

Fixes #42.