### PR TITLE
feat(tag-release): support nested field paths in .version-bump.json

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -57,6 +57,75 @@ jobs:
 
 The two streams compute next-version independently — `tools/v` callers see only `tools/v*.*.*` tags when looking up the previous version, never `v*.*.*`.
 
+### Version file bumping (`.version-bump.json`)
+
+Optional. If a file named `.version-bump.json` exists at the repo root, the workflow updates the listed JSON files with the new version *before* creating the tag. The bumped files are committed and pushed to `main` as a separate `chore(release): bump version files to <version>` commit. The new tag points at that commit.
+
+If `.version-bump.json` is absent, the bumper step is a no-op.
+
+#### Schema
+
+```json
+{
+  "files": [
+    { "path": "<relative-path>", "field": "<top-level-key>" },
+    { "path": "<relative-path>", "path_expr": "<jq-path>" }
+  ]
+}
+```
+
+Each entry must contain exactly one of `field` or `path_expr` (mutually exclusive).
+
+| Key | Purpose |
+|---|---|
+| `path` | Path relative to repo root. Must end in `.json`. Absolute paths and `..` traversal rejected. |
+| `field` | Top-level key to update. Shorthand for `path_expr: ".<field>"`. Any string value safe (passed to jq as a literal). |
+| `path_expr` | jq-style path expression. Validated against an identifier+integer-index allowlist before use. |
+
+#### Examples
+
+**Top-level field (legacy form):**
+
+```json
+{ "files": [ { "path": "package.json", "field": "version" } ] }
+```
+
+**Nested path — same file, multiple locations:**
+
+```json
+{
+  "files": [
+    { "path": "server.json", "path_expr": ".version" },
+    { "path": "server.json", "path_expr": ".packages[0].version" }
+  ]
+}
+```
+
+#### Allowed `path_expr` syntax
+
+- `.identifier` — top-level key (`.version`, `._private`)
+- `.identifier.identifier` — nested key (`.metadata.semver`)
+- `.identifier[N]` — non-negative integer index (`.packages[0]`)
+- Combinations (`.packages[0].version`, `.foo.bar[2].baz`)
+
+The first segment must be `.identifier`. Identifiers follow `[A-Za-z_][A-Za-z0-9_]*`.
+
+#### Rejected syntax (security boundary)
+
+The validator rejects pipes (`|`), wildcards (`[*]`), slices (`[2:5]`), negative indices (`[-1]`), recursive descent (`..`), variable references (`$ENV`), format strings (`@sh`), parens, arithmetic, and quoted-string keys (`."weird-key"`, `["weird-key"]`). Path expressions originate from repo-committed config but are still validated as a defense-in-depth measure.
+
+For files whose schemas require quoted-string keys (e.g. `package.json` `.dependencies."@scope/pkg".version`), file an issue — quoted-string support is a documented future extension.
+
+#### Step summary
+
+The workflow run summary includes a per-entry table:
+
+| File | Path | Version | Status |
+|---|---|---|---|
+| `server.json` | `.version` | `0.8.1` -> `0.10.0` | updated |
+| `server.json` | `.packages[0].version` | `0.8.1` -> `0.10.0` | updated |
+| `package.json` | `.version` | `0.10.0` | already up to date |
+
 ## `publish-pypi.yml`
 
 Builds a Python package with `uv build`, stages on TestPyPI with install verification, promotes to production PyPI via OIDC trusted publishing, and creates a GitHub Release.

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -221,86 +221,214 @@ jobs:
           NEXT_TAG: ${{ steps.compute.outputs.next_tag }}
           TAG_PREFIX: ${{ inputs.tag-prefix }}
         run: |
-          # --- Bump version files (opt-in via .version-bump.json) ---
-          CONFIG=".version-bump.json"
-          if [ ! -f "$CONFIG" ]; then
-            echo "No .version-bump.json found, skipping version file bump"
-            exit 0
+          PREFIX="${TAG_PREFIX:-v}"
+          VERSION="${NEXT_TAG#"${PREFIX}"}"
+
+          # --- BEGIN inline:scripts/bump-version-files.sh ---
+          bump_version_files() (
+          # bump-version-files.sh — apply version bumps from .version-bump.json
+          #
+          # Reads .version-bump.json and writes the supplied version into each
+          # entry's target. Supports two per-entry forms (mutually exclusive):
+          #
+          #   { "path": "X.json", "field": "version" }                 — legacy
+          #   { "path": "X.json", "path_expr": ".pkg[0].version" }     — new
+          #
+          # Usage:
+          #   ./scripts/bump-version-files.sh <config-path> <version>
+          #   VERSION=1.2.3 ./scripts/bump-version-files.sh .version-bump.json
+          #
+          # Exit codes:
+          #   0 — at least one entry was modified (caller should commit)
+          #   1 — config error: malformed JSON, missing files array, schema
+          #       violation. Caller MUST fail the workflow.
+          #   2 — config valid but nothing modified: no config file, or all
+          #       entries already up to date, or all entries skipped. Caller
+          #       should NOT commit, but workflow continues.
+
+          set -euo pipefail
+
+          # Strict allowlist: identifiers + integer indices.
+          # Bracket-quoted string keys (e.g. .["kebab-case"]) and wildcards [*] are
+          # reserved for future minor releases — see follow-up issues filed at
+          # PR-merge time.
+          PATH_EXPR_RE='^\.[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*|\[[0-9]+\])*$'
+
+          validate_path_expr() {
+            local expr="$1"
+            printf '%s' "$expr" | grep -qE "$PATH_EXPR_RE"
+          }
+
+          display_path() {
+            local field="$1" path_expr="$2"
+            if [ -n "$path_expr" ]; then
+              printf '%s' "$path_expr"
+            else
+              printf '.%s' "$field"
+            fi
+          }
+
+          read_current() {
+            local file="$1" field="$2" path_expr="$3"
+            if [ -n "$path_expr" ]; then
+              jq -r "$path_expr" "$file"
+            else
+              jq -r --arg f "$field" '.[$f]' "$file"
+            fi
+          }
+
+          write_value() {
+            local file="$1" field="$2" path_expr="$3" version="$4" tmpfile
+            tmpfile=$(mktemp)
+            if [ -n "$path_expr" ]; then
+              jq --indent 2 --arg v "$version" "$path_expr = \$v" "$file" > "$tmpfile"
+            else
+              jq --indent 2 --arg f "$field" --arg v "$version" '.[$f] = $v' "$file" > "$tmpfile"
+            fi
+            mv "$tmpfile" "$file"
+          }
+
+          # bump_entry — process one .files[] entry
+          # Returns 0 if file was modified, 1 if skipped (any reason).
+          bump_entry() {
+            local file_path="$1" field="$2" path_expr="$3" version="$4"
+            local disp; disp=$(display_path "$field" "$path_expr")
+
+            if [ -n "$path_expr" ] && ! validate_path_expr "$path_expr"; then
+              printf '::error file=.version-bump.json::Entry for %q has invalid path_expr %q\n' \
+                "$file_path" "$path_expr" >&2
+              printf '| `%s` | `%s` | - | skipped (invalid path_expr) |\n' "$file_path" "$disp"
+              return 1
+            fi
+
+            case "$file_path" in
+              /*|*..*)
+                printf '::warning::%s contains path traversal or is absolute\n' "$file_path" >&2
+                printf '| `%s` | `%s` | - | skipped (unsafe path) |\n' "$file_path" "$disp"
+                return 1 ;;
+            esac
+            if [ ! -f "$file_path" ]; then
+              printf '::warning::%s not found\n' "$file_path" >&2
+              printf '| `%s` | `%s` | - | skipped (file not found) |\n' "$file_path" "$disp"
+              return 1
+            fi
+            case "$file_path" in
+              *.json) ;;
+              *)
+                printf '::warning::%s is not a JSON file\n' "$file_path" >&2
+                printf '| `%s` | `%s` | - | skipped (not JSON) |\n' "$file_path" "$disp"
+                return 1 ;;
+            esac
+            if ! jq -e . "$file_path" >/dev/null 2>&1; then
+              printf '::warning::%s is not valid JSON\n' "$file_path" >&2
+              printf '| `%s` | `%s` | - | skipped (invalid JSON) |\n' "$file_path" "$disp"
+              return 1
+            fi
+
+            local current; current=$(read_current "$file_path" "$field" "$path_expr")
+            if [ "$current" = "$version" ]; then
+              printf '| `%s` | `%s` | `%s` | already up to date |\n' "$file_path" "$disp" "$current"
+              return 1
+            fi
+
+            write_value "$file_path" "$field" "$path_expr" "$version"
+            printf '| `%s` | `%s` | `%s` -> `%s` | updated |\n' \
+              "$file_path" "$disp" "$current" "$version"
+            return 0
+          }
+
+          # --- Main procedural body ---
+
+          config="${1:-.version-bump.json}"
+          version="${2:-${VERSION:-}}"
+          : "${version:?usage: $0 <config> <version> | VERSION=X $0 [config]}"
+
+          if [ ! -f "$config" ]; then
+            echo "No $config found, skipping version file bump"
+            exit 2
           fi
 
-          if ! jq -e '.files | type == "array" and length > 0' "$CONFIG" > /dev/null 2>&1; then
-            echo "::error::.version-bump.json is missing or has an invalid 'files' array"
+          if ! jq -e '.files | type == "array" and length > 0' "$config" >/dev/null 2>&1; then
+            echo "::error::$config is missing or has an invalid 'files' array" >&2
             exit 1
           fi
 
-          PREFIX="${TAG_PREFIX:-v}"
-          VERSION="${NEXT_TAG#"${PREFIX}"}"   # tools/v0.2.0 -> 0.2.0, v0.2.0 -> 0.2.0
-          CHANGED=false
-          SUMMARY=""
-
+          # Schema validation pass — hard fail before touching any file
           while IFS= read -r row; do
-            FILE_PATH=$(echo "$row" | jq -r '.path')
-            FIELD=$(echo "$row" | jq -r '.field')
+            file_path=$(jq -r '.path // ""' <<<"$row")
+            field=$(jq -r '.field // ""' <<<"$row")
+            path_expr=$(jq -r '.path_expr // ""' <<<"$row")
 
-            # Reject absolute paths and directory traversal
-            case "$FILE_PATH" in
-              /* | *..*)
-                echo "::warning::$FILE_PATH contains path traversal or is absolute, skipping"
-                SUMMARY="${SUMMARY}\n| \`$FILE_PATH\` | - | skipped (unsafe path) |"
-                continue
-                ;;
-            esac
-
-            if [ ! -f "$FILE_PATH" ]; then
-              echo "::warning::$FILE_PATH not found, skipping"
-              SUMMARY="${SUMMARY}\n| \`$FILE_PATH\` | - | skipped (file not found) |"
-              continue
+            if [ -z "$file_path" ]; then
+              echo "::error::$config has an entry missing 'path'" >&2
+              exit 1
             fi
-
-            case "$FILE_PATH" in
-              *.json) ;;
-              *)
-                echo "::warning::$FILE_PATH is not a JSON file, skipping (only JSON supported)"
-                SUMMARY="${SUMMARY}\n| \`$FILE_PATH\` | - | skipped (not JSON) |"
-                continue
-                ;;
-            esac
-
-            CURRENT=$(jq -r --arg f "$FIELD" '.[$f]' "$FILE_PATH")
-            if [ "$CURRENT" = "$VERSION" ]; then
-              echo "$FILE_PATH already at $VERSION, skipping"
-              SUMMARY="${SUMMARY}\n| \`$FILE_PATH\` | \`$CURRENT\` | already up to date |"
-              continue
+            if [ -n "$field" ] && [ -n "$path_expr" ]; then
+              echo "::error::$config entry for '$file_path' has both 'field' and 'path_expr' (mutually exclusive)" >&2
+              exit 1
             fi
+            if [ -z "$field" ] && [ -z "$path_expr" ]; then
+              echo "::error::$config entry for '$file_path' has neither 'field' nor 'path_expr'" >&2
+              exit 1
+            fi
+          done < <(jq -c '.files[]' "$config")
 
-            TMPFILE=$(mktemp)
-            jq --indent 2 --arg f "$FIELD" --arg v "$VERSION" '.[$f] = $v' "$FILE_PATH" > "$TMPFILE" && mv "$TMPFILE" "$FILE_PATH"
-            git add "$FILE_PATH"
-            echo "Updated $FILE_PATH: $CURRENT -> $VERSION"
-            SUMMARY="${SUMMARY}\n| \`$FILE_PATH\` | \`$CURRENT\` -> \`$VERSION\` | updated |"
-            CHANGED=true
+          # Apply pass — per-entry, accumulates summary
+          changed=0
+          while IFS= read -r row; do
+            file_path=$(jq -r '.path // ""' <<<"$row")
+            field=$(jq -r '.field // ""' <<<"$row")
+            path_expr=$(jq -r '.path_expr // ""' <<<"$row")
+            if bump_entry "$file_path" "$field" "$path_expr" "$version"; then
+              changed=1
+            fi
+          done < <(jq -c '.files[]' "$config")
 
-          done < <(jq -c '.files[]' "$CONFIG")
-
-          if [ "$CHANGED" = true ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git commit -m "chore(release): bump version files to $VERSION"
-            git push origin HEAD:main
-            RESULT="Committed and pushed version file updates"
+          if [ "$changed" -eq 1 ]; then
+            exit 0
           else
-            RESULT="All version files already up to date — no commit needed"
+            exit 2
           fi
+          )
+          # --- END inline:scripts/bump-version-files.sh ---
 
-          # --- Step summary ---
+          set +e
+          bump_version_files .version-bump.json "$VERSION" > /tmp/bump.summary
+          BUMP_EXIT=$?
+          set -e
+
+          case "$BUMP_EXIT" in
+            0)
+              git config user.name "github-actions[bot]"
+              git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+              for entry in $(jq -r '.files[] | .path' .version-bump.json); do
+                git add "$entry"
+              done
+              git commit -m "chore(release): bump version files to $VERSION"
+              git push origin HEAD:main
+              RESULT="Committed and pushed version file updates"
+              ;;
+            1)
+              echo "::error::Bump version files step failed due to .version-bump.json error"
+              exit 1
+              ;;
+            2)
+              RESULT="No changes — config absent, all up to date, or all entries skipped"
+              ;;
+            *)
+              echo "::error::bump-version-files.sh exited with unexpected code $BUMP_EXIT"
+              exit 1
+              ;;
+          esac
+
           {
             echo "### Version file bump"
             echo ""
             echo "**Target version:** \`$VERSION\`"
             echo ""
-            echo "| File | Version | Status |"
-            echo "|------|---------|--------|"
-            printf '%b\n' "$SUMMARY"
+            echo "| File | Path | Version | Status |"
+            echo "|------|------|---------|--------|"
+            cat /tmp/bump.summary
             echo ""
             echo "$RESULT"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -416,6 +416,10 @@ jobs:
       tag: ${{ needs.tag.outputs.tag }}
 ```
 
+### Auto-bumping version files at release time
+
+If your repo has version strings in committed JSON files (e.g. `server.json`, `package.json`), `tag-release.yml` can rewrite them as part of the release commit. Add a `.version-bump.json` at repo root listing the files and locations to update. See [`.github/workflows/README.md` › Version file bumping](.github/workflows/README.md#version-file-bumping-version-bumpjson) for the schema, examples, and security model.
+
 ### Required downstream setup
 
 1. **Create a `release` GitHub Environment**, restricted to the `main` branch via deployment branch policy (Settings → Environments → New environment → Deployment branches → Selected branches → `main`).

--- a/scripts/bump-version-files.sh
+++ b/scripts/bump-version-files.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# bump-version-files.sh — apply version bumps from .version-bump.json
+#
+# Reads .version-bump.json and writes the supplied version into each
+# entry's target. Supports two per-entry forms (mutually exclusive):
+#
+#   { "path": "X.json", "field": "version" }                 — legacy
+#   { "path": "X.json", "path_expr": ".pkg[0].version" }     — new
+#
+# Usage:
+#   ./scripts/bump-version-files.sh <config-path> <version>
+#   VERSION=1.2.3 ./scripts/bump-version-files.sh .version-bump.json
+#
+# Exit codes:
+#   0 — at least one entry was modified (caller should commit)
+#   1 — config error: malformed JSON, missing files array, schema
+#       violation. Caller MUST fail the workflow.
+#   2 — config valid but nothing modified: no config file, or all
+#       entries already up to date, or all entries skipped. Caller
+#       should NOT commit, but workflow continues.
+
+set -euo pipefail
+
+# Strict allowlist: identifiers + integer indices.
+# Bracket-quoted string keys (e.g. .["kebab-case"]) and wildcards [*] are
+# reserved for future minor releases — see follow-up issues filed at
+# PR-merge time.
+PATH_EXPR_RE='^\.[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*|\[[0-9]+\])*$'
+
+validate_path_expr() {
+  local expr="$1"
+  printf '%s' "$expr" | grep -qE "$PATH_EXPR_RE"
+}
+
+display_path() {
+  local field="$1" path_expr="$2"
+  if [ -n "$path_expr" ]; then
+    printf '%s' "$path_expr"
+  else
+    printf '.%s' "$field"
+  fi
+}
+
+read_current() {
+  local file="$1" field="$2" path_expr="$3"
+  if [ -n "$path_expr" ]; then
+    jq -r "$path_expr" "$file"
+  else
+    jq -r --arg f "$field" '.[$f]' "$file"
+  fi
+}
+
+write_value() {
+  local file="$1" field="$2" path_expr="$3" version="$4" tmpfile
+  tmpfile=$(mktemp)
+  if [ -n "$path_expr" ]; then
+    jq --indent 2 --arg v "$version" "$path_expr = \$v" "$file" > "$tmpfile"
+  else
+    jq --indent 2 --arg f "$field" --arg v "$version" '.[$f] = $v' "$file" > "$tmpfile"
+  fi
+  mv "$tmpfile" "$file"
+}
+
+# bump_entry — process one .files[] entry
+# Returns 0 if file was modified, 1 if skipped (any reason).
+bump_entry() {
+  local file_path="$1" field="$2" path_expr="$3" version="$4"
+  local disp; disp=$(display_path "$field" "$path_expr")
+
+  if [ -n "$path_expr" ] && ! validate_path_expr "$path_expr"; then
+    printf '::error file=.version-bump.json::Entry for %q has invalid path_expr %q\n' \
+      "$file_path" "$path_expr" >&2
+    printf '| `%s` | `%s` | - | skipped (invalid path_expr) |\n' "$file_path" "$disp"
+    return 1
+  fi
+
+  case "$file_path" in
+    /*|*..*)
+      printf '::warning::%s contains path traversal or is absolute\n' "$file_path" >&2
+      printf '| `%s` | `%s` | - | skipped (unsafe path) |\n' "$file_path" "$disp"
+      return 1 ;;
+  esac
+  if [ ! -f "$file_path" ]; then
+    printf '::warning::%s not found\n' "$file_path" >&2
+    printf '| `%s` | `%s` | - | skipped (file not found) |\n' "$file_path" "$disp"
+    return 1
+  fi
+  case "$file_path" in
+    *.json) ;;
+    *)
+      printf '::warning::%s is not a JSON file\n' "$file_path" >&2
+      printf '| `%s` | `%s` | - | skipped (not JSON) |\n' "$file_path" "$disp"
+      return 1 ;;
+  esac
+  if ! jq -e . "$file_path" >/dev/null 2>&1; then
+    printf '::warning::%s is not valid JSON\n' "$file_path" >&2
+    printf '| `%s` | `%s` | - | skipped (invalid JSON) |\n' "$file_path" "$disp"
+    return 1
+  fi
+
+  local current; current=$(read_current "$file_path" "$field" "$path_expr")
+  if [ "$current" = "$version" ]; then
+    printf '| `%s` | `%s` | `%s` | already up to date |\n' "$file_path" "$disp" "$current"
+    return 1
+  fi
+
+  write_value "$file_path" "$field" "$path_expr" "$version"
+  printf '| `%s` | `%s` | `%s` -> `%s` | updated |\n' \
+    "$file_path" "$disp" "$current" "$version"
+  return 0
+}
+
+# --- Main procedural body ---
+
+config="${1:-.version-bump.json}"
+version="${2:-${VERSION:-}}"
+: "${version:?usage: $0 <config> <version> | VERSION=X $0 [config]}"
+
+if [ ! -f "$config" ]; then
+  echo "No $config found, skipping version file bump"
+  exit 2
+fi
+
+if ! jq -e '.files | type == "array" and length > 0' "$config" >/dev/null 2>&1; then
+  echo "::error::$config is missing or has an invalid 'files' array" >&2
+  exit 1
+fi
+
+# Schema validation pass — hard fail before touching any file
+while IFS= read -r row; do
+  file_path=$(jq -r '.path // ""' <<<"$row")
+  field=$(jq -r '.field // ""' <<<"$row")
+  path_expr=$(jq -r '.path_expr // ""' <<<"$row")
+
+  if [ -z "$file_path" ]; then
+    echo "::error::$config has an entry missing 'path'" >&2
+    exit 1
+  fi
+  if [ -n "$field" ] && [ -n "$path_expr" ]; then
+    echo "::error::$config entry for '$file_path' has both 'field' and 'path_expr' (mutually exclusive)" >&2
+    exit 1
+  fi
+  if [ -z "$field" ] && [ -z "$path_expr" ]; then
+    echo "::error::$config entry for '$file_path' has neither 'field' nor 'path_expr'" >&2
+    exit 1
+  fi
+done < <(jq -c '.files[]' "$config")
+
+# Apply pass — per-entry, accumulates summary
+changed=0
+while IFS= read -r row; do
+  file_path=$(jq -r '.path // ""' <<<"$row")
+  field=$(jq -r '.field // ""' <<<"$row")
+  path_expr=$(jq -r '.path_expr // ""' <<<"$row")
+  if bump_entry "$file_path" "$field" "$path_expr" "$version"; then
+    changed=1
+  fi
+done < <(jq -c '.files[]' "$config")
+
+if [ "$changed" -eq 1 ]; then
+  exit 0
+else
+  exit 2
+fi

--- a/scripts/check-inline-sync.sh
+++ b/scripts/check-inline-sync.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# check-inline-sync.sh — verify inline bash in dependency-cooldown.yml
-# matches scripts/*.sh byte-for-byte after the known normalization rules
+# check-inline-sync.sh — verify inline bash in workflow YAMLs matches
+# scripts/*.sh byte-for-byte after the known normalization rules
 # (YAML indent strip, function wrapper strip, shebang strip).
 #
 # Usage: ./scripts/check-inline-sync.sh
@@ -9,17 +9,18 @@
 
 set -euo pipefail
 
-WORKFLOW=".github/workflows/dependency-cooldown.yml"
-SCRIPTS=(
-  "scripts/extract-deps.sh"
-  "scripts/check-release-age.sh"
+# Each entry: "<workflow-yaml>:<script-path>"
+INLINE_PAIRS=(
+  ".github/workflows/dependency-cooldown.yml:scripts/extract-deps.sh"
+  ".github/workflows/dependency-cooldown.yml:scripts/check-release-age.sh"
 )
+
 YAML_INDENT="          "  # exactly 10 spaces — matches the `run: |` indent
 
 fail=0
 
 extract_inline_body() {
-  local script_path="$1"
+  local workflow="$1" script_path="$2"
   local begin_marker="# --- BEGIN inline:${script_path} ---"
   local end_marker="# --- END inline:${script_path} ---"
 
@@ -27,35 +28,40 @@ extract_inline_body() {
     index($0, begin) { inside=1; next }
     index($0, end)   { inside=0; next }
     inside { print }
-  ' "$WORKFLOW"
+  ' "$workflow"
 }
 
-for script in "${SCRIPTS[@]}"; do
-  if ! grep -qF "# --- BEGIN inline:${script} ---" "$WORKFLOW"; then
-    echo "FAIL: no inline sentinel for '${script}' found in ${WORKFLOW}"
+for pair in "${INLINE_PAIRS[@]}"; do
+  workflow="${pair%%:*}"
+  script="${pair##*:}"
+
+  if ! grep -qF "# --- BEGIN inline:${script} ---" "$workflow"; then
+    echo "FAIL: no inline sentinel for '${script}' found in ${workflow}"
     fail=1
     continue
   fi
 
   # Strip first and last lines (the `fn() (` opener and the `)` closer),
   # then strip the 10-space YAML indent from every remaining line.
-  inline_body=$(extract_inline_body "$script" | sed -E '1d;$d' | sed -E "s/^${YAML_INDENT}//")
+  inline_body=$(extract_inline_body "$workflow" "$script" | sed -E '1d;$d' | sed -E "s/^${YAML_INDENT}//")
   standalone_body=$(tail -n +2 "$script")
 
   if ! diff <(printf '%s\n' "$inline_body") <(printf '%s\n' "$standalone_body") > /dev/null 2>&1; then
-    echo "FAIL: inline copy of '${script}' in ${WORKFLOW} does not match source:"
+    echo "FAIL: inline copy of '${script}' in ${workflow} does not match source:"
     diff <(printf '%s\n' "$inline_body") <(printf '%s\n' "$standalone_body") || true
     fail=1
   else
-    echo "OK:   ${script} inline copy matches source"
+    echo "OK:   ${script} inline copy matches source ($workflow)"
   fi
 done
 
-# Safety net: residual runtime source-fetch references must not exist.
-if grep -qF '${GITHUB_WORKSPACE}/shared-workflows/scripts/' "$WORKFLOW"; then
-  echo "FAIL: residual runtime source-fetch reference in ${WORKFLOW}:"
-  grep -nF '${GITHUB_WORKSPACE}/shared-workflows/scripts/' "$WORKFLOW" || true
-  fail=1
-fi
+# Safety net: residual runtime source-fetch references must not exist in any tracked workflow.
+for workflow in .github/workflows/*.yml; do
+  if grep -qF '${GITHUB_WORKSPACE}/shared-workflows/scripts/' "$workflow"; then
+    echo "FAIL: residual runtime source-fetch reference in ${workflow}:"
+    grep -nF '${GITHUB_WORKSPACE}/shared-workflows/scripts/' "$workflow" || true
+    fail=1
+  fi
+done
 
 exit $fail

--- a/scripts/check-inline-sync.sh
+++ b/scripts/check-inline-sync.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 INLINE_PAIRS=(
   ".github/workflows/dependency-cooldown.yml:scripts/extract-deps.sh"
   ".github/workflows/dependency-cooldown.yml:scripts/check-release-age.sh"
+  ".github/workflows/tag-release.yml:scripts/bump-version-files.sh"
 )
 
 YAML_INDENT="          "  # exactly 10 spaces — matches the `run: |` indent

--- a/tests/bump-version-files.bats
+++ b/tests/bump-version-files.bats
@@ -238,3 +238,41 @@ JSON
   [ "$status" -eq 2 ]
   [ "$(cat package.json)" = "$ORIG" ]
 }
+
+# === Filesystem-path safety (regression coverage from inline bumper) ===
+
+@test "filesystem: absolute path is skipped with warning" {
+  run_bumper "valid/absolute-path.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "skipped (unsafe path)" ]]
+}
+
+@test "filesystem: traversal '..' is skipped with warning" {
+  run_bumper "valid/traversal-path.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "skipped (unsafe path)" ]]
+}
+
+@test "filesystem: missing target file is skipped" {
+  run_bumper "valid/missing-target.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "skipped (file not found)" ]]
+}
+
+@test "filesystem: non-JSON file is skipped" {
+  # Create a Cargo.toml in the temp dir for this test
+  echo 'version = "0.0.0"' > Cargo.toml
+  run_bumper "valid/non-json-target.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "skipped (not JSON)" ]]
+  # Cargo.toml must be untouched
+  [ "$(cat Cargo.toml)" = 'version = "0.0.0"' ]
+}
+
+@test "filesystem: invalid-JSON target is skipped (NEW behavior)" {
+  run_bumper "valid/invalid-json-target.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "skipped (invalid JSON)" ]]
+  # invalid.json is part of the targets fixture set (copied by setup())
+  # and remains untouched
+}

--- a/tests/bump-version-files.bats
+++ b/tests/bump-version-files.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+# bump-version-files.bats — tests for scripts/bump-version-files.sh
+#
+# Each test copies fixture targets into a temp dir, runs the script
+# against a config fixture, asserts post-state of target files plus
+# the script's stdout summary rows.
+
+setup() {
+  TMPDIR=$(mktemp -d)
+  REPO_ROOT="$BATS_TEST_DIRNAME/.."
+  cp "$REPO_ROOT"/tests/fixtures/bump-version-files/targets/*.json "$TMPDIR/"
+  cd "$TMPDIR"
+}
+
+teardown() {
+  cd /
+  rm -rf "$TMPDIR"
+}
+
+run_bumper() {
+  local config="$1" version="$2"
+  cp "$REPO_ROOT/tests/fixtures/bump-version-files/$config" .version-bump.json
+  run bash "$REPO_ROOT/scripts/bump-version-files.sh" .version-bump.json "$version"
+}
+
+# === Acceptance: legacy `field` codepath ===
+
+@test "legacy: field='version' bumps top-level .version" {
+  run_bumper "valid/legacy-field.json" "1.2.3"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r .version package.json)" = "1.2.3" ]
+}
+
+@test "legacy: idempotent re-run reports 'already up to date'" {
+  cp "$REPO_ROOT/tests/fixtures/bump-version-files/valid/legacy-field.json" .version-bump.json
+  bash "$REPO_ROOT/scripts/bump-version-files.sh" .version-bump.json 1.2.3
+  run bash "$REPO_ROOT/scripts/bump-version-files.sh" .version-bump.json 1.2.3
+  [ "$status" -eq 2 ]
+  [[ "$output" =~ "already up to date" ]]
+}

--- a/tests/bump-version-files.bats
+++ b/tests/bump-version-files.bats
@@ -200,3 +200,41 @@ JSON
   [ "$status" -eq 2 ]
   [ "$(cat package.json)" = "$ORIG" ]
 }
+
+# === Anchor-bypass attempts (^ and $ on the regex) ===
+
+@test "anchor: leading whitespace cannot bypass validator" {
+  ORIG=$(cat package.json)
+  run_bumper "invalid-path-expr/leading-whitespace.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [ "$(cat package.json)" = "$ORIG" ]
+}
+
+@test "anchor: trailing whitespace cannot bypass validator" {
+  ORIG=$(cat package.json)
+  run_bumper "invalid-path-expr/trailing-whitespace.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [ "$(cat package.json)" = "$ORIG" ]
+}
+
+@test "anchor: unanchored prefix 'xxx.version' rejected" {
+  ORIG=$(cat package.json)
+  run_bumper "invalid-path-expr/unanchored-prefix.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [ "$(cat package.json)" = "$ORIG" ]
+}
+
+@test "anchor: empty path_expr is treated as missing — schema error" {
+  run_bumper "invalid-path-expr/empty.json" "1.2.3"
+  # Empty path_expr is jq-extracted as "" — same as not present —
+  # so schema validation catches it as "neither field nor path_expr"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "neither 'field' nor 'path_expr'" ]]
+}
+
+@test "anchor: injection suffix '.version; rm -rf /' is rejected as a whole" {
+  ORIG=$(cat package.json)
+  run_bumper "invalid-path-expr/injection-suffix.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [ "$(cat package.json)" = "$ORIG" ]
+}

--- a/tests/bump-version-files.bats
+++ b/tests/bump-version-files.bats
@@ -97,3 +97,32 @@ JSON
   [ "$(jq -r .version package.json)" = "1.2.3" ]
   [ "$(jq -r '.packages[0].version' server.json)" = "1.2.3" ]
 }
+
+# === Schema validation: hard errors (exit 1, fails workflow) ===
+
+@test "schema: entry with both 'field' and 'path_expr' fails workflow" {
+  run_bumper "invalid-schema/both-keys.json" "1.2.3"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "mutually exclusive" ]]
+  # Target file MUST be untouched (schema error fails BEFORE apply pass)
+  [ "$(jq -r .version package.json)" = "0.0.0" ]
+}
+
+@test "schema: entry with neither 'field' nor 'path_expr' fails workflow" {
+  run_bumper "invalid-schema/neither-key.json" "1.2.3"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "neither 'field' nor 'path_expr'" ]]
+  [ "$(jq -r .version package.json)" = "0.0.0" ]
+}
+
+@test "schema: entry missing 'path' fails workflow" {
+  run_bumper "invalid-schema/missing-path.json" "1.2.3"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "missing 'path'" ]]
+}
+
+@test "schema: missing 'files' array fails workflow" {
+  run_bumper "invalid-schema/missing-files-array.json" "1.2.3"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "invalid 'files' array" ]]
+}

--- a/tests/bump-version-files.bats
+++ b/tests/bump-version-files.bats
@@ -77,3 +77,23 @@ JSON
   [ "$(cat package.json)" = "$ORIG" ]
   [[ "$output" =~ "skipped (invalid path_expr)" ]]
 }
+
+@test "path_expr: deeply nested (3+ levels) is bumped" {
+  run_bumper "valid/path-expr-deep.json" "1.2.3"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.metadata.release.semver' deeply-nested.json)" = "1.2.3" ]
+}
+
+@test "multi-entry: two path_expr entries against same file write both" {
+  run_bumper "valid/multi-entry-same-file.json" "1.2.3"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.version' server.json)" = "1.2.3" ]
+  [ "$(jq -r '.packages[0].version' server.json)" = "1.2.3" ]
+}
+
+@test "mixed: legacy field entry + path_expr entry both apply" {
+  run_bumper "valid/mixed-old-and-new.json" "1.2.3"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r .version package.json)" = "1.2.3" ]
+  [ "$(jq -r '.packages[0].version' server.json)" = "1.2.3" ]
+}

--- a/tests/bump-version-files.bats
+++ b/tests/bump-version-files.bats
@@ -126,3 +126,77 @@ JSON
   [ "$status" -eq 1 ]
   [[ "$output" =~ "invalid 'files' array" ]]
 }
+
+# === Path-expression rejection (per-entry skip; security boundary) ===
+
+@test "rejection: pipe '|' is rejected, file untouched" {
+  ORIG=$(cat package.json)
+  run_bumper "invalid-path-expr/pipe.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [ "$(cat package.json)" = "$ORIG" ]
+  [[ "$output" =~ "skipped (invalid path_expr)" ]]
+}
+
+@test "rejection: wildcard '[*]' is rejected" {
+  ORIG=$(cat server.json)
+  run_bumper "invalid-path-expr/wildcard.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [ "$(cat server.json)" = "$ORIG" ]
+  [[ "$output" =~ "skipped (invalid path_expr)" ]]
+}
+
+@test "rejection: slice '[0:1]' is rejected" {
+  ORIG=$(cat server.json)
+  run_bumper "invalid-path-expr/slice.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [ "$(cat server.json)" = "$ORIG" ]
+}
+
+@test "rejection: negative index '[-1]' is rejected" {
+  ORIG=$(cat server.json)
+  run_bumper "invalid-path-expr/negative-index.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [ "$(cat server.json)" = "$ORIG" ]
+}
+
+@test "rejection: recursive descent '..' is rejected" {
+  ORIG=$(cat server.json)
+  run_bumper "invalid-path-expr/recursive-descent.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [ "$(cat server.json)" = "$ORIG" ]
+}
+
+@test "rejection: parens '()' are rejected" {
+  ORIG=$(cat package.json)
+  run_bumper "invalid-path-expr/parens.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [ "$(cat package.json)" = "$ORIG" ]
+}
+
+@test "rejection: arithmetic '+' is rejected" {
+  ORIG=$(cat package.json)
+  run_bumper "invalid-path-expr/arithmetic.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [ "$(cat package.json)" = "$ORIG" ]
+}
+
+@test "rejection: format string '@sh' is rejected" {
+  ORIG=$(cat package.json)
+  run_bumper "invalid-path-expr/format-string.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [ "$(cat package.json)" = "$ORIG" ]
+}
+
+@test "rejection: variable reference '\$ENV' is rejected" {
+  ORIG=$(cat package.json)
+  run_bumper "invalid-path-expr/variable-ref.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [ "$(cat package.json)" = "$ORIG" ]
+}
+
+@test "rejection: quoted-string key '[\"x\"]' is rejected" {
+  ORIG=$(cat package.json)
+  run_bumper "invalid-path-expr/quoted-key.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [ "$(cat package.json)" = "$ORIG" ]
+}

--- a/tests/bump-version-files.bats
+++ b/tests/bump-version-files.bats
@@ -276,3 +276,33 @@ JSON
   # invalid.json is part of the targets fixture set (copied by setup())
   # and remains untouched
 }
+
+# === Step-summary table format ===
+
+@test "summary: path_expr entry renders the full path in the Path column" {
+  run_bumper "valid/path-expr-nested.json" "1.2.3"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "| \`server.json\` | \`.packages[0].version\` | \`0.0.0\` -> \`1.2.3\` | updated |" ]]
+}
+
+@test "summary: legacy field='version' renders as '.version' (unified display)" {
+  run_bumper "valid/legacy-field.json" "1.2.3"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "| \`package.json\` | \`.version\` | \`0.0.0\` -> \`1.2.3\` | updated |" ]]
+}
+
+# === Multi-entry interleaving — the 'partial progress' guarantee ===
+
+@test "interleaving: one valid entry + one invalid path_expr — valid still applied" {
+  run_bumper "valid/one-good-one-bad.json" "1.2.3"
+  # Exit 0 because at least one entry was modified (the valid one)
+  [ "$status" -eq 0 ]
+  # Valid entry: package.json updated
+  [ "$(jq -r .version package.json)" = "1.2.3" ]
+  # Invalid entry: server.json untouched
+  [ "$(jq -r .version server.json)" = "0.0.0" ]
+  [ "$(jq -r '.packages[0].version' server.json)" = "0.0.0" ]
+  # Both rows appear in the summary
+  [[ "$output" =~ "| \`package.json\` | \`.version\` |" ]]
+  [[ "$output" =~ "skipped (invalid path_expr)" ]]
+}

--- a/tests/bump-version-files.bats
+++ b/tests/bump-version-files.bats
@@ -39,3 +39,41 @@ run_bumper() {
   [ "$status" -eq 2 ]
   [[ "$output" =~ "already up to date" ]]
 }
+
+# === Acceptance: path_expr codepath ===
+
+@test "path_expr: '.version' bumps top-level (equivalent to legacy field)" {
+  run_bumper "valid/path-expr-simple.json" "1.2.3"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r .version package.json)" = "1.2.3" ]
+}
+
+@test "path_expr: '.packages[0].version' bumps nested array element" {
+  run_bumper "valid/path-expr-nested.json" "1.2.3"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.packages[0].version' server.json)" = "1.2.3" ]
+  # Confirm the top-level .version was NOT touched
+  [ "$(jq -r .version server.json)" = "0.0.0" ]
+}
+
+@test "path_expr: '.packages[1].version' touches only that index" {
+  run_bumper "valid/path-expr-indexed.json" "1.2.3"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.packages[0].version' multi-pkg-server.json)" = "0.0.0" ]
+  [ "$(jq -r '.packages[1].version' multi-pkg-server.json)" = "1.2.3" ]
+  [ "$(jq -r '.packages[2].version' multi-pkg-server.json)" = "0.0.0" ]
+  [ "$(jq -r '.version' multi-pkg-server.json)" = "0.0.0" ]
+}
+
+# === Security boundary smoke (I4 mitigation — full coverage in T8/T9) ===
+
+@test "validator: rejects path_expr with pipe (smoke; T8 has full coverage)" {
+  cat > .version-bump.json <<'JSON'
+{ "files": [ { "path": "package.json", "path_expr": ".version | input_filename" } ] }
+JSON
+  ORIG=$(cat package.json)
+  run bash "$REPO_ROOT/scripts/bump-version-files.sh" .version-bump.json 1.2.3
+  [ "$status" -eq 2 ]
+  [ "$(cat package.json)" = "$ORIG" ]
+  [[ "$output" =~ "skipped (invalid path_expr)" ]]
+}

--- a/tests/fixtures/bump-version-files/invalid-path-expr/arithmetic.json
+++ b/tests/fixtures/bump-version-files/invalid-path-expr/arithmetic.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "package.json", "path_expr": ".version+1" } ] }

--- a/tests/fixtures/bump-version-files/invalid-path-expr/empty.json
+++ b/tests/fixtures/bump-version-files/invalid-path-expr/empty.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "package.json", "path_expr": "" } ] }

--- a/tests/fixtures/bump-version-files/invalid-path-expr/format-string.json
+++ b/tests/fixtures/bump-version-files/invalid-path-expr/format-string.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "package.json", "path_expr": "@sh \".version\"" } ] }

--- a/tests/fixtures/bump-version-files/invalid-path-expr/injection-suffix.json
+++ b/tests/fixtures/bump-version-files/invalid-path-expr/injection-suffix.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "package.json", "path_expr": ".version; rm -rf /" } ] }

--- a/tests/fixtures/bump-version-files/invalid-path-expr/leading-whitespace.json
+++ b/tests/fixtures/bump-version-files/invalid-path-expr/leading-whitespace.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "package.json", "path_expr": " .version" } ] }

--- a/tests/fixtures/bump-version-files/invalid-path-expr/negative-index.json
+++ b/tests/fixtures/bump-version-files/invalid-path-expr/negative-index.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "server.json", "path_expr": ".packages[-1].version" } ] }

--- a/tests/fixtures/bump-version-files/invalid-path-expr/parens.json
+++ b/tests/fixtures/bump-version-files/invalid-path-expr/parens.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "package.json", "path_expr": "(.version)" } ] }

--- a/tests/fixtures/bump-version-files/invalid-path-expr/pipe.json
+++ b/tests/fixtures/bump-version-files/invalid-path-expr/pipe.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "package.json", "path_expr": ".version | .other" } ] }

--- a/tests/fixtures/bump-version-files/invalid-path-expr/quoted-key.json
+++ b/tests/fixtures/bump-version-files/invalid-path-expr/quoted-key.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "package.json", "path_expr": ".[\"version\"]" } ] }

--- a/tests/fixtures/bump-version-files/invalid-path-expr/recursive-descent.json
+++ b/tests/fixtures/bump-version-files/invalid-path-expr/recursive-descent.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "server.json", "path_expr": "..version" } ] }

--- a/tests/fixtures/bump-version-files/invalid-path-expr/slice.json
+++ b/tests/fixtures/bump-version-files/invalid-path-expr/slice.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "server.json", "path_expr": ".packages[0:1].version" } ] }

--- a/tests/fixtures/bump-version-files/invalid-path-expr/trailing-whitespace.json
+++ b/tests/fixtures/bump-version-files/invalid-path-expr/trailing-whitespace.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "package.json", "path_expr": ".version " } ] }

--- a/tests/fixtures/bump-version-files/invalid-path-expr/unanchored-prefix.json
+++ b/tests/fixtures/bump-version-files/invalid-path-expr/unanchored-prefix.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "package.json", "path_expr": "xxx.version" } ] }

--- a/tests/fixtures/bump-version-files/invalid-path-expr/variable-ref.json
+++ b/tests/fixtures/bump-version-files/invalid-path-expr/variable-ref.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "package.json", "path_expr": "$ENV.PATH" } ] }

--- a/tests/fixtures/bump-version-files/invalid-path-expr/wildcard.json
+++ b/tests/fixtures/bump-version-files/invalid-path-expr/wildcard.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "server.json", "path_expr": ".packages[*].version" } ] }

--- a/tests/fixtures/bump-version-files/invalid-schema/both-keys.json
+++ b/tests/fixtures/bump-version-files/invalid-schema/both-keys.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "package.json", "field": "version", "path_expr": ".version" } ] }

--- a/tests/fixtures/bump-version-files/invalid-schema/missing-files-array.json
+++ b/tests/fixtures/bump-version-files/invalid-schema/missing-files-array.json
@@ -1,0 +1,1 @@
+{ "version_files": [] }

--- a/tests/fixtures/bump-version-files/invalid-schema/missing-path.json
+++ b/tests/fixtures/bump-version-files/invalid-schema/missing-path.json
@@ -1,0 +1,1 @@
+{ "files": [ { "field": "version" } ] }

--- a/tests/fixtures/bump-version-files/invalid-schema/neither-key.json
+++ b/tests/fixtures/bump-version-files/invalid-schema/neither-key.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "package.json" } ] }

--- a/tests/fixtures/bump-version-files/targets/deeply-nested.json
+++ b/tests/fixtures/bump-version-files/targets/deeply-nested.json
@@ -1,0 +1,7 @@
+{
+  "metadata": {
+    "release": {
+      "semver": "0.0.0"
+    }
+  }
+}

--- a/tests/fixtures/bump-version-files/targets/invalid.json
+++ b/tests/fixtures/bump-version-files/targets/invalid.json
@@ -1,0 +1,1 @@
+{this is not valid json

--- a/tests/fixtures/bump-version-files/targets/multi-pkg-server.json
+++ b/tests/fixtures/bump-version-files/targets/multi-pkg-server.json
@@ -1,0 +1,8 @@
+{
+  "version": "0.0.0",
+  "packages": [
+    { "name": "pkg-a", "version": "0.0.0" },
+    { "name": "pkg-b", "version": "0.0.0" },
+    { "name": "pkg-c", "version": "0.0.0" }
+  ]
+}

--- a/tests/fixtures/bump-version-files/targets/package.json
+++ b/tests/fixtures/bump-version-files/targets/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test-package",
+  "version": "0.0.0"
+}

--- a/tests/fixtures/bump-version-files/targets/server.json
+++ b/tests/fixtures/bump-version-files/targets/server.json
@@ -1,0 +1,11 @@
+{
+  "name": "test-server",
+  "version": "0.0.0",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "test-pkg",
+      "version": "0.0.0"
+    }
+  ]
+}

--- a/tests/fixtures/bump-version-files/valid/absolute-path.json
+++ b/tests/fixtures/bump-version-files/valid/absolute-path.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "/etc/passwd", "field": "version" } ] }

--- a/tests/fixtures/bump-version-files/valid/invalid-json-target.json
+++ b/tests/fixtures/bump-version-files/valid/invalid-json-target.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "invalid.json", "field": "version" } ] }

--- a/tests/fixtures/bump-version-files/valid/legacy-field.json
+++ b/tests/fixtures/bump-version-files/valid/legacy-field.json
@@ -1,0 +1,5 @@
+{
+  "files": [
+    { "path": "package.json", "field": "version" }
+  ]
+}

--- a/tests/fixtures/bump-version-files/valid/missing-target.json
+++ b/tests/fixtures/bump-version-files/valid/missing-target.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "does-not-exist.json", "field": "version" } ] }

--- a/tests/fixtures/bump-version-files/valid/mixed-old-and-new.json
+++ b/tests/fixtures/bump-version-files/valid/mixed-old-and-new.json
@@ -1,0 +1,6 @@
+{
+  "files": [
+    { "path": "package.json", "field": "version" },
+    { "path": "server.json", "path_expr": ".packages[0].version" }
+  ]
+}

--- a/tests/fixtures/bump-version-files/valid/multi-entry-same-file.json
+++ b/tests/fixtures/bump-version-files/valid/multi-entry-same-file.json
@@ -1,0 +1,6 @@
+{
+  "files": [
+    { "path": "server.json", "path_expr": ".version" },
+    { "path": "server.json", "path_expr": ".packages[0].version" }
+  ]
+}

--- a/tests/fixtures/bump-version-files/valid/non-json-target.json
+++ b/tests/fixtures/bump-version-files/valid/non-json-target.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "Cargo.toml", "field": "version" } ] }

--- a/tests/fixtures/bump-version-files/valid/one-good-one-bad.json
+++ b/tests/fixtures/bump-version-files/valid/one-good-one-bad.json
@@ -1,0 +1,6 @@
+{
+  "files": [
+    { "path": "package.json", "path_expr": ".version" },
+    { "path": "server.json", "path_expr": ".packages[*].version" }
+  ]
+}

--- a/tests/fixtures/bump-version-files/valid/path-expr-deep.json
+++ b/tests/fixtures/bump-version-files/valid/path-expr-deep.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "deeply-nested.json", "path_expr": ".metadata.release.semver" } ] }

--- a/tests/fixtures/bump-version-files/valid/path-expr-indexed.json
+++ b/tests/fixtures/bump-version-files/valid/path-expr-indexed.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "multi-pkg-server.json", "path_expr": ".packages[1].version" } ] }

--- a/tests/fixtures/bump-version-files/valid/path-expr-nested.json
+++ b/tests/fixtures/bump-version-files/valid/path-expr-nested.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "server.json", "path_expr": ".packages[0].version" } ] }

--- a/tests/fixtures/bump-version-files/valid/path-expr-simple.json
+++ b/tests/fixtures/bump-version-files/valid/path-expr-simple.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "package.json", "path_expr": ".version" } ] }

--- a/tests/fixtures/bump-version-files/valid/traversal-path.json
+++ b/tests/fixtures/bump-version-files/valid/traversal-path.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "../escape.json", "field": "version" } ] }


### PR DESCRIPTION
## Summary

- Adds an optional `path_expr` key to per-entry `.version-bump.json` schema, accepting strict jq-style path expressions (`.packages[0].version`, `.metadata.semver`, etc.) — the existing top-level-only `field` shorthand continues to work unchanged.
- Extracts the inline bumper bash from `tag-release.yml` into `scripts/bump-version-files.sh` with 36 bats cases covering acceptance, schema-rejection, path-expression rejection (one per dangerous jq metachar), anchor-bypass attempts, and filesystem-safety regressions.
- Documents the schema (previously undocumented) in both READMEs.
- Generalizes `scripts/check-inline-sync.sh` to cover multiple workflows.

Fixes #44

## Release category

`feat(tag-release):` — semver **minor** bump → `v2.5.0`. Strictly additive; existing legacy-`field` configs continue to work byte-identically. Floating `@v2` callers automatically inherit the new capability.

Per global commit-prefix rule: every commit subject in this PR uses `feat(tag-release):`, `test(tag-release):`, or `docs(tag-release):` — none use `chore:` or `refactor:` even though some commits add brand-new test files. The PR-level intent (introduce a new capability) governs the prefix.

## Design

See `docs/superpowers/specs/2026-04-19-version-bump-nested-paths-design.md` for the full design rationale, including:
- Why the validator regex is anchored on both ends and uses a strict allowlist
- Why `field` and `path_expr` keep separate jq invocation paths despite schema unification
- Why the `Bump version files` step body became its own bats-tested script

(Note: spec/plan files live under `docs/superpowers/` per local-only convention; not committed in this PR.)

## Test plan

- [ ] CI `bats` job: 36 new cases under `tests/bump-version-files.bats` plus the existing test files (53 total)
- [ ] CI `inline-sync` job: three OK lines (added `tag-release.yml:bump-version-files.sh` pair)
- [ ] CI `lint-workflow-call` job: unchanged, must remain green
- [ ] Manual smoke (deferred to nexus-mcp's later consumer-migration spec): real `Tag Release` dispatch against a `.version-bump.json` with both `.version` and `.packages[0].version` entries

## Follow-ups (filed before this PR opened)

- #45 — bracket-quoted string keys (`["kebab-case"]`) for path_expr
- #46 — wildcard `[*]` selectors for path_expr

Both are strictly additive future minor releases. Neither is in scope here.

## Out of scope

- TOML / YAML file support
- The nexus-mcp consumer migration (separate future spec, blocked on this PR landing AND on nexus-mcp's auto-bump-release migration landing first)