### PR TITLE
fix(tag-release): use Git Data API so commits and tags auto-sign

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -220,6 +220,7 @@ jobs:
         env:
           NEXT_TAG: ${{ steps.compute.outputs.next_tag }}
           TAG_PREFIX: ${{ inputs.tag-prefix }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           PREFIX="${TAG_PREFIX:-v}"
           VERSION="${NEXT_TAG#"${PREFIX}"}"
@@ -414,21 +415,82 @@ jobs:
 
           case "$BUMP_EXIT" in
             0)
-              git config user.name "github-actions[bot]"
-              git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-              for entry in $(jq -r '.files[] | .path' .version-bump.json); do
-                git add "$entry"
-              done
-              git commit -m "chore(release): bump version files to $VERSION"
-              git push origin HEAD:main
-              RESULT="Committed and pushed version file updates"
+              # --- Git Data API rewrite (spec §3.1) ---
+              # BASE_SHA is the workflow's runtime view of the repo HEAD —
+              # the SHA actions/checkout checked out. Reading refs/heads/main
+              # fresh here would race with concurrent pushes (spec §2).
+              REPO="${GITHUB_REPOSITORY}"
+              BASE_SHA="${GITHUB_SHA}"
+
+              # Step 4 (spec): read parent tree SHA from BASE_SHA's commit.
+              PARENT_TREE_SHA=$(gh api "repos/${REPO}/git/commits/${BASE_SHA}" --jq '.tree.sha')
+
+              # Steps 3+5: create blobs for each modified file, accumulate
+              # tree[] entries, then create the tree.
+              TREE_ENTRIES='[]'
+              while IFS= read -r modified_path; do
+                [ -z "$modified_path" ] && continue
+                blob_content_b64=$(base64 < "$modified_path" | tr -d '\n')
+                blob_sha=$(jq -nc \
+                  --arg c "$blob_content_b64" \
+                  '{content: $c, encoding: "base64"}' \
+                  | gh api -X POST "repos/${REPO}/git/blobs" --input - --jq '.sha')
+                TREE_ENTRIES=$(jq --arg p "$modified_path" --arg s "$blob_sha" \
+                  '. + [{path: $p, mode: "100644", type: "blob", sha: $s}]' \
+                  <<<"$TREE_ENTRIES")
+              done < /tmp/bump.modified
+
+              TREE_SHA=$(jq -nc \
+                --arg base "$PARENT_TREE_SHA" \
+                --argjson entries "$TREE_ENTRIES" \
+                '{base_tree: $base, tree: $entries}' \
+                | gh api -X POST "repos/${REPO}/git/trees" --input - --jq '.sha')
+
+              # Step 6: create commit. NO author/committer fields — GitHub
+              # auto-signs with the bot/web-flow key only when the request is
+              # authenticated as the App AND the body has no identity overrides
+              # (spec §3.3).
+              NEW_COMMIT_SHA=$(jq -nc \
+                --arg msg "chore(release): bump version files to $VERSION" \
+                --arg tree "$TREE_SHA" \
+                --arg parent "$BASE_SHA" \
+                '{message: $msg, tree: $tree, parents: [$parent]}' \
+                | gh api -X POST "repos/${REPO}/git/commits" --input - --jq '.sha')
+
+              # Step 7: fast-forward main to the new commit. force=false (default).
+              # 422 = non-fast-forward = main moved past BASE_SHA after checkout
+              # → fail the run loudly (spec §3.1 step 7, race-detection backstop).
+              gh api -X PATCH "repos/${REPO}/git/refs/heads/main" \
+                -f sha="$NEW_COMMIT_SHA" \
+                -F force=false
+
+              # Acceptance criterion #2 (spec §6): bump commit MUST verify.
+              VERIFIED=$(gh api "repos/${REPO}/git/commits/${NEW_COMMIT_SHA}" \
+                --jq '.commit.verification.verified')
+              REASON=$(gh api "repos/${REPO}/git/commits/${NEW_COMMIT_SHA}" \
+                --jq '.commit.verification.reason')
+              if [ "$VERIFIED" != "true" ]; then
+                echo "::error::Bump commit ${NEW_COMMIT_SHA} did not auto-sign (verified=${VERIFIED} reason=${REASON})"
+                echo "::error::This means the API rewrite is not satisfying the required_signatures rule — investigate before proceeding."
+                exit 1
+              fi
+
+              # Export TAG_TARGET_SHA for the Create-and-push-tag step.
+              echo "TAG_TARGET_SHA=${NEW_COMMIT_SHA}" >> "$GITHUB_ENV"
+              RESULT="Committed and pushed version file updates via Git Data API (sha: ${NEW_COMMIT_SHA}, verified: true, reason: ${REASON})"
               ;;
             1)
               echo "::error::Bump version files step failed due to .version-bump.json error"
               exit 1
               ;;
             2)
-              RESULT="No changes — config absent, all up to date, or all entries skipped"
+              # No bump created — set TAG_TARGET_SHA from main HEAD via API
+              # (spec §3.2 conditional). Covers fresh-no-bump-needed AND
+              # rerun-after-partial-failure. NEVER read local checkout state.
+              REPO="${GITHUB_REPOSITORY}"
+              MAIN_SHA=$(gh api "repos/${REPO}/git/ref/heads/main" --jq '.object.sha')
+              echo "TAG_TARGET_SHA=${MAIN_SHA}" >> "$GITHUB_ENV"
+              RESULT="No changes — config absent, all up to date, or all entries skipped (tag will point at current main: ${MAIN_SHA})"
               ;;
             *)
               echo "::error::bump-version-files.sh exited with unexpected code $BUMP_EXIT"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -499,9 +499,15 @@ jobs:
               # the original GITHUB_SHA, recreates a sibling bump commit
               # (different timestamp → different SHA), and this non-force PATCH
               # will 422 (non-fast-forward). Recover with a fresh
-              # `workflow_dispatch` from main: its GITHUB_SHA is then the
-              # bumped HEAD, so the bump step takes the no-bump path and tags
-              # it directly.
+              # `workflow_dispatch` from main, using the SAME `bump` and
+              # `tag-prefix` inputs as the failed run. "Compute release"
+              # derives the version from the last *tag* — still unchanged,
+              # since the tag was never created — so a different `bump` (e.g.
+              # `auto` in place of an explicit override) or `tag-prefix` would
+              # recompute a different version and create a second, wrong bump
+              # commit instead of taking the no-bump path. With the same
+              # inputs the recomputed version matches the already-bumped
+              # files: the bump step takes the no-bump path, tag points at it.
               gh api -X PATCH "repos/${REPO}/git/refs/heads/main" \
                 -f sha="$NEW_COMMIT_SHA" \
                 -F force=false
@@ -509,6 +515,11 @@ jobs:
               # Export TAG_TARGET_SHA for the Create-and-push-tag step.
               echo "TAG_TARGET_SHA=${NEW_COMMIT_SHA}" >> "$GITHUB_ENV"
               RESULT="Committed and pushed version file updates via Git Data API (sha: ${NEW_COMMIT_SHA}, verified: true, reason: ${REASON})"
+              # Operator-facing recovery guidance, surfaced in the step summary
+              # below. Set only on this path — case 0 is the only one that
+              # advances main, so it is the only partial-failure-recoverable
+              # state. See the RECOVERY NOTE on the PATCH above.
+              RECOVERY_HINT="> **Partial-failure recovery:** \`main\` now carries this bump commit. If a later step fails, do NOT use GitHub's \"Re-run failed jobs\" — start a fresh \`workflow_dispatch\` from \`main\` with the **same \`bump\` and \`tag-prefix\` inputs** used for this run."
               ;;
             1)
               echo "::error::Bump version files step failed due to .version-bump.json error"
@@ -541,6 +552,10 @@ jobs:
             cat /tmp/bump.summary
             echo ""
             echo "$RESULT"
+            if [ -n "${RECOVERY_HINT:-}" ]; then
+              echo ""
+              echo "$RECOVERY_HINT"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create and push tag

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -249,6 +249,13 @@ jobs:
 
           set -euo pipefail
 
+          # Manifest file path — the unique set of modified paths, consumed by
+          # tag-release.yml's Git Data API tree builder. Overridable so parallel
+          # test runs and concurrent script invocations don't clobber one
+          # another through a shared /tmp file (the default preserves prior
+          # behavior).
+          BUMP_MODIFIED_FILE="${BUMP_MODIFIED_FILE:-/tmp/bump.modified}"
+
           # Strict allowlist: identifiers, integer indices, bracket-quoted string keys
           # (npm/composer style: kebab-case, @scope/pkg, dotted paths), and the []
           # iterator (applies-to-every). The jq [*] form is NOT valid jq grammar and
@@ -333,7 +340,7 @@ jobs:
             fi
 
             write_value "$file_path" "$field" "$path_expr" "$version"
-            printf '%s\n' "$file_path" >> /tmp/bump.modified
+            printf '%s\n' "$file_path" >> "$BUMP_MODIFIED_FILE"
             printf '| `%s` | `%s` | `%s` -> `%s` | updated |\n' \
               "$file_path" "$disp" "$current" "$version"
             return 0
@@ -349,7 +356,7 @@ jobs:
           # Git Data API path to build POST /git/trees). Truncate-or-create at
           # start so the file is always a fresh, well-defined snapshot of THIS
           # invocation's modifications. De-dup happens at end of apply pass.
-          : > /tmp/bump.modified
+          : > "$BUMP_MODIFIED_FILE"
 
           if [ ! -f "$config" ]; then
             echo "No $config found, skipping version file bump"
@@ -396,8 +403,8 @@ jobs:
           # .version-bump.json has multiple entries against it (see test
           # `multi-entry: two path_expr entries against same file write both`).
           # sort -u keeps the contract that /tmp/bump.modified is a unique set.
-          if [ -s /tmp/bump.modified ]; then
-            sort -u /tmp/bump.modified -o /tmp/bump.modified
+          if [ -s "$BUMP_MODIFIED_FILE" ]; then
+            sort -u "$BUMP_MODIFIED_FILE" -o "$BUMP_MODIFIED_FILE"
           fi
 
           if [ "$changed" -eq 1 ]; then
@@ -426,7 +433,10 @@ jobs:
               PARENT_TREE_SHA=$(gh api "repos/${REPO}/git/commits/${BASE_SHA}" --jq '.tree.sha')
 
               # Steps 3+5: create blobs for each modified file, accumulate
-              # tree[] entries, then create the tree.
+              # tree[] entries, then create the tree. The manifest path must
+              # match the one bump_version_files wrote — same default, same
+              # BUMP_MODIFIED_FILE override if the step env sets it.
+              MANIFEST="${BUMP_MODIFIED_FILE:-/tmp/bump.modified}"
               TREE_ENTRIES='[]'
               while IFS= read -r modified_path; do
                 [ -z "$modified_path" ] && continue
@@ -438,7 +448,7 @@ jobs:
                 TREE_ENTRIES=$(jq --arg p "$modified_path" --arg s "$blob_sha" \
                   '. + [{path: $p, mode: "100644", type: "blob", sha: $s}]' \
                   <<<"$TREE_ENTRIES")
-              done < /tmp/bump.modified
+              done < "$MANIFEST"
 
               TREE_SHA=$(jq -nc \
                 --arg base "$PARENT_TREE_SHA" \
@@ -457,14 +467,13 @@ jobs:
                 '{message: $msg, tree: $tree, parents: [$parent]}' \
                 | gh api -X POST "repos/${REPO}/git/commits" --input - --jq '.sha')
 
-              # Step 7: fast-forward main to the new commit. force=false (default).
-              # 422 = non-fast-forward = main moved past BASE_SHA after checkout
-              # → fail the run loudly (spec §3.1 step 7, race-detection backstop).
-              gh api -X PATCH "repos/${REPO}/git/refs/heads/main" \
-                -f sha="$NEW_COMMIT_SHA" \
-                -F force=false
-
               # Acceptance criterion #2 (spec §6): bump commit MUST verify.
+              # Verify the commit OBJECT *before* advancing main. A commit is
+              # addressable by SHA the instant POST /git/commits returns —
+              # independent of any ref — so this check needs no branch update
+              # first. Verifying first means a verification failure (or a
+              # failed lookup) leaves main untouched: no dangling unverified
+              # commit for a later rerun to pick up via the no-bump path.
               # Note jq path: GET /git/commits/{sha} returns the raw Git commit
               # object with `verification` at the TOP level. The higher-level
               # /commits/{sha} endpoint (no `git/` prefix) wraps it as
@@ -479,6 +488,14 @@ jobs:
                 exit 1
               fi
 
+              # Step 7: fast-forward main to the verified commit. force=false
+              # (default). 422 = non-fast-forward = main moved past BASE_SHA
+              # after checkout → fail the run loudly (spec §3.1 step 7,
+              # race-detection backstop).
+              gh api -X PATCH "repos/${REPO}/git/refs/heads/main" \
+                -f sha="$NEW_COMMIT_SHA" \
+                -F force=false
+
               # Export TAG_TARGET_SHA for the Create-and-push-tag step.
               echo "TAG_TARGET_SHA=${NEW_COMMIT_SHA}" >> "$GITHUB_ENV"
               RESULT="Committed and pushed version file updates via Git Data API (sha: ${NEW_COMMIT_SHA}, verified: true, reason: ${REASON})"
@@ -488,13 +505,15 @@ jobs:
               exit 1
               ;;
             2)
-              # No bump created — set TAG_TARGET_SHA from main HEAD via API
-              # (spec §3.2 conditional). Covers fresh-no-bump-needed AND
-              # rerun-after-partial-failure. NEVER read local checkout state.
-              REPO="${GITHUB_REPOSITORY}"
-              MAIN_SHA=$(gh api "repos/${REPO}/git/ref/heads/main" --jq '.object.sha')
-              echo "TAG_TARGET_SHA=${MAIN_SHA}" >> "$GITHUB_ENV"
-              RESULT="No changes — config absent, all up to date, or all entries skipped (tag will point at current main: ${MAIN_SHA})"
+              # No bump created. The commit to tag is exactly the commit that
+              # "Compute release" semver-analyzed — i.e. GITHUB_SHA. Reading
+              # live refs/heads/main here instead would race with concurrent
+              # pushes (spec §2) and could tag a commit that was never
+              # analyzed, publishing it under a bump computed from a different
+              # tree. GITHUB_SHA also covers rerun-after-partial-failure: a
+              # fresh dispatch resolves GITHUB_SHA to current main HEAD anyway.
+              echo "TAG_TARGET_SHA=${GITHUB_SHA}" >> "$GITHUB_ENV"
+              RESULT="No changes — config absent, all up to date, or all entries skipped (tag will point at analyzed commit: ${GITHUB_SHA})"
               ;;
             *)
               echo "::error::bump-version-files.sh exited with unexpected code $BUMP_EXIT"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -332,6 +332,7 @@ jobs:
             fi
 
             write_value "$file_path" "$field" "$path_expr" "$version"
+            printf '%s\n' "$file_path" >> /tmp/bump.modified
             printf '| `%s` | `%s` | `%s` -> `%s` | updated |\n' \
               "$file_path" "$disp" "$current" "$version"
             return 0
@@ -342,6 +343,12 @@ jobs:
           config="${1:-.version-bump.json}"
           version="${2:-${VERSION:-}}"
           : "${version:?usage: $0 <config> <version> | VERSION=X $0 [config]}"
+
+          # Manifest of unique modified paths (consumed by tag-release.yml's
+          # Git Data API path to build POST /git/trees). Truncate-or-create at
+          # start so the file is always a fresh, well-defined snapshot of THIS
+          # invocation's modifications. De-dup happens at end of apply pass.
+          : > /tmp/bump.modified
 
           if [ ! -f "$config" ]; then
             echo "No $config found, skipping version file bump"
@@ -383,6 +390,14 @@ jobs:
               changed=1
             fi
           done < <(jq -c '.files[]' "$config")
+
+          # De-dup manifest in place: a single file may appear N times if
+          # .version-bump.json has multiple entries against it (see test
+          # `multi-entry: two path_expr entries against same file write both`).
+          # sort -u keeps the contract that /tmp/bump.modified is a unique set.
+          if [ -s /tmp/bump.modified ]; then
+            sort -u /tmp/bump.modified -o /tmp/bump.modified
+          fi
 
           if [ "$changed" -eq 1 ]; then
             exit 0

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -517,11 +517,54 @@ jobs:
       - name: Create and push tag
         env:
           NEXT_TAG: ${{ steps.compute.outputs.next_tag }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # --- Git Data API rewrite (spec §3.2) ---
+          # TAG_TARGET_SHA is set by the prior "Bump version files" step:
+          #   - case 0: the new bump commit's SHA (returned by POST /git/commits)
+          #   - case 2: current refs/heads/main SHA (read via GET /git/ref/heads/main)
+          # Either way, NEVER from local checkout state (spec §2).
+          REPO="${GITHUB_REPOSITORY}"
 
-          git tag -a "$NEXT_TAG" -m "Release $NEXT_TAG"
-          git push origin "$NEXT_TAG"
+          if [ -z "${TAG_TARGET_SHA:-}" ]; then
+            echo "::error::TAG_TARGET_SHA not set by Bump version files step — workflow contract violated"
+            exit 1
+          fi
 
-          echo "Tagged and pushed $NEXT_TAG - release.yml will pick up from here."
+          # Create tag OBJECT. NO tagger field — GitHub auto-signs with the
+          # bot/web-flow key only when authenticated as the App AND the body
+          # has no identity overrides (spec §3.3).
+          TAG_OBJECT_SHA=$(jq -nc \
+            --arg tag "$NEXT_TAG" \
+            --arg msg "Release $NEXT_TAG" \
+            --arg sha "$TAG_TARGET_SHA" \
+            '{tag: $tag, message: $msg, object: $sha, type: "commit"}' \
+            | gh api -X POST "repos/${REPO}/git/tags" --input - --jq '.sha')
+
+          # Create tag REF. 422 = ref already exists → fail loudly (spec §4
+          # row 3): re-creating an existing tag is not a workflow-level
+          # decision; operator must intentionally delete/replace before rerun.
+          gh api -X POST "repos/${REPO}/git/refs" \
+            -f ref="refs/tags/${NEXT_TAG}" \
+            -f sha="$TAG_OBJECT_SHA"
+
+          # Report tag verification status (acceptance criterion #3 OR #4
+          # per spec §6 — the canary run records which path locks in for v2.5.3).
+          # Note jq path: GET /git/tags/{sha} returns the raw Git tag object
+          # with `verification` at the TOP level (same convention as
+          # /git/commits/{sha} — see Bump step's verification check).
+          TAG_VERIFIED=$(gh api "repos/${REPO}/git/tags/${TAG_OBJECT_SHA}" --jq '.verification.verified')
+          TAG_REASON=$(gh api "repos/${REPO}/git/tags/${TAG_OBJECT_SHA}" --jq '.verification.reason')
+
+          {
+            echo "### Tag created"
+            echo ""
+            echo "**Tag:** \`$NEXT_TAG\`"
+            echo "**Tag object SHA:** \`$TAG_OBJECT_SHA\`"
+            echo "**Target commit SHA:** \`$TAG_TARGET_SHA\`"
+            echo "**Tag object verification:** \`verified=$TAG_VERIFIED\` \`reason=$TAG_REASON\`"
+            echo ""
+            echo "Tag created via Git Data API. If the caller workflow chains a publish step, it will pick up from here."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "Tag $NEXT_TAG created via Git Data API (verified=$TAG_VERIFIED reason=$TAG_REASON)."

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -465,10 +465,14 @@ jobs:
                 -F force=false
 
               # Acceptance criterion #2 (spec §6): bump commit MUST verify.
+              # Note jq path: GET /git/commits/{sha} returns the raw Git commit
+              # object with `verification` at the TOP level. The higher-level
+              # /commits/{sha} endpoint (no `git/` prefix) wraps it as
+              # `.commit.verification` — do NOT confuse the two.
               VERIFIED=$(gh api "repos/${REPO}/git/commits/${NEW_COMMIT_SHA}" \
-                --jq '.commit.verification.verified')
+                --jq '.verification.verified')
               REASON=$(gh api "repos/${REPO}/git/commits/${NEW_COMMIT_SHA}" \
-                --jq '.commit.verification.reason')
+                --jq '.verification.reason')
               if [ "$VERIFIED" != "true" ]; then
                 echo "::error::Bump commit ${NEW_COMMIT_SHA} did not auto-sign (verified=${VERIFIED} reason=${REASON})"
                 echo "::error::This means the API rewrite is not satisfying the required_signatures rule — investigate before proceeding."

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -492,6 +492,16 @@ jobs:
               # (default). 422 = non-fast-forward = main moved past BASE_SHA
               # after checkout → fail the run loudly (spec §3.1 step 7,
               # race-detection backstop).
+              #
+              # RECOVERY NOTE: this PATCH is the point of no return for main.
+              # If the run fails AFTER this succeeds but before the tag is
+              # created, do NOT use GitHub's "Re-run failed jobs" — it reuses
+              # the original GITHUB_SHA, recreates a sibling bump commit
+              # (different timestamp → different SHA), and this non-force PATCH
+              # will 422 (non-fast-forward). Recover with a fresh
+              # `workflow_dispatch` from main: its GITHUB_SHA is then the
+              # bumped HEAD, so the bump step takes the no-bump path and tags
+              # it directly.
               gh api -X PATCH "repos/${REPO}/git/refs/heads/main" \
                 -f sha="$NEW_COMMIT_SHA" \
                 -F force=false
@@ -541,7 +551,8 @@ jobs:
           # --- Git Data API rewrite (spec §3.2) ---
           # TAG_TARGET_SHA is set by the prior "Bump version files" step:
           #   - case 0: the new bump commit's SHA (returned by POST /git/commits)
-          #   - case 2: current refs/heads/main SHA (read via GET /git/ref/heads/main)
+          #   - case 2: GITHUB_SHA — the semver-analyzed commit, no ref read
+          #            (spec §2 / review Finding 1)
           # Either way, NEVER from local checkout state (spec §2).
           REPO="${GITHUB_REPOSITORY}"
 

--- a/scripts/bump-version-files.sh
+++ b/scripts/bump-version-files.sh
@@ -21,6 +21,13 @@
 
 set -euo pipefail
 
+# Manifest file path — the unique set of modified paths, consumed by
+# tag-release.yml's Git Data API tree builder. Overridable so parallel
+# test runs and concurrent script invocations don't clobber one
+# another through a shared /tmp file (the default preserves prior
+# behavior).
+BUMP_MODIFIED_FILE="${BUMP_MODIFIED_FILE:-/tmp/bump.modified}"
+
 # Strict allowlist: identifiers, integer indices, bracket-quoted string keys
 # (npm/composer style: kebab-case, @scope/pkg, dotted paths), and the []
 # iterator (applies-to-every). The jq [*] form is NOT valid jq grammar and
@@ -105,7 +112,7 @@ bump_entry() {
   fi
 
   write_value "$file_path" "$field" "$path_expr" "$version"
-  printf '%s\n' "$file_path" >> /tmp/bump.modified
+  printf '%s\n' "$file_path" >> "$BUMP_MODIFIED_FILE"
   printf '| `%s` | `%s` | `%s` -> `%s` | updated |\n' \
     "$file_path" "$disp" "$current" "$version"
   return 0
@@ -121,7 +128,7 @@ version="${2:-${VERSION:-}}"
 # Git Data API path to build POST /git/trees). Truncate-or-create at
 # start so the file is always a fresh, well-defined snapshot of THIS
 # invocation's modifications. De-dup happens at end of apply pass.
-: > /tmp/bump.modified
+: > "$BUMP_MODIFIED_FILE"
 
 if [ ! -f "$config" ]; then
   echo "No $config found, skipping version file bump"
@@ -168,8 +175,8 @@ done < <(jq -c '.files[]' "$config")
 # .version-bump.json has multiple entries against it (see test
 # `multi-entry: two path_expr entries against same file write both`).
 # sort -u keeps the contract that /tmp/bump.modified is a unique set.
-if [ -s /tmp/bump.modified ]; then
-  sort -u /tmp/bump.modified -o /tmp/bump.modified
+if [ -s "$BUMP_MODIFIED_FILE" ]; then
+  sort -u "$BUMP_MODIFIED_FILE" -o "$BUMP_MODIFIED_FILE"
 fi
 
 if [ "$changed" -eq 1 ]; then

--- a/scripts/bump-version-files.sh
+++ b/scripts/bump-version-files.sh
@@ -105,6 +105,7 @@ bump_entry() {
   fi
 
   write_value "$file_path" "$field" "$path_expr" "$version"
+  printf '%s\n' "$file_path" >> /tmp/bump.modified
   printf '| `%s` | `%s` | `%s` -> `%s` | updated |\n' \
     "$file_path" "$disp" "$current" "$version"
   return 0
@@ -115,6 +116,12 @@ bump_entry() {
 config="${1:-.version-bump.json}"
 version="${2:-${VERSION:-}}"
 : "${version:?usage: $0 <config> <version> | VERSION=X $0 [config]}"
+
+# Manifest of unique modified paths (consumed by tag-release.yml's
+# Git Data API path to build POST /git/trees). Truncate-or-create at
+# start so the file is always a fresh, well-defined snapshot of THIS
+# invocation's modifications. De-dup happens at end of apply pass.
+: > /tmp/bump.modified
 
 if [ ! -f "$config" ]; then
   echo "No $config found, skipping version file bump"
@@ -156,6 +163,14 @@ while IFS= read -r row; do
     changed=1
   fi
 done < <(jq -c '.files[]' "$config")
+
+# De-dup manifest in place: a single file may appear N times if
+# .version-bump.json has multiple entries against it (see test
+# `multi-entry: two path_expr entries against same file write both`).
+# sort -u keeps the contract that /tmp/bump.modified is a unique set.
+if [ -s /tmp/bump.modified ]; then
+  sort -u /tmp/bump.modified -o /tmp/bump.modified
+fi
 
 if [ "$changed" -eq 1 ]; then
   exit 0

--- a/tests/bump-version-files.bats
+++ b/tests/bump-version-files.bats
@@ -11,6 +11,10 @@ setup() {
   REPO_ROOT="$BATS_TEST_DIRNAME/.."
   cp "$REPO_ROOT"/tests/fixtures/bump-version-files/targets/*.json "$TMPDIR/"
   cd "$TMPDIR"
+  # Per-test manifest path. The script defaults to a shared /tmp/bump.modified;
+  # pinning it inside this test's unique TMPDIR keeps parallel/concurrent runs
+  # from clobbering one another (teardown's rm -rf cleans it up).
+  export BUMP_MODIFIED_FILE="$TMPDIR/bump.modified"
 }
 
 teardown() {
@@ -396,40 +400,42 @@ JSON
   [[ "$output" =~ "skipped (invalid path_expr)" ]]
 }
 
-# === Manifest emission: /tmp/bump.modified contract (#issue-cross-agent-12) ===
+# === Manifest emission: bump.modified contract (#issue-cross-agent-12) ===
 # Manifest must be a UNIQUE PATH SET — see spec §3.1 step 2. The Git Data API
 # rewrite of tag-release.yml consumes this file to build POST /git/trees;
 # duplicates would produce duplicate tree[] entries with undefined behavior.
+# Each test reads $BUMP_MODIFIED_FILE (a per-test path exported in setup),
+# not the shared /tmp default, so concurrent runs stay isolated.
 
-@test "manifest: /tmp/bump.modified is unique path set after multi-entry-same-file run" {
+@test "manifest: bump.modified is unique path set after multi-entry-same-file run" {
   run_bumper "valid/multi-entry-same-file.json" "1.2.3"
   [ "$status" -eq 0 ]
-  [ -f /tmp/bump.modified ]
+  [ -f "$BUMP_MODIFIED_FILE" ]
   # Exactly one line: server.json (despite TWO entries targeting it)
-  [ "$(wc -l < /tmp/bump.modified)" -eq 1 ]
-  [ "$(cat /tmp/bump.modified)" = "server.json" ]
+  [ "$(wc -l < "$BUMP_MODIFIED_FILE")" -eq 1 ]
+  [ "$(cat "$BUMP_MODIFIED_FILE")" = "server.json" ]
 }
 
-@test "manifest: /tmp/bump.modified contains all unique modified paths in mixed run" {
+@test "manifest: bump.modified contains all unique modified paths in mixed run" {
   run_bumper "valid/mixed-old-and-new.json" "1.2.3"
   [ "$status" -eq 0 ]
   # mixed-old-and-new.json bumps package.json (legacy field) AND server.json (path_expr).
   # `< file` redirect makes the assertion fail loudly if the manifest is missing,
   # rather than passing a stray empty string into the comparison.
   expected=$(printf 'package.json\nserver.json\n')
-  [ "$(sort < /tmp/bump.modified)" = "$expected" ]
+  [ "$(sort < "$BUMP_MODIFIED_FILE")" = "$expected" ]
 }
 
-@test "manifest: /tmp/bump.modified is empty when no entries are updated (idempotent rerun)" {
+@test "manifest: bump.modified is empty when no entries are updated (idempotent rerun)" {
   cp "$REPO_ROOT/tests/fixtures/bump-version-files/valid/legacy-field.json" .version-bump.json
   bash "$REPO_ROOT/scripts/bump-version-files.sh" .version-bump.json 1.2.3  # First run: bumps
   run bash "$REPO_ROOT/scripts/bump-version-files.sh" .version-bump.json 1.2.3  # Second run: no-op
   [ "$status" -eq 2 ]
-  [ -f /tmp/bump.modified ]
-  [ ! -s /tmp/bump.modified ]  # File exists but is empty
+  [ -f "$BUMP_MODIFIED_FILE" ]
+  [ ! -s "$BUMP_MODIFIED_FILE" ]  # File exists but is empty
 }
 
-@test "manifest: /tmp/bump.modified is truncated on each invocation (no cross-run pollution)" {
+@test "manifest: bump.modified is truncated on each invocation (no cross-run pollution)" {
   # Run 1: bump multi-entry-same-file (writes "server.json")
   run_bumper "valid/multi-entry-same-file.json" "1.2.3"
   [ "$status" -eq 0 ]
@@ -443,6 +449,6 @@ JSON
   # File-existence guard prevents this from passing vacuously when the
   # script doesn't yet create the manifest (red phase): grep on a missing
   # file returns 1, and `! grep` would silently succeed without it.
-  [ -f /tmp/bump.modified ]
-  ! grep -q server.json /tmp/bump.modified
+  [ -f "$BUMP_MODIFIED_FILE" ]
+  ! grep -q server.json "$BUMP_MODIFIED_FILE"
 }

--- a/tests/bump-version-files.bats
+++ b/tests/bump-version-files.bats
@@ -413,10 +413,11 @@ JSON
 @test "manifest: /tmp/bump.modified contains all unique modified paths in mixed run" {
   run_bumper "valid/mixed-old-and-new.json" "1.2.3"
   [ "$status" -eq 0 ]
-  # mixed-old-and-new.json bumps package.json (legacy field) AND server.json (path_expr)
+  # mixed-old-and-new.json bumps package.json (legacy field) AND server.json (path_expr).
+  # `< file` redirect makes the assertion fail loudly if the manifest is missing,
+  # rather than passing a stray empty string into the comparison.
   expected=$(printf 'package.json\nserver.json\n')
-  actual=$(sort /tmp/bump.modified)
-  [ "$actual" = "$expected" ]
+  [ "$(sort < /tmp/bump.modified)" = "$expected" ]
 }
 
 @test "manifest: /tmp/bump.modified is empty when no entries are updated (idempotent rerun)" {
@@ -432,12 +433,16 @@ JSON
   # Run 1: bump multi-entry-same-file (writes "server.json")
   run_bumper "valid/multi-entry-same-file.json" "1.2.3"
   [ "$status" -eq 0 ]
-  # Run 2: no-op (legacy-field already at 0.0.0, bump to same version - actually different)
-  # Use idempotent rerun: run legacy-field twice
+  # Run 2: idempotent rerun of legacy-field. First bump 0.0.0 -> 9.9.9 succeeds;
+  # second bump 9.9.9 -> 9.9.9 is a no-op (exit 2). The manifest after run 2
+  # must still be truncated (empty) AND must NOT carry server.json across.
   cp "$REPO_ROOT/tests/fixtures/bump-version-files/valid/legacy-field.json" .version-bump.json
   bash "$REPO_ROOT/scripts/bump-version-files.sh" .version-bump.json 9.9.9  # First bump
   run bash "$REPO_ROOT/scripts/bump-version-files.sh" .version-bump.json 9.9.9  # Idempotent rerun
   [ "$status" -eq 2 ]
-  # /tmp/bump.modified must NOT contain server.json from the earlier multi-entry run
+  # File-existence guard prevents this from passing vacuously when the
+  # script doesn't yet create the manifest (red phase): grep on a missing
+  # file returns 1, and `! grep` would silently succeed without it.
+  [ -f /tmp/bump.modified ]
   ! grep -q server.json /tmp/bump.modified
 }

--- a/tests/bump-version-files.bats
+++ b/tests/bump-version-files.bats
@@ -395,3 +395,49 @@ JSON
   [ "$(cat server.json)" = "$ORIG" ]
   [[ "$output" =~ "skipped (invalid path_expr)" ]]
 }
+
+# === Manifest emission: /tmp/bump.modified contract (#issue-cross-agent-12) ===
+# Manifest must be a UNIQUE PATH SET — see spec §3.1 step 2. The Git Data API
+# rewrite of tag-release.yml consumes this file to build POST /git/trees;
+# duplicates would produce duplicate tree[] entries with undefined behavior.
+
+@test "manifest: /tmp/bump.modified is unique path set after multi-entry-same-file run" {
+  run_bumper "valid/multi-entry-same-file.json" "1.2.3"
+  [ "$status" -eq 0 ]
+  [ -f /tmp/bump.modified ]
+  # Exactly one line: server.json (despite TWO entries targeting it)
+  [ "$(wc -l < /tmp/bump.modified)" -eq 1 ]
+  [ "$(cat /tmp/bump.modified)" = "server.json" ]
+}
+
+@test "manifest: /tmp/bump.modified contains all unique modified paths in mixed run" {
+  run_bumper "valid/mixed-old-and-new.json" "1.2.3"
+  [ "$status" -eq 0 ]
+  # mixed-old-and-new.json bumps package.json (legacy field) AND server.json (path_expr)
+  expected=$(printf 'package.json\nserver.json\n')
+  actual=$(sort /tmp/bump.modified)
+  [ "$actual" = "$expected" ]
+}
+
+@test "manifest: /tmp/bump.modified is empty when no entries are updated (idempotent rerun)" {
+  cp "$REPO_ROOT/tests/fixtures/bump-version-files/valid/legacy-field.json" .version-bump.json
+  bash "$REPO_ROOT/scripts/bump-version-files.sh" .version-bump.json 1.2.3  # First run: bumps
+  run bash "$REPO_ROOT/scripts/bump-version-files.sh" .version-bump.json 1.2.3  # Second run: no-op
+  [ "$status" -eq 2 ]
+  [ -f /tmp/bump.modified ]
+  [ ! -s /tmp/bump.modified ]  # File exists but is empty
+}
+
+@test "manifest: /tmp/bump.modified is truncated on each invocation (no cross-run pollution)" {
+  # Run 1: bump multi-entry-same-file (writes "server.json")
+  run_bumper "valid/multi-entry-same-file.json" "1.2.3"
+  [ "$status" -eq 0 ]
+  # Run 2: no-op (legacy-field already at 0.0.0, bump to same version - actually different)
+  # Use idempotent rerun: run legacy-field twice
+  cp "$REPO_ROOT/tests/fixtures/bump-version-files/valid/legacy-field.json" .version-bump.json
+  bash "$REPO_ROOT/scripts/bump-version-files.sh" .version-bump.json 9.9.9  # First bump
+  run bash "$REPO_ROOT/scripts/bump-version-files.sh" .version-bump.json 9.9.9  # Idempotent rerun
+  [ "$status" -eq 2 ]
+  # /tmp/bump.modified must NOT contain server.json from the earlier multi-entry run
+  ! grep -q server.json /tmp/bump.modified
+}

--- a/tests/tag-release-invariants.bats
+++ b/tests/tag-release-invariants.bats
@@ -60,10 +60,39 @@ extract_step_body() {
   if printf '%s' "$body" | grep -qF 'git push origin HEAD:main'; then
     skip "Phase A baseline — bump step still uses git push; check applies after Phase B"
   fi
-  printf '%s' "$body" | grep -qF 'GITHUB_SHA' || {
-    echo "VIOLATION: rewritten Bump step does not reference GITHUB_SHA (spec §2 / §3.1 step 1)"
+  # Assert the full load-bearing chain, not merely that GITHUB_SHA appears
+  # somewhere — a stray `echo "$GITHUB_SHA"` must NOT satisfy this test:
+  #   GITHUB_SHA  ->  BASE_SHA  ->  jq --arg parent  ->  commit payload
+  printf '%s' "$body" | grep -qF 'BASE_SHA="${GITHUB_SHA}"' || {
+    echo "VIOLATION: bump step does not bind BASE_SHA to GITHUB_SHA (spec §2 / §3.1 step 1)"
     false
   }
+  # `--` ends grep option parsing so the leading `--arg` is treated as a
+  # pattern, not a flag.
+  printf '%s' "$body" | grep -qF -- '--arg parent "$BASE_SHA"' || {
+    echo "VIOLATION: commit-create jq call does not wire its parent arg from BASE_SHA"
+    false
+  }
+  printf '%s' "$body" | grep -qF 'parents: [$parent]' || {
+    echo "VIOLATION: commit payload does not build parents from the \$parent arg"
+    false
+  }
+}
+
+@test "invariant: 'Bump version files' step never reads a live ref for the tag target" {
+  body=$(extract_step_body "Bump version files")
+  [ -n "$body" ]
+  # Spec §2 / review Finding 1: the no-bump (exit 2) path must tag the
+  # semver-analyzed commit (GITHUB_SHA), never a fresh `GET /git/ref/heads/...`
+  # read — that races with concurrent pushes and can tag an unanalyzed commit.
+  # The discriminator is the singular/plural ref endpoint form: the legitimate
+  # fast-forward PATCH uses the PLURAL `git/refs/heads/main`; only the
+  # SINGULAR-`ref` GET form (`git/ref/heads/`) is forbidden here.
+  if printf '%s' "$body" | grep -qF 'git/ref/heads/'; then
+    echo "VIOLATION: Bump step performs a live 'GET .../git/ref/heads/' read (spec §2 / Finding 1)"
+    printf '%s' "$body" | grep -nF 'git/ref/heads/'
+    false
+  fi
 }
 
 @test "invariant: bump-commit and tag payloads omit author/committer/tagger fields" {

--- a/tests/tag-release-invariants.bats
+++ b/tests/tag-release-invariants.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+# tag-release-invariants.bats — static checks on the rewritten Git Data API
+# blocks in .github/workflows/tag-release.yml.
+#
+# Spec §2 invariant: the rewritten "Bump version files" and "Create and push
+# tag" steps must never depend on a post-checkout local-state read for
+# deciding what SHA to use as a commit parent, what SHA to update main to,
+# or what SHA to tag. The single load-bearing SHA value is $GITHUB_SHA,
+# captured once.
+
+setup() {
+  REPO_ROOT="$BATS_TEST_DIRNAME/.."
+  WORKFLOW="$REPO_ROOT/.github/workflows/tag-release.yml"
+}
+
+# Extract the YAML body of a step by name, up to the next "      - name:" boundary.
+extract_step_body() {
+  local name="$1"
+  awk -v marker="      - name: $name" '
+    index($0, marker) == 1 { inside=1; next }
+    inside && /^      - name: / { inside=0 }
+    inside { print }
+  ' "$WORKFLOW"
+}
+
+@test "invariant: 'Bump version files' step contains no post-checkout local-state git reads" {
+  body=$(extract_step_body "Bump version files")
+  [ -n "$body" ]
+  # Spec §2 forbids ALL post-checkout local-state git reads — the same set
+  # in both the bump step and the tag step. `git log` is included even though
+  # the bump step doesn't currently call it, to prevent future regressions
+  # (e.g., "look up the parent commit's date" via local git instead of API).
+  for forbidden in 'git rev-parse' 'git symbolic-ref' 'git for-each-ref' 'git describe' 'git log'; do
+    if printf '%s' "$body" | grep -qF "$forbidden"; then
+      printf 'VIOLATION: "%s" appears in Bump version files step (spec §2)\n' "$forbidden"
+      printf '%s\n' "$body" | grep -nF "$forbidden"
+      false
+    fi
+  done
+}
+
+@test "invariant: 'Create and push tag' step contains no post-checkout local-state git reads" {
+  body=$(extract_step_body "Create and push tag")
+  [ -n "$body" ]
+  for forbidden in 'git rev-parse' 'git symbolic-ref' 'git for-each-ref' 'git describe' 'git log'; do
+    if printf '%s' "$body" | grep -qF "$forbidden"; then
+      printf 'VIOLATION: "%s" appears in Create and push tag step (spec §2)\n' "$forbidden"
+      printf '%s\n' "$body" | grep -nF "$forbidden"
+      false
+    fi
+  done
+}
+
+@test "invariant: 'Bump version files' step uses GITHUB_SHA as commit parent" {
+  body=$(extract_step_body "Bump version files")
+  # After Phase B rewrite, BASE_SHA must be derived from GITHUB_SHA, not from
+  # GET /git/ref/heads/main (which would race per spec §2). Skip this check
+  # if the step still uses git push (Phase A only — pre-Phase-B baseline).
+  if printf '%s' "$body" | grep -qF 'git push origin HEAD:main'; then
+    skip "Phase A baseline — bump step still uses git push; check applies after Phase B"
+  fi
+  printf '%s' "$body" | grep -qF 'GITHUB_SHA' || {
+    echo "VIOLATION: rewritten Bump step does not reference GITHUB_SHA (spec §2 / §3.1 step 1)"
+    false
+  }
+}
+
+@test "invariant: bump-commit and tag payloads omit author/committer/tagger fields" {
+  # Strip comment-only lines first — the workflow code's own commentary
+  # legitimately mentions these field names (e.g., "NO author/committer
+  # fields — auto-signs"). The test enforces that the words appear ONLY
+  # in comments, never in code positions where they could become real
+  # identity overrides via a jq object literal, gh api -f/-F/--field flag,
+  # or YAML key.
+  body_bump=$(extract_step_body "Bump version files" | grep -v '^[[:space:]]*#')
+  body_tag=$(extract_step_body "Create and push tag" | grep -v '^[[:space:]]*#')
+  if printf '%s' "$body_bump" | grep -qF 'git push origin HEAD:main'; then
+    skip "Phase A baseline — checks apply after Phase B"
+  fi
+  # Word-boundary match catches every escape hatch: "author", 'author',
+  # author: (jq literal), -f author=, -F author=, --field author=.
+  # If a real workflow change needs one of these field names in code
+  # for a non-identity-override reason, the test must be updated
+  # deliberately, with a comment explaining why.
+  for field in 'author' 'committer'; do
+    if printf '%s' "$body_bump" | grep -qE "\\b${field}\\b"; then
+      echo "VIOLATION: '$field' appears in Bump step (non-comment context) — disables auto-signing if used as a payload field name (spec §3.3)"
+      printf '%s' "$body_bump" | grep -nE "\\b${field}\\b"
+      false
+    fi
+  done
+  if printf '%s' "$body_tag" | grep -qE '\btagger\b'; then
+    echo "VIOLATION: 'tagger' appears in Tag step (non-comment context) — disables auto-signing if used as a payload field name (spec §3.3)"
+    printf '%s' "$body_tag" | grep -nE '\btagger\b'
+    false
+  fi
+}


### PR DESCRIPTION
## Summary

- Rewrite `tag-release.yml`'s bump-commit step to use the GitHub Git Data API (`POST /git/blobs` → `POST /git/trees` → `POST /git/commits` → `PATCH /git/refs/heads/main`). The commit's parent is `BASE_SHA=$GITHUB_SHA`, not a fresh read of `main`, to avoid the silent-overwrite race documented in the spec.
- Rewrite the annotated-tag step to use `POST /git/tags` + `POST /git/refs` against either the new bump commit's SHA or `main`'s current HEAD (via API, never local checkout state).
- Both API payloads omit `author` / `committer` / `tagger` fields so GitHub auto-signs with its bot/web-flow key — satisfying the `required_signatures` branch ruleset on consumer repos without bypass-actor entries.
- Add `/tmp/bump.modified` manifest emission (unique path set) to `scripts/bump-version-files.sh` so the API path knows which files to put in the tree.
- Add bats tests for manifest contract (4 tests) and §2 design invariant (4 tests).

The verification check uses the low-level `GET /git/commits/{sha}` endpoint with jq path `.verification.verified` (top-level), not the higher-level `/commits/{sha}` endpoint with `.commit.verification.verified` — a distinction that bit us during review and is now documented in-line.

See the design notes in the spec authored alongside this PR (kept locally per the project's docs/ workflow; not committed) for the full reasoning behind the design invariant, race-detection backstop, and acceptance criteria.

## Test plan

- [x] `bash scripts/check-inline-sync.sh` passes
- [x] `bash scripts/lint-workflow-call.sh` passes
- [x] `bats tests/bump-version-files.bats` — 50/50 (existing 46 + 4 new manifest tests)
- [x] `bats tests/tag-release-invariants.bats` — 4/4
- [x] Full `bats tests/` suite — 92/92
- [x] All 4 workflow YAML files parse via `python3 yaml.safe_load(...)`
- [x] No `git config user.*`, `git tag -a`, or `git push origin` patterns remain in `tag-release.yml`
- [x] Commit-subject audit: 5 × `fix:` + 3 × `test:`, 0 × `feat:` (no inadvertent minor-bump trigger)
- [ ] After merge: cut `v2.5.3-rc1` (manual — `release.yml` is `workflow_call` only, not push-driven), pin `cross-agent-reviews` to RC SHA, run Tag Release on `cross-agent-reviews` via `workflow_dispatch`, verify acceptance criteria #1–#7 from spec §6
- [ ] After canary success: promote `v2.5.3` from RC SHA (manual replay of `release.yml`'s two steps — floating `v2`/`v2.5` tag updates + `gh release create v2.5.3`), bump `cross-agent-reviews` to `v2.5.3` final

Refs j7an/cross-agent-reviews#12. Not auto-closed on merge: `cross-agent-reviews` must still adopt the resulting `v2.5.3` tag release (the two unchecked post-merge items above) before #12 is fully resolved.
