### PR TITLE
feat(tag-release): accept bracket-quoted keys and [] iterator in path_expr

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -80,7 +80,7 @@ Each entry must contain exactly one of `field` or `path_expr` (mutually exclusiv
 |---|---|
 | `path` | Path relative to repo root. Must end in `.json`. Absolute paths and `..` traversal rejected. |
 | `field` | Top-level key to update. Shorthand for `path_expr: ".<field>"`. Any string value safe (passed to jq as a literal). |
-| `path_expr` | jq-style path expression. Validated against an identifier+integer-index allowlist before use. |
+| `path_expr` | jq-style path expression. Validated against a strict allowlist before use — see "Allowed path_expr syntax" below. |
 
 #### Examples
 
@@ -101,20 +101,42 @@ Each entry must contain exactly one of `field` or `path_expr` (mutually exclusiv
 }
 ```
 
+**Scoped or hyphenated dependency keys** (npm, Composer, Helm):
+
+```json
+{
+  "files": [
+    { "path": "package.json", "path_expr": ".dependencies[\"@scope/pkg\"].version" }
+  ]
+}
+```
+
+**Update every element of an array** (jq's `[]` iterator):
+
+```json
+{
+  "files": [
+    { "path": "server.json", "path_expr": ".packages[].version" }
+  ]
+}
+```
+
 #### Allowed `path_expr` syntax
 
 - `.identifier` — top-level key (`.version`, `._private`)
 - `.identifier.identifier` — nested key (`.metadata.semver`)
 - `.identifier[N]` — non-negative integer index (`.packages[0]`)
-- Combinations (`.packages[0].version`, `.foo.bar[2].baz`)
+- `.identifier["string-key"]` — bracket-quoted string key (`.dependencies["@scope/pkg"]`). Content allowlist: letters, digits, `.`, `_`, `@`, `/`, `-`. Covers npm scoped packages, Composer `vendor/package`, Helm kebab-case values.
+- `.identifier[]` — jq iterator; updates every element of an array (`.packages[].version` sets `.version` on every package entry)
+- Combinations (`.packages[0].version`, `.foo.bar[2].baz`, `.dependencies["lodash.debounce"].version`, `.packages[].version`)
 
-The first segment must be `.identifier`. Identifiers follow `[A-Za-z_][A-Za-z0-9_]*`.
+The first segment must be `.identifier`. Identifiers follow `[A-Za-z_][A-Za-z0-9_]*`. Bracket-quoted keys and the `[]` iterator can appear anywhere after the first segment.
 
 #### Rejected syntax (security boundary)
 
-The validator rejects pipes (`|`), wildcards (`[*]`), slices (`[2:5]`), negative indices (`[-1]`), recursive descent (`..`), variable references (`$ENV`), format strings (`@sh`), parens, arithmetic, and quoted-string keys (`."weird-key"`, `["weird-key"]`). Path expressions originate from repo-committed config but are still validated as a defense-in-depth measure.
+The validator rejects pipes (`|`), JSONPath-style wildcards (`[*]`), slices (`[2:5]`), negative indices (`[-1]`), recursive descent (`..`), variable references (`$ENV`), format strings (`@sh`), parens, arithmetic, dot-quoted keys (`."weird-key"`), and single-quoted keys (`['key']`). Empty or whitespace-containing quoted keys (`[""]`, `["a b"]`) are also rejected. Path expressions originate from repo-committed config but are still validated as a defense-in-depth measure.
 
-For files whose schemas require quoted-string keys (e.g. `package.json` `.dependencies."@scope/pkg".version`), file an issue — quoted-string support is a documented future extension.
+**Note on `[*]` vs. `[]`:** jq's iterate-all operator is `[]`, not `[*]` (the latter is JSONPath, not jq). Use `.foo[]` to update every element of an array.
 
 #### Step summary
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -130,13 +130,13 @@ Each entry must contain exactly one of `field` or `path_expr` (mutually exclusiv
 - `.identifier[]` — jq iterator; updates every element of an array (`.packages[].version` sets `.version` on every package entry)
 - Combinations (`.packages[0].version`, `.foo.bar[2].baz`, `.dependencies["lodash.debounce"].version`, `.packages[].version`)
 
-The first segment must be `.identifier`. Identifiers follow `[A-Za-z_][A-Za-z0-9_]*`. Bracket-quoted keys and the `[]` iterator can appear anywhere after the first segment.
+The first segment must be `.identifier`. Identifiers follow `[A-Za-z_][A-Za-z0-9_]*`. Bracket-quoted string keys and the `[]` iterator can appear anywhere after the first segment.
 
 #### Rejected syntax (security boundary)
 
-The validator rejects pipes (`|`), JSONPath-style wildcards (`[*]`), slices (`[2:5]`), negative indices (`[-1]`), recursive descent (`..`), variable references (`$ENV`), format strings (`@sh`), parens, arithmetic, dot-quoted keys (`."weird-key"`), and single-quoted keys (`['key']`). Empty or whitespace-containing quoted keys (`[""]`, `["a b"]`) are also rejected. Path expressions originate from repo-committed config but are still validated as a defense-in-depth measure.
+The validator rejects pipes (`|`), JSONPath-style wildcards (`[*]`), slices (`[2:5]`), negative indices (`[-1]`), recursive descent (`..`), variable references (`$ENV`), format strings (`@sh`), parens, arithmetic, dot-quoted keys (`."weird-key"`), leading-bracket keys at the root (`.["key"]`), and single-quoted keys (`['key']`). Empty or whitespace-containing quoted keys (`[""]`, `["a b"]`) are also rejected. Path expressions originate from repo-committed config but are still validated as a defense-in-depth measure.
 
-**Note on `[*]` vs. `[]`:** jq's iterate-all operator is `[]`, not `[*]` (the latter is JSONPath, not jq). Use `.foo[]` to update every element of an array.
+**Note on `[*]` vs. `[]`:** jq's iterate-all operator is `[]`, not `[*]` (the latter is JSONPath, not jq). Use `.packages[].version` to update every element's `.version` (or `.foo[]` in general).
 
 #### Step summary
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -248,11 +248,11 @@ jobs:
 
           set -euo pipefail
 
-          # Strict allowlist: identifiers + integer indices.
-          # Bracket-quoted string keys (e.g. .["kebab-case"]) and wildcards [*] are
-          # reserved for future minor releases — see follow-up issues filed at
-          # PR-merge time.
-          PATH_EXPR_RE='^\.[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*|\[[0-9]+\])*$'
+          # Strict allowlist: identifiers, integer indices, bracket-quoted string keys
+          # (npm/composer style: kebab-case, @scope/pkg, dotted paths), and the []
+          # iterator (applies-to-every). The jq [*] form is NOT valid jq grammar and
+          # stays rejected.
+          PATH_EXPR_RE='^\.[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*|\[[0-9]+\]|\["[A-Za-z0-9._@/-]+"\]|\[\])*$'
 
           validate_path_expr() {
             local expr="$1"

--- a/scripts/bump-version-files.sh
+++ b/scripts/bump-version-files.sh
@@ -21,10 +21,11 @@
 
 set -euo pipefail
 
-# Strict allowlist: identifiers, integer indices, and bracket-quoted string
-# keys (npm/composer style: kebab-case, @scope/pkg, dotted paths). The jq []
-# iterator is reserved for a follow-up minor release in this PR.
-PATH_EXPR_RE='^\.[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*|\[[0-9]+\]|\["[A-Za-z0-9._@/-]+"\])*$'
+# Strict allowlist: identifiers, integer indices, bracket-quoted string keys
+# (npm/composer style: kebab-case, @scope/pkg, dotted paths), and the []
+# iterator (applies-to-every). The jq [*] form is NOT valid jq grammar and
+# stays rejected.
+PATH_EXPR_RE='^\.[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*|\[[0-9]+\]|\["[A-Za-z0-9._@/-]+"\]|\[\])*$'
 
 validate_path_expr() {
   local expr="$1"

--- a/scripts/bump-version-files.sh
+++ b/scripts/bump-version-files.sh
@@ -21,11 +21,10 @@
 
 set -euo pipefail
 
-# Strict allowlist: identifiers + integer indices.
-# Bracket-quoted string keys (e.g. .["kebab-case"]) and wildcards [*] are
-# reserved for future minor releases — see follow-up issues filed at
-# PR-merge time.
-PATH_EXPR_RE='^\.[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*|\[[0-9]+\])*$'
+# Strict allowlist: identifiers, integer indices, and bracket-quoted string
+# keys (npm/composer style: kebab-case, @scope/pkg, dotted paths). The jq []
+# iterator is reserved for a follow-up minor release in this PR.
+PATH_EXPR_RE='^\.[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*|\[[0-9]+\]|\["[A-Za-z0-9._@/-]+"\])*$'
 
 validate_path_expr() {
   local expr="$1"

--- a/tests/bump-version-files.bats
+++ b/tests/bump-version-files.bats
@@ -306,3 +306,15 @@ JSON
   [[ "$output" =~ "| \`package.json\` | \`.version\` |" ]]
   [[ "$output" =~ "skipped (invalid path_expr)" ]]
 }
+
+# === Acceptance: bracket-quoted string keys (#45) ===
+
+@test "path_expr: quoted-key '[\"@scope/pkg\"]' bumps scoped dependency" {
+  run_bumper "valid/path-expr-quoted-key-scoped.json" "1.2.3"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.dependencies["@scope/pkg"].version' package-scoped.json)" = "1.2.3" ]
+  # Confirm the other dependency was NOT touched
+  [ "$(jq -r '.dependencies["eslint-config-airbnb"].version' package-scoped.json)" = "0.0.0" ]
+  # Confirm the top-level .version was NOT touched
+  [ "$(jq -r '.version' package-scoped.json)" = "1.0.0" ]
+}

--- a/tests/bump-version-files.bats
+++ b/tests/bump-version-files.bats
@@ -318,3 +318,16 @@ JSON
   # Confirm the top-level .version was NOT touched
   [ "$(jq -r '.version' package-scoped.json)" = "1.0.0" ]
 }
+
+# === Acceptance: [] iterator (#46) ===
+
+@test "path_expr: '[]' iterator updates every array element" {
+  run_bumper "valid/path-expr-iterate-all.json" "1.2.3"
+  [ "$status" -eq 0 ]
+  # All three .packages[*].version entries are updated
+  [ "$(jq -r '.packages[0].version' multi-pkg-server.json)" = "1.2.3" ]
+  [ "$(jq -r '.packages[1].version' multi-pkg-server.json)" = "1.2.3" ]
+  [ "$(jq -r '.packages[2].version' multi-pkg-server.json)" = "1.2.3" ]
+  # Top-level .version is NOT touched
+  [ "$(jq -r '.version' multi-pkg-server.json)" = "0.0.0" ]
+}

--- a/tests/bump-version-files.bats
+++ b/tests/bump-version-files.bats
@@ -324,10 +324,18 @@ JSON
 @test "path_expr: '[]' iterator updates every array element" {
   run_bumper "valid/path-expr-iterate-all.json" "1.2.3"
   [ "$status" -eq 0 ]
-  # All three .packages[*].version entries are updated
+  # All three .packages[].version entries are updated
   [ "$(jq -r '.packages[0].version' multi-pkg-server.json)" = "1.2.3" ]
   [ "$(jq -r '.packages[1].version' multi-pkg-server.json)" = "1.2.3" ]
   [ "$(jq -r '.packages[2].version' multi-pkg-server.json)" = "1.2.3" ]
   # Top-level .version is NOT touched
   [ "$(jq -r '.version' multi-pkg-server.json)" = "0.0.0" ]
+}
+
+@test "path_expr: quoted-key with kebab-case hyphens is bumped" {
+  run_bumper "valid/path-expr-quoted-key-kebab.json" "1.2.3"
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.dependencies["eslint-config-airbnb"].version' package-scoped.json)" = "1.2.3" ]
+  # Sibling dependency was NOT touched
+  [ "$(jq -r '.dependencies["@scope/pkg"].version' package-scoped.json)" = "0.0.0" ]
 }

--- a/tests/bump-version-files.bats
+++ b/tests/bump-version-files.bats
@@ -291,6 +291,12 @@ JSON
   [[ "$output" =~ "| \`package.json\` | \`.version\` | \`0.0.0\` -> \`1.2.3\` | updated |" ]]
 }
 
+@test "summary: '[]' iterator renders verbatim in step-summary path column" {
+  run_bumper "valid/path-expr-iterate-all.json" "1.2.3"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "| \`multi-pkg-server.json\` | \`.packages[].version\` |" ]]
+}
+
 # === Multi-entry interleaving — the 'partial progress' guarantee ===
 
 @test "interleaving: one valid entry + one invalid path_expr — valid still applied" {

--- a/tests/bump-version-files.bats
+++ b/tests/bump-version-files.bats
@@ -339,3 +339,53 @@ JSON
   # Sibling dependency was NOT touched
   [ "$(jq -r '.dependencies["@scope/pkg"].version' package-scoped.json)" = "0.0.0" ]
 }
+
+# === Hardening: rejection of malformed new forms ===
+
+@test "rejection: empty quoted key '[\"\"]' is rejected" {
+  ORIG=$(cat package.json)
+  run_bumper "invalid-path-expr/empty-quoted-key.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [ "$(cat package.json)" = "$ORIG" ]
+  [[ "$output" =~ "skipped (invalid path_expr)" ]]
+}
+
+@test "rejection: whitespace in quoted key is rejected" {
+  ORIG=$(cat package.json)
+  run_bumper "invalid-path-expr/whitespace-in-key.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [ "$(cat package.json)" = "$ORIG" ]
+  [[ "$output" =~ "skipped (invalid path_expr)" ]]
+}
+
+@test "rejection: injection char ';' in quoted key is rejected" {
+  ORIG=$(cat package.json)
+  run_bumper "invalid-path-expr/injection-in-key.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [ "$(cat package.json)" = "$ORIG" ]
+  [[ "$output" =~ "skipped (invalid path_expr)" ]]
+}
+
+@test "rejection: single-quoted key is rejected" {
+  ORIG=$(cat package.json)
+  run_bumper "invalid-path-expr/single-quoted-key.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [ "$(cat package.json)" = "$ORIG" ]
+  [[ "$output" =~ "skipped (invalid path_expr)" ]]
+}
+
+@test "rejection: unclosed quoted key is rejected" {
+  ORIG=$(cat package.json)
+  run_bumper "invalid-path-expr/unclosed-quoted-key.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [ "$(cat package.json)" = "$ORIG" ]
+  [[ "$output" =~ "skipped (invalid path_expr)" ]]
+}
+
+@test "rejection: spaced wildcard '[ ]' is rejected" {
+  ORIG=$(cat server.json)
+  run_bumper "invalid-path-expr/whitespace-wildcard.json" "1.2.3"
+  [ "$status" -eq 2 ]
+  [ "$(cat server.json)" = "$ORIG" ]
+  [[ "$output" =~ "skipped (invalid path_expr)" ]]
+}

--- a/tests/fixtures/bump-version-files/invalid-path-expr/empty-quoted-key.json
+++ b/tests/fixtures/bump-version-files/invalid-path-expr/empty-quoted-key.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "package.json", "path_expr": ".deps[\"\"].version" } ] }

--- a/tests/fixtures/bump-version-files/invalid-path-expr/injection-in-key.json
+++ b/tests/fixtures/bump-version-files/invalid-path-expr/injection-in-key.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "package.json", "path_expr": ".deps[\"a;b\"].version" } ] }

--- a/tests/fixtures/bump-version-files/invalid-path-expr/single-quoted-key.json
+++ b/tests/fixtures/bump-version-files/invalid-path-expr/single-quoted-key.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "package.json", "path_expr": ".deps['a'].version" } ] }

--- a/tests/fixtures/bump-version-files/invalid-path-expr/unclosed-quoted-key.json
+++ b/tests/fixtures/bump-version-files/invalid-path-expr/unclosed-quoted-key.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "package.json", "path_expr": ".deps[\"a].version" } ] }

--- a/tests/fixtures/bump-version-files/invalid-path-expr/whitespace-in-key.json
+++ b/tests/fixtures/bump-version-files/invalid-path-expr/whitespace-in-key.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "package.json", "path_expr": ".deps[\"a b\"].version" } ] }

--- a/tests/fixtures/bump-version-files/invalid-path-expr/whitespace-wildcard.json
+++ b/tests/fixtures/bump-version-files/invalid-path-expr/whitespace-wildcard.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "server.json", "path_expr": ".packages[ ].version" } ] }

--- a/tests/fixtures/bump-version-files/targets/package-scoped.json
+++ b/tests/fixtures/bump-version-files/targets/package-scoped.json
@@ -1,0 +1,12 @@
+{
+  "name": "host-package",
+  "version": "1.0.0",
+  "dependencies": {
+    "@scope/pkg": {
+      "version": "0.0.0"
+    },
+    "eslint-config-airbnb": {
+      "version": "0.0.0"
+    }
+  }
+}

--- a/tests/fixtures/bump-version-files/valid/path-expr-iterate-all.json
+++ b/tests/fixtures/bump-version-files/valid/path-expr-iterate-all.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "multi-pkg-server.json", "path_expr": ".packages[].version" } ] }

--- a/tests/fixtures/bump-version-files/valid/path-expr-quoted-key-kebab.json
+++ b/tests/fixtures/bump-version-files/valid/path-expr-quoted-key-kebab.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "package-scoped.json", "path_expr": ".dependencies[\"eslint-config-airbnb\"].version" } ] }

--- a/tests/fixtures/bump-version-files/valid/path-expr-quoted-key-scoped.json
+++ b/tests/fixtures/bump-version-files/valid/path-expr-quoted-key-scoped.json
@@ -1,0 +1,1 @@
+{ "files": [ { "path": "package-scoped.json", "path_expr": ".dependencies[\"@scope/pkg\"].version" } ] }


### PR DESCRIPTION
## Summary

Extends the `path_expr` validator introduced in #44 with two new jq path forms:

- **Bracket-quoted string keys** — `.dependencies["@scope/pkg"].version`, `.deps["kebab-case"].version`. Covers npm scoped packages, Composer `vendor/package`, Helm kebab-case values.
- **jq `[]` iterator** — `.packages[].version` updates every element of an array in one entry.

Both are purely additive: two new alternation branches in `PATH_EXPR_RE`, no other code changes. Backward compatible — all existing accept/reject behavior preserved.

## Correction re: issue #46

Issue #46 proposed `[*]` as the wildcard syntax. That is **not valid jq grammar** (`jq '.packages[*].v = "X"'` errors with `syntax error, unexpected '*'`). jq's iterate-all operator is `[]` (empty brackets). This PR ships `[]` and leaves `[*]` in the rejection bucket. A correction comment is posted on #46.

## Test coverage added

- 3 positive tests: `@scope/pkg`, kebab-case, `[]` iterator
- 6 hardening rejection tests: empty quoted key, whitespace in key, `;` injection, single-quoted key, unclosed quote, spaced `[ ]`
- 1 summary-rendering test: `[]` renders verbatim

All existing rejection cases continue to reject (including `[*]` and `.["version"]` — both still rejected under the new regex).

## Security boundary

The regex remains a strict allowlist, anchored `^...$`. New quoted-key branch adds a second-layer allowlist on content (letters/digits/`.`/`_`/`@`/`/`/`-`). New `[]` branch is a two-character literal.

Fixes #45
Fixes #46