### PR TITLE
feat(safety): add dependency-safety workflow with native-cooldown verification

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -31,6 +31,7 @@ A reusable workflow cannot reliably check out *its own* repo's scripts: in a `wo
 `scripts/*.sh` is the source of truth; the inline copy is a derived artifact. **Editing a script means updating its inline copy too**, or `check-inline-sync.sh` fails CI. The sync is byte-for-byte after known normalizations (10-space YAML indent strip, shebang strip, function-wrapper strip). The pairs are listed in `check-inline-sync.sh` (`INLINE_PAIRS`):
 
 - `dependency-cooldown.yml` embeds `extract-deps.sh`, `check-release-age.sh`, `diff-touches-lockfile.sh`, `pr-body-to-deps.sh`
+- `dependency-safety.yml` embeds the same four scripts plus `safety-verdict.sh`
 - `tag-release.yml` embeds `bump-version-files.sh`
 
 `lint-workflow-call.sh` is the partner guard: it fails CI if any `workflow_call` file reintroduces a caller-scoped ref as a checkout `ref:`.
@@ -39,14 +40,15 @@ A reusable workflow cannot reliably check out *its own* repo's scripts: in a `wo
 
 **Consumer-facing reusable workflows:**
 
-- `dependency-cooldown.yml` — scans Dependabot PRs. Pipeline: parse diff → `extract-deps.sh` (with `pr-body-to-deps.sh` as fallback when the diff yields zero rows, and `diff-touches-lockfile.sh` as a fail-loud guard so a clean-but-wrong extraction can't produce a false-green gate) → `check-release-age.sh` for the cooldown gate → GHSA/OSV advisory scan → single update-or-create comment + label reconciliation.
-- `cooldown-rescan.yml` — scheduled re-scan of PRs stuck in the `pending` cooldown state.
+- `dependency-safety.yml` — verifies the native-Dependabot-cooldown invariant on each Dependabot PR. Pipeline mirrors `dependency-cooldown.yml` (extract → fallback → guard → age check → GHSA/OSV scan → scorecard → comment → labels) but the verdict layer is deterministic: `failure` on age violation (when `fail_on_age_violation: true`), `error` on extraction/scan failure, `success` otherwise. Verdict translation lives in `safety-verdict.sh`. No rescan companion — verifier is single-shot per PR event.
+- `dependency-cooldown.yml` — **legacy**, retained for Phase 2 migration window. Scans Dependabot PRs. Pipeline: parse diff → `extract-deps.sh` (with `pr-body-to-deps.sh` as fallback when the diff yields zero rows, and `diff-touches-lockfile.sh` as a fail-loud guard so a clean-but-wrong extraction can't produce a false-green gate) → `check-release-age.sh` for the cooldown gate → GHSA/OSV advisory scan → single update-or-create comment + label reconciliation.
+- `cooldown-rescan.yml` — **legacy**, retained for Phase 2 migration window. Scheduled re-scan of PRs stuck in the `pending` cooldown state.
 - `tag-release.yml` — computes the next semver tag from Conventional Commits, optionally runs `bump-version-files.sh` against `.version-bump.json`, creates the tag via the GitHub Git Data API (so commits/tags auto-sign under the App identity). Requires a GitHub App key (`RELEASE_BOT_PRIVATE_KEY` secret, `RELEASE_BOT_APP_ID` var).
 - `publish-pypi.yml` — `uv build` → TestPyPI (with install verification) → PyPI via OIDC trusted publishing → GitHub Release.
 
 **Release machinery for this repo itself:** `release-self.yml` (manual `workflow_dispatch`) → calls `tag-release.yml` → calls `release.yml`. `release.yml` is `workflow_call`-only (no `push: tags` trigger) and floats the major/minor tags (`v2` → `v2.3` → `v2.3.1`). Merging to `main` does **not** auto-release; a release is always a deliberate `release-self.yml` dispatch.
 
-**CI:** `ci-scripts.yml` (bats + inline-sync + workflow-call lint), `ci-cooldown.yml` (dogfoods `dependency-cooldown.yml` on this repo's own Dependabot PRs), `security.yml` (zizmor workflow analysis).
+**CI:** `ci-scripts.yml` (bats + inline-sync + workflow-call lint), `ci-safety.yml` (dogfoods `dependency-safety.yml` on this repo's own Dependabot PRs), `security.yml` (zizmor workflow analysis).
 
 ## Conventions
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,4 @@ updates:
     commit-message:
       prefix: "deps"
     cooldown:
-      default-days: 7
+      default-days: 5

--- a/.github/workflows/ci-safety.yml
+++ b/.github/workflows/ci-safety.yml
@@ -1,4 +1,4 @@
-name: Dependency Cool-Down
+name: Dependency Safety
 
 on:
   pull_request:
@@ -12,11 +12,11 @@ permissions:
   issues: write
 
 concurrency:
-  group: cooldown-${{ github.event.pull_request.number }}
+  group: safety-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
-  cooldown:
-    uses: ./.github/workflows/dependency-cooldown.yml
+  safety:
+    uses: ./.github/workflows/dependency-safety.yml
     with:
       auto_merge: true

--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -616,6 +616,7 @@ jobs:
           GHSA_TOTAL=0
           OSV_TOTAL=0
           HAS_ERROR=""
+          SCAN_ERROR_COUNT=0
           declare -A ACTION_VERSIONS PY_VERSIONS
           FILTERED_RESULTS=""
           FILTERED_TOTAL=0
@@ -763,12 +764,14 @@ jobs:
               }
             ' -f "name=${ACTION}" 2>&1) || {
               HAS_ERROR="true"
+              SCAN_ERROR_COUNT=$((SCAN_ERROR_COUNT + 1))
               SCAN_RESULTS="${SCAN_RESULTS}| (GHSA query failed for \`${ACTION}\`) | - | - | GHSA |"$'\n'
               GHSA_RESULT=""
             }
 
             if [ -n "$GHSA_RESULT" ] && echo "$GHSA_RESULT" | jq -e '.errors' > /dev/null 2>&1; then
               HAS_ERROR="true"
+              SCAN_ERROR_COUNT=$((SCAN_ERROR_COUNT + 1))
               GHSA_ERR=$(echo "$GHSA_RESULT" | jq -r '.errors[0].message // "unknown error"')
               SCAN_RESULTS="${SCAN_RESULTS}| (GHSA error for \`${ACTION}\`: ${GHSA_ERR}) | - | - | GHSA |"$'\n'
               GHSA_RESULT=""
@@ -823,6 +826,7 @@ jobs:
               -d "$OSV_BODY" \
               2>&1) || {
               HAS_ERROR="true"
+              SCAN_ERROR_COUNT=$((SCAN_ERROR_COUNT + 1))
               SCAN_RESULTS="${SCAN_RESULTS}| (OSV query failed for \`${ACTION}\`) | - | - | OSV |"$'\n'
               OSV_RESULT=""
             }
@@ -872,12 +876,14 @@ jobs:
               }
             ' -f "name=${PKG}" 2>&1) || {
               HAS_ERROR="true"
+              SCAN_ERROR_COUNT=$((SCAN_ERROR_COUNT + 1))
               SCAN_RESULTS="${SCAN_RESULTS}| (GHSA query failed for \`${PKG}\`) | - | - | GHSA |"$'\n'
               GHSA_RESULT=""
             }
 
             if [ -n "$GHSA_RESULT" ] && echo "$GHSA_RESULT" | jq -e '.errors' > /dev/null 2>&1; then
               HAS_ERROR="true"
+              SCAN_ERROR_COUNT=$((SCAN_ERROR_COUNT + 1))
               GHSA_ERR=$(echo "$GHSA_RESULT" | jq -r '.errors[0].message // "unknown error"')
               SCAN_RESULTS="${SCAN_RESULTS}| (GHSA error for \`${PKG}\`: ${GHSA_ERR}) | - | - | GHSA |"$'\n'
               GHSA_RESULT=""
@@ -932,6 +938,7 @@ jobs:
               -d "$OSV_BODY" \
               2>&1) || {
               HAS_ERROR="true"
+              SCAN_ERROR_COUNT=$((SCAN_ERROR_COUNT + 1))
               SCAN_RESULTS="${SCAN_RESULTS}| (OSV query failed for \`${PKG}\`) | - | - | OSV |"$'\n'
               OSV_RESULT=""
             }
@@ -993,14 +1000,10 @@ jobs:
           AGE_VIOLATION_COUNT=$(echo "$AGE_TSV" | awk -F'\t' '$6=="fail"'  | wc -l | tr -d ' ')
           AGE_ERROR_COUNT=$(    echo "$AGE_TSV" | awk -F'\t' '$6=="error"' | wc -l | tr -d ' ')
 
-          # SCAN_ERROR_COUNT = GHSA/OSV failures (scorecard failures are NOT blocking).
-          # The existing code sets HAS_ERROR=true on any GHSA/OSV failure but doesn't
-          # count individual failures; we conservatively report 1 if any occurred.
-          if [ -n "${HAS_ERROR:-}" ]; then
-            SCAN_ERROR_COUNT=1
-          else
-            SCAN_ERROR_COUNT=0
-          fi
+          # SCAN_ERROR_COUNT is incremented at each GHSA/OSV failure point in the
+          # scan loops above (scorecard failures are NOT counted — they're not
+          # blocking). HAS_ERROR is preserved alongside as the legacy boolean
+          # consumers below still test for.
 
           # Map GUARD_TRIGGERED to lowercase string the script expects.
           if [ "$GUARD_TRIGGERED" = "true" ]; then

--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -1,0 +1,1095 @@
+name: Dependency Safety
+
+on:
+  workflow_call:
+    inputs:
+      enable_scorecard:
+        type: boolean
+        default: true
+        description: "Include OpenSSF Scorecard in scan results"
+      auto_merge:
+        type: boolean
+        default: false
+        description: "Auto-merge clean PRs after scan completes"
+      cooldown_days:
+        type: number
+        default: 7
+        description: "Minimum release age in days before auto-merge is allowed. 0 disables the release-age gate entirely (pre-v2.0.2 behavior)."
+      fail_on_cooldown:
+        type: boolean
+        default: false
+        description: "If true, cooldown blocks set the gate to failure instead of pending. Use when branch protection requires a hard-red blocker."
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    # Gate discipline (see #29): `Set initial status` must be the first
+    # step after `Harden runner`. Every subsequent step must carry
+    # `if: steps.gate.outputs.skip == 'false'` unless it is itself part
+    # of the gate. This avoids making non-bot PRs pay for fallible work
+    # (cross-repo fetches, API calls, script execution) that would only
+    # be used for Dependabot PRs.
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Set initial status
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          if [[ "$PR_AUTHOR" != "dependabot[bot]" ]]; then
+            gh api "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
+              -f state="success" \
+              -f context="dependency-safety / gate" \
+              -f description="Non-bot PR — no cool-down required"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            gh api "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
+              -f state="pending" \
+              -f context="dependency-safety / gate" \
+              -f description="Scanning dependencies for known exploits..."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Scan and report
+        if: steps.gate.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          ENABLE_SCORECARD: ${{ inputs.enable_scorecard }}
+          AUTO_MERGE: ${{ inputs.auto_merge }}
+          COOLDOWN_DAYS: ${{ inputs.cooldown_days }}
+          FAIL_ON_COOLDOWN: ${{ inputs.fail_on_cooldown }}
+        run: |
+          # --- BEGIN inline:scripts/extract-deps.sh ---
+          extract_deps() (
+          # extract-deps.sh — parse unified diff on stdin, emit dependency TSV on stdout
+          #
+          # Output: <name>\t<version>\t<ecosystem>  where ecosystem ∈ {actions, pypi}
+          # Exit:   0 on success (possibly zero rows), 2 on malformed input
+          #
+          # Handles THREE shapes observed in real PR diffs:
+          #   1. GitHub Actions `uses:` lines (single-line name@version)
+          #   2. pip/requirements `name==version` single-line format
+          #   3. TOML lockfile [[package]] stanzas (uv.lock, poetry.lock) where the
+          #      name line may be on an unchanged context line while only the version
+          #      is `+`-prefixed — section-aware parsing required.
+          #
+          # The TOML lockfile parser addresses issue #52: Dependabot bumps to uv.lock
+          # and poetry.lock previously yielded zero rows, cascading to silent-green
+          # cooldown gates on unscanned code.
+
+          set -euo pipefail
+
+          # pypi-shape lockfiles only. Cargo.lock / package-lock.json would need
+          # downstream ecosystem support (registry clients, OSV enums) before rows
+          # could be scanned — the fail-loud guard in dependency-cooldown.yml covers
+          # unhandled lockfiles.
+          filename_to_ecosystem() {
+            case "$1" in
+              uv.lock|poetry.lock) echo "pypi" ;;
+              *) echo "" ;;
+            esac
+          }
+
+          # Dedup sentinel: newline-delimited list of "ecosystem:name" keys.
+          # Plain string (not `declare -A`) for bash 3.2 compatibility — macOS ships
+          # bash 3.2 and bats invokes bash directly.
+          seen=$'\n'
+          rows=()
+
+          # Lockfile parser state
+          current_file=""
+          current_name=""
+          current_ecosystem=""
+
+          input=$(cat)
+
+          # Empty input → exit 0 with no output
+          if [ -z "$input" ]; then
+            exit 0
+          fi
+
+          # Malformed input detection: here-string (not pipeline) to avoid SIGPIPE
+          # under pipefail on large valid diffs (issue #50).
+          if ! grep -qE '^(\+\+\+|---|@@|diff --git)' <<< "$input"; then
+            echo "extract-deps.sh: input is not a unified diff" >&2
+            exit 2
+          fi
+
+          while IFS= read -r line; do
+            # Strip CR for CRLF-encoded diffs
+            line="${line%$'\r'}"
+
+            # --- Branch 1: diff --git file header — track current file/ecosystem ---
+            if [[ "$line" =~ ^diff[[:space:]]--git[[:space:]]a/([^[:space:]]+)[[:space:]]b/([^[:space:]]+) ]]; then
+              current_file="${BASH_REMATCH[2]##*/}"
+              current_ecosystem=$(filename_to_ecosystem "$current_file")
+              current_name=""
+              continue
+            fi
+
+            # Skip diff file headers (+++ b/path)
+            [[ "$line" == +++* ]] && continue
+
+            # --- Branch 3: [[package]] stanza boundary (context or +, not -) ---
+            if [ -n "$current_ecosystem" ] && [[ "$line" =~ ^[+\ ][[:space:]]*\[\[package\]\] ]]; then
+              current_name=""
+              continue
+            fi
+
+            # --- Branch 4: name = "..." line (context or +, not -) ---
+            if [ -n "$current_ecosystem" ] && [[ "$line" =~ ^[+\ ][[:space:]]*name[[:space:]]*=[[:space:]]*\"([^\"]+)\" ]]; then
+              current_name="${BASH_REMATCH[1]}"
+              continue
+            fi
+
+            # --- Branch 5: + version = "..." line (only + lines emit rows) ---
+            if [ -n "$current_ecosystem" ] && [ -n "$current_name" ] \
+               && [[ "$line" =~ ^\+[[:space:]]*version[[:space:]]*=[[:space:]]*\"([^\"]+)\" ]]; then
+              key="$current_ecosystem:$current_name"
+              case "$seen" in *$'\n'"$key"$'\n'*) continue ;; esac
+              seen="${seen}${key}"$'\n'
+              rows+=("$current_name"$'\t'"${BASH_REMATCH[1]}"$'\t'"$current_ecosystem")
+              continue
+            fi
+
+            # --- GitHub Actions parser (existing, unchanged) ---
+            if [[ "$line" =~ ^\+[[:space:]]+(-[[:space:]]+)?uses:[[:space:]]+([^[:space:]@]+)@[^[:space:]]+(.*)$ ]]; then
+              name="${BASH_REMATCH[2]}"
+              rest="${BASH_REMATCH[3]}"
+
+              [[ "$name" == ./* ]] && continue
+              [[ "$name" == docker://* ]] && continue
+
+              version=""
+              if [[ "$rest" =~ \#[[:space:]]*v?([0-9][0-9.]*) ]]; then
+                version="${BASH_REMATCH[1]}"
+              fi
+
+              key="actions:$name"
+              case "$seen" in *$'\n'"$key"$'\n'*) continue ;; esac
+              seen="${seen}${key}"$'\n'
+              rows+=("$name"$'\t'"$version"$'\t'"actions")
+              continue
+            fi
+
+            # --- Python deps parser (existing, unchanged) ---
+            [[ "$line" =~ ^\+[[:space:]]*# ]] && continue
+
+            if [[ "$line" =~ ^\+[[:space:]]*([a-zA-Z][a-zA-Z0-9_.\-]*)[[:space:]]*(==|\>=|\<=|~=|\!=|\>|\<)[[:space:]]*([0-9][0-9a-zA-Z.\-]*) ]]; then
+              name="${BASH_REMATCH[1]}"
+              version="${BASH_REMATCH[3]}"
+              key="pypi:$name"
+              case "$seen" in *$'\n'"$key"$'\n'*) continue ;; esac
+              seen="${seen}${key}"$'\n'
+              rows+=("$name"$'\t'"$version"$'\t'"pypi")
+              continue
+            fi
+          done <<< "$input"
+
+          if [ ${#rows[@]} -gt 0 ]; then
+            printf '%s\n' "${rows[@]}" | sort -t$'\t' -k1,1
+          fi
+          )
+          # --- END inline:scripts/extract-deps.sh ---
+
+          # --- BEGIN inline:scripts/diff-touches-lockfile.sh ---
+          diff_touches_lockfile() (
+          # diff-touches-lockfile.sh — detect dependency-relevant file edits in a
+          # unified diff (lockfiles, manifests, and GitHub Actions workflow YAMLs).
+          # Used by dependency-cooldown.yml's fail-loud guard to refuse green gates
+          # when the dep extractor returns zero rows on a diff that touches files
+          # which *should* have produced deps.
+          #
+          # Input:  unified diff on stdin
+          # Output: matched paths (b/ side of diff --git headers), sorted & deduped,
+          #         one per line; empty stdout if nothing matched.
+          # Exit:   0 if any dependency-relevant path touched, 1 if none, 2 on malformed input.
+
+          set -euo pipefail
+
+          input=$(cat)
+
+          if [ -z "$input" ]; then
+            exit 1
+          fi
+
+          if ! grep -qE '^diff --git ' <<< "$input"; then
+            echo "diff-touches-lockfile.sh: input is not a unified diff" >&2
+            exit 2
+          fi
+
+          matches=()
+          while IFS= read -r path; do
+            base="${path##*/}"
+            # Add new lockfile/manifest filename patterns to this case list as needed.
+            case "$base" in
+              *.lock|requirements*.txt|pyproject.toml|Pipfile|go.mod|Cargo.toml \
+                |package.json|package-lock.json|yarn.lock|pnpm-lock.yaml)
+                matches+=("$path")
+                continue
+                ;;
+            esac
+            # GitHub Actions workflow YAMLs are dependency declarations (uses: lines).
+            # Matched by full path, not basename, to avoid over-triggering on any *.yml.
+            case "$path" in
+              .github/workflows/*.yml|.github/workflows/*.yaml)
+                matches+=("$path")
+                ;;
+            esac
+          done < <(grep -oE '^diff --git a/[^ ]+ b/[^ ]+' <<< "$input" \
+                   | sed -E 's|^diff --git a/[^ ]+ b/||')
+
+          if [ ${#matches[@]} -eq 0 ]; then
+            exit 1
+          fi
+
+          printf '%s\n' "${matches[@]}" | sort -u
+          )
+          # --- END inline:scripts/diff-touches-lockfile.sh ---
+
+          # --- BEGIN inline:scripts/pr-body-to-deps.sh ---
+          pr_body_to_deps() (
+          # pr-body-to-deps.sh — extract Dependabot dep bumps from a PR body, emit TSV.
+          # Defense-in-depth fallback for when extract-deps.sh returns zero rows.
+          #
+          # Arg:    <ecosystem>  — 'pypi' or 'actions'; emitted verbatim in TSV col 3.
+          # Input:  PR body text on stdin.
+          # Output: <name>\t<version>\t<ecosystem>  sorted, deduplicated.
+          # Exit:   0 on success (including zero rows), 2 if ecosystem arg invalid.
+
+          set -euo pipefail
+
+          ecosystem="${1:-}"
+          case "$ecosystem" in
+            pypi|actions) ;;
+            *) echo "pr-body-to-deps.sh: ecosystem must be 'pypi' or 'actions'" >&2; exit 2 ;;
+          esac
+
+          input=$(cat)
+          [ -z "$input" ] && exit 0
+
+          seen=$'\n'
+          rows=()
+          VER='[0-9][0-9A-Za-z.+!\-]*'
+
+          # Regex patterns stored in variables — bash 3.2 on macOS cannot parse certain
+          # metacharacters (like `)`) inline within [[ =~ ]] conditionals.
+          # Pattern A — Bumps [name](url) from X to Y. The URL is consumed explicitly
+          # via \([^)]+\) rather than a character class, because earlier attempts using
+          # [^f]* silently dropped any bump whose URL contained `f` (e.g. `ruff`).
+          re_a="^Bumps[[:space:]]\[([^]]+)\]\([^)]+\)[[:space:]]+from[[:space:]]+${VER}[[:space:]]+to[[:space:]]+(${VER})"
+          # Pattern B — Updates `name` from X to Y (anchored at column 0 to avoid
+          # matching blockquote/release-notes content which is typically indented)
+          re_b="^Updates[[:space:]]\`([^\`]+)\`[[:space:]]+from[[:space:]]+${VER}[[:space:]]+to[[:space:]]+(${VER})"
+          # Pattern C — | [name](url) | `fromVer` | `toVer` |
+          re_c="^\|[[:space:]]+\[([^]]+)\]\([^)]+\)[[:space:]]+\|[[:space:]]+\`${VER}\`[[:space:]]+\|[[:space:]]+\`(${VER})\`[[:space:]]+\|"
+
+          while IFS= read -r line; do
+            line="${line%$'\r'}"
+            name=""
+            version=""
+
+            if [[ "$line" =~ $re_a ]]; then
+              name="${BASH_REMATCH[1]}"; version="${BASH_REMATCH[2]}"
+            elif [[ "$line" =~ $re_b ]]; then
+              name="${BASH_REMATCH[1]}"; version="${BASH_REMATCH[2]}"
+            elif [[ "$line" =~ $re_c ]]; then
+              name="${BASH_REMATCH[1]}"; version="${BASH_REMATCH[2]}"
+            fi
+
+            [ -z "$name" ] && continue
+
+            # Strip trailing sentence punctuation from the version (e.g. "2.13.0."
+            # in Pattern A's "Bumps ... from X to Y." lines).
+            version="${version%.}"
+
+            key="$ecosystem:$name"
+            case "$seen" in *$'\n'"$key"$'\n'*) continue ;; esac
+            seen="${seen}${key}"$'\n'
+            rows+=("$name"$'\t'"$version"$'\t'"$ecosystem")
+          done <<< "$input"
+
+          if [ ${#rows[@]} -gt 0 ]; then
+            printf '%s\n' "${rows[@]}" | sort -t$'\t' -k1,1
+          fi
+          )
+          # --- END inline:scripts/pr-body-to-deps.sh ---
+
+          # --- BEGIN inline:scripts/check-release-age.sh ---
+          check_release_age() (
+          # check-release-age.sh — read dep TSV on stdin, emit verdict TSV on stdout
+          #
+          # Schema:
+          #   in:  <name>\t<version>\t<ecosystem>
+          #   out: <name>\t<version>\t<ecosystem>\t<published_iso>\t<age_days>\t<verdict>\t<reason>
+          #
+          # Verdicts: pass | fail | error
+          # Exit: always 0; failures are per-row.
+          #
+          # Bash 3.2 compatible (macOS system bash).
+
+          set -uo pipefail
+
+          : "${COOLDOWN_DAYS:?COOLDOWN_DAYS env var is required}"
+          : "${NOW_EPOCH:=$(date +%s)}"
+
+          # iso_to_epoch <iso> — print unix epoch on stdout, return 1 on parse failure.
+          # Handles both GitHub ("2026-03-29T12:00:00Z") and PyPI ("2026-03-29T12:00:00")
+          # ISO variants across GNU and BSD date.
+          iso_to_epoch() {
+            local iso="$1"
+            # GNU date: accepts the ISO string as-is (with or without Z).
+            date -u -d "$iso" +%s 2>/dev/null && return 0
+            # GNU date: append Z for naive PyPI upload_time.
+            date -u -d "${iso}Z" +%s 2>/dev/null && return 0
+            # BSD date (macOS): strip trailing Z and parse via -jf.
+            local stripped="${iso%Z}"
+            date -u -jf '%Y-%m-%dT%H:%M:%S' "$stripped" +%s 2>/dev/null && return 0
+            return 1
+          }
+
+          # fetch_github <owner> <repo> <version> — print published_at ISO on stdout, return 1 on failure.
+          fetch_github() {
+            local owner="$1" repo="$2" version="$3"
+            if [ -n "${AGE_FIXTURE_DIR:-}" ]; then
+              local fx="$AGE_FIXTURE_DIR/github/$owner/$repo/releases/tags/v$version.json"
+              [ -f "$fx" ] || return 1
+              jq -r '.published_at // empty' "$fx"
+              return 0
+            fi
+            local resp
+            if ! resp=$(gh api "repos/$owner/$repo/releases/tags/v$version" 2>/dev/null); then
+              sleep 2
+              if ! resp=$(gh api "repos/$owner/$repo/releases/tags/v$version" 2>/dev/null); then
+                return 1
+              fi
+            fi
+            printf '%s' "$resp" | jq -r '.published_at // empty'
+          }
+
+          # fetch_pypi <pkg> <version> — print "<upload_time>\t<yanked_bool>" on stdout, return 1 on failure.
+          fetch_pypi() {
+            local pkg="$1" version="$2"
+            local upload yanked
+            if [ -n "${AGE_FIXTURE_DIR:-}" ]; then
+              local fx="$AGE_FIXTURE_DIR/pypi/$pkg/$version.json"
+              [ -f "$fx" ] || return 1
+              upload=$(jq -r '.urls[0].upload_time // empty' "$fx")
+              yanked=$(jq -r '.urls[0].yanked // false' "$fx")
+              printf '%s\t%s\n' "$upload" "$yanked"
+              return 0
+            fi
+            local resp
+            if ! resp=$(curl -sf --max-time 30 "https://pypi.org/pypi/$pkg/$version/json" 2>/dev/null); then
+              sleep 2
+              if ! resp=$(curl -sf --max-time 30 "https://pypi.org/pypi/$pkg/$version/json" 2>/dev/null); then
+                return 1
+              fi
+            fi
+            upload=$(printf '%s' "$resp" | jq -r '.urls[0].upload_time // empty')
+            yanked=$(printf '%s' "$resp" | jq -r '.urls[0].yanked // false')
+            printf '%s\t%s\n' "$upload" "$yanked"
+          }
+
+          # emit name version ecosystem published age verdict reason
+          emit() {
+            printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5" "$6" "$7"
+          }
+
+          while IFS=$'\t' read -r name version ecosystem || [ -n "${name:-}" ]; do
+            [ -z "${name:-}" ] && continue
+
+            # Escape hatch: COOLDOWN_DAYS=0 → all pass without lookup.
+            if [ "$COOLDOWN_DAYS" -eq 0 ]; then
+              emit "$name" "$version" "$ecosystem" "-" "-" "pass" ""
+              continue
+            fi
+
+            case "$ecosystem" in
+              actions)
+                owner="${name%%/*}"
+                remainder="${name#*/}"
+                repo="${remainder%%/*}"
+                if ! iso=$(fetch_github "$owner" "$repo" "$version"); then
+                  emit "$name" "$version" "$ecosystem" "-" "-" "error" "tier-1-404"
+                  continue
+                fi
+                if [ -z "$iso" ]; then
+                  emit "$name" "$version" "$ecosystem" "-" "-" "error" "transient-failure"
+                  continue
+                fi
+                if ! pub_epoch=$(iso_to_epoch "$iso"); then
+                  emit "$name" "$version" "$ecosystem" "-" "-" "error" "parse-failure"
+                  continue
+                fi
+                age_days=$(( (NOW_EPOCH - pub_epoch) / 86400 ))
+                if [ "$age_days" -ge "$COOLDOWN_DAYS" ]; then
+                  emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "pass" ""
+                else
+                  emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "fail" ""
+                fi
+                ;;
+
+              pypi)
+                if ! result=$(fetch_pypi "$name" "$version"); then
+                  emit "$name" "$version" "$ecosystem" "-" "-" "error" "pypi-404"
+                  continue
+                fi
+                iso="${result%%$'\t'*}"
+                yanked="${result##*$'\t'}"
+                if [ -z "$iso" ]; then
+                  emit "$name" "$version" "$ecosystem" "-" "-" "error" "transient-failure"
+                  continue
+                fi
+                if ! pub_epoch=$(iso_to_epoch "$iso"); then
+                  emit "$name" "$version" "$ecosystem" "-" "-" "error" "parse-failure"
+                  continue
+                fi
+                age_days=$(( (NOW_EPOCH - pub_epoch) / 86400 ))
+                if [ "$yanked" = "true" ]; then
+                  emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "fail" "yanked"
+                elif [ "$age_days" -ge "$COOLDOWN_DAYS" ]; then
+                  emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "pass" ""
+                else
+                  emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "fail" ""
+                fi
+                ;;
+
+              *)
+                emit "$name" "$version" "$ecosystem" "-" "-" "error" "unknown-ecosystem"
+                ;;
+            esac
+          done
+
+          exit 0
+          )
+          # --- END inline:scripts/check-release-age.sh ---
+
+          DIFF=$(gh pr diff "$PR_NUMBER" --repo "$GH_REPO")
+
+          DEPS=""
+          SCAN_RESULTS=""
+          GHSA_TOTAL=0
+          OSV_TOTAL=0
+          HAS_ERROR=""
+          declare -A ACTION_VERSIONS PY_VERSIONS
+          FILTERED_RESULTS=""
+          FILTERED_TOTAL=0
+
+          # Fetch PR body for Dependabot version fallback
+          PR_BODY=$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json body --jq '.body // ""')
+
+          # --- Extract dependencies via standalone script (Task 8) ---
+          DEPS_TSV=$(echo "$DIFF" | extract_deps)
+
+          # --- Layer 2: PR-body fallback (defense in depth for issue #52) ---
+          TOUCHED_PATHS=""
+          if [ -z "$(echo "$DEPS_TSV" | sed '/^$/d')" ]; then
+            TOUCHED_PATHS=$(echo "$DIFF" | diff_touches_lockfile 2>/dev/null || true)
+            # Keep the pypi regex below in sync with filename_to_ecosystem() in
+            # scripts/extract-deps.sh — ONLY lockfiles the parser actually handles
+            # should route to the pypi fallback. Cargo.lock, yarn.lock, etc. are
+            # emitted by diff_touches_lockfile (for guard detection) but must NOT
+            # route here — they fall through and trip the fail-loud guard instead.
+            # Mixed-touch policy: if a PR touches BOTH a pypi lockfile AND an actions
+            # workflow YAML, pypi wins. The fallback parser handles one ecosystem per
+            # PR; actions bumps (if any) fall through to the guard and will refuse green.
+            ECO_HINT=""
+            if echo "$TOUCHED_PATHS" | grep -qE '((^|/)(uv|poetry)\.lock$|requirements[^/]*\.txt$|pyproject\.toml$|Pipfile$)'; then
+              ECO_HINT="pypi"
+            elif echo "$TOUCHED_PATHS" | grep -qE '\.github/workflows/.*\.ya?ml$'; then
+              ECO_HINT="actions"
+            fi
+            if [ -n "$ECO_HINT" ]; then
+              DEPS_TSV=$(echo "$PR_BODY" | pr_body_to_deps "$ECO_HINT" 2>/dev/null || true)
+              [ -n "$(echo "$DEPS_TSV" | sed '/^$/d')" ] && \
+                echo "Recovered $(echo "$DEPS_TSV" | wc -l | tr -d ' ') dep(s) via PR-body fallback (${ECO_HINT})"
+            fi
+          fi
+
+          # --- Layer 3: Fail-loud guard (fix for issue #52) ---
+          GUARD_TRIGGERED=false
+          if [ -z "$(echo "$DEPS_TSV" | sed '/^$/d')" ]; then
+            # Defense-in-depth: Layer 2 always sets TOUCHED_PATHS when it runs, but the
+            # ${:-} default guards against future refactors that might skip Layer 2.
+            TOUCHED_PATHS="${TOUCHED_PATHS:-$(echo "$DIFF" | diff_touches_lockfile 2>/dev/null || true)}"
+            if [ -n "$TOUCHED_PATHS" ]; then
+              GUARD_TRIGGERED=true
+              TOUCHED_LIST=$(echo "$TOUCHED_PATHS" | paste -sd, -)
+              EXTRACTION_WARNING="⚠️ Parser could not extract dependencies from this diff (touched: ${TOUCHED_LIST}). Manual review required before merge."
+            fi
+          fi
+
+          # Populate ACTIONS, PY_DEPS, ACTION_VERSIONS, PY_VERSIONS from DEPS_TSV
+          # so the existing advisory-scan loops below can consume them unchanged.
+          ACTIONS=""
+          PY_DEPS=""
+          while IFS=$'\t' read -r _name _ver _eco; do
+            [ -z "$_name" ] && continue
+            case "$_eco" in
+              actions)
+                ACTIONS="$(printf '%s\n%s' "$ACTIONS" "$_name")"
+                ACTION_VERSIONS["$_name"]="$_ver"
+                ;;
+              pypi)
+                PY_DEPS="$(printf '%s\n%s' "$PY_DEPS" "$_name")"
+                PY_VERSIONS["$_name"]="$_ver"
+                ;;
+            esac
+          done <<< "$DEPS_TSV"
+          ACTIONS=$(echo "$ACTIONS" | sed '/^$/d' | sort -u)
+          PY_DEPS=$(echo "$PY_DEPS" | sed '/^$/d' | sort -u)
+
+          # PR-body version fallback for deps without inline version (preserved from v2.0.1)
+          for ACTION in $ACTIONS; do
+            [ -z "$ACTION" ] && continue
+            if [ -z "${ACTION_VERSIONS[$ACTION]:-}" ]; then
+              _dep_ver=$(echo "$PR_BODY" | grep -F "[$ACTION]" | grep -oE 'to [0-9][0-9.]*' | head -1 | sed 's/^to //' || true)
+              ACTION_VERSIONS["$ACTION"]="$_dep_ver"
+            fi
+          done
+          for PKG in $PY_DEPS; do
+            [ -z "$PKG" ] && continue
+            if [ -z "${PY_VERSIONS[$PKG]:-}" ]; then
+              _dep_ver=$(echo "$PR_BODY" | grep -Fi "[$PKG]" | grep -oE 'to [0-9][0-9.]*' | head -1 | sed 's/^to //' || true)
+              PY_VERSIONS["$PKG"]="$_dep_ver"
+            fi
+          done
+
+          # Sanity-check: count UNIQUE action names in the diff vs extracted actions.
+          # Filters ./ (local) and docker:// actions because the extractor at
+          # scripts/extract-deps.sh:51-52 intentionally skips them — counting them
+          # here would produce a false-positive extraction-mismatch warning on any
+          # PR adding a local or docker action reference.
+          # (Task 13c — fixes regression introduced by Task 13b)
+          EXPECTED_ACTIONS=$(echo "$DIFF" \
+            | grep -oE '^\+[[:space:]]+(-[[:space:]]+)?uses:[[:space:]]+[^[:space:]@]+' \
+            | sed -E 's/^\+[[:space:]]+(-[[:space:]]+)?uses:[[:space:]]+//' \
+            | grep -vE '^(\./|docker://)' \
+            | sort -u | wc -l | tr -d ' ')
+          EXTRACTED_ACTIONS=$(echo "$ACTIONS" | sed '/^$/d' | wc -l | tr -d ' ')
+          # Do not overwrite a guard-set EXTRACTION_WARNING.
+          if [ -z "${EXTRACTION_WARNING:-}" ]; then
+            EXTRACTION_WARNING=""
+            if [ "$EXPECTED_ACTIONS" != "$EXTRACTED_ACTIONS" ]; then
+              EXTRACTION_WARNING="⚠️ Extraction mismatch: diff contains ${EXPECTED_ACTIONS} unique action(s), extractor returned ${EXTRACTED_ACTIONS}. This may indicate a silent parsing failure. Please report."
+            fi
+          fi
+
+          # --- Check release age via standalone script (Task 9 — phase 2) ---
+          COOLDOWN_FAILURES=0
+          AGE_TSV=""
+          if [ "$COOLDOWN_DAYS" -gt 0 ]; then
+            # check_release_age must be invoked via command substitution so
+            # bash's parent -e is dropped — this preserves per-row error
+            # tolerance (404s, parse failures, etc. emit error verdicts
+            # instead of killing the step). Do not convert to a direct call.
+            AGE_TSV=$(echo "$DEPS_TSV" | check_release_age)
+            COOLDOWN_FAILURES=$(echo "$AGE_TSV" | awk -F'\t' '$6=="fail" || $6=="error"' | wc -l | tr -d ' ')
+          fi
+
+          for ACTION in $ACTIONS; do
+            [ -z "$ACTION" ] && continue
+            _ver="${ACTION_VERSIONS[$ACTION]}"
+            if [ -n "$_ver" ]; then
+              DEPS="${DEPS}\`${ACTION}\` (v${_ver}), "
+            else
+              DEPS="${DEPS}\`${ACTION}\`, "
+            fi
+
+            GHSA_RESULT=$(gh api graphql -f query='
+              query($name: String!) {
+                securityVulnerabilities(
+                  ecosystem: ACTIONS
+                  package: $name
+                  first: 10
+                ) {
+                  nodes {
+                    advisory {
+                      ghsaId
+                      severity
+                      summary
+                    }
+                    vulnerableVersionRange
+                    firstPatchedVersion {
+                      identifier
+                    }
+                  }
+                }
+              }
+            ' -f "name=${ACTION}" 2>&1) || {
+              HAS_ERROR="true"
+              SCAN_RESULTS="${SCAN_RESULTS}| (GHSA query failed for \`${ACTION}\`) | - | - | GHSA |"$'\n'
+              GHSA_RESULT=""
+            }
+
+            if [ -n "$GHSA_RESULT" ] && echo "$GHSA_RESULT" | jq -e '.errors' > /dev/null 2>&1; then
+              HAS_ERROR="true"
+              GHSA_ERR=$(echo "$GHSA_RESULT" | jq -r '.errors[0].message // "unknown error"')
+              SCAN_RESULTS="${SCAN_RESULTS}| (GHSA error for \`${ACTION}\`: ${GHSA_ERR}) | - | - | GHSA |"$'\n'
+              GHSA_RESULT=""
+            fi
+
+            if [ -n "$GHSA_RESULT" ]; then
+              _target_ver="${ACTION_VERSIONS[$ACTION]}"
+
+              if [ -n "$_target_ver" ]; then
+                while IFS=$'\t' read -r _g_id _g_sev _g_sum _g_patched; do
+                  [ -z "$_g_id" ] && continue
+                  if [ -n "$_g_patched" ]; then
+                    _lowest=$(printf '%s\n' "$_g_patched" "$_target_ver" | sort -V | head -1)
+                    if [ "$_lowest" = "$_g_patched" ]; then
+                      FILTERED_RESULTS="${FILTERED_RESULTS}| ${_g_id} | ${_g_sev} | ${_g_sum} | GHSA | ${_g_patched} |"$'\n'
+                      FILTERED_TOTAL=$((FILTERED_TOTAL + 1))
+                      continue
+                    fi
+                  fi
+                  SCAN_RESULTS="${SCAN_RESULTS}| ${_g_id} | ${_g_sev} | ${_g_sum} | GHSA |"$'\n'
+                  GHSA_TOTAL=$((GHSA_TOTAL + 1))
+                done <<< "$(echo "$GHSA_RESULT" | jq -r '
+                  .data.securityVulnerabilities.nodes[] |
+                  [.advisory.ghsaId, .advisory.severity, .advisory.summary, ((.firstPatchedVersion.identifier // "") | ltrimstr("v"))] |
+                  @tsv
+                ' 2>/dev/null || true)"
+              else
+                GHSA_VULNS=$(echo "$GHSA_RESULT" | jq -r '
+                  .data.securityVulnerabilities.nodes[] |
+                  "| \(.advisory.ghsaId) | \(.advisory.severity) | \(.advisory.summary) | GHSA |"
+                ' 2>/dev/null || true)
+
+                if [ -n "$GHSA_VULNS" ]; then
+                  GHSA_COUNT=$(echo "$GHSA_VULNS" | wc -l | tr -d ' ')
+                  GHSA_TOTAL=$((GHSA_TOTAL + GHSA_COUNT))
+                  SCAN_RESULTS="${SCAN_RESULTS}${GHSA_VULNS}"$'\n'
+                fi
+              fi
+            fi
+
+            _target_ver="${ACTION_VERSIONS[$ACTION]}"
+            if [ -n "$_target_ver" ]; then
+              OSV_BODY=$(jq -n --arg name "$ACTION" --arg eco "GitHub Actions" --arg ver "$_target_ver" \
+                '{"package":{"name":$name,"ecosystem":$eco},"version":$ver}')
+            else
+              OSV_BODY=$(jq -n --arg name "$ACTION" --arg eco "GitHub Actions" \
+                '{"package":{"name":$name,"ecosystem":$eco}}')
+            fi
+            OSV_RESULT=$(curl -sf --max-time 30 \
+              -X POST "https://api.osv.dev/v1/query" \
+              -H "Content-Type: application/json" \
+              -d "$OSV_BODY" \
+              2>&1) || {
+              HAS_ERROR="true"
+              SCAN_RESULTS="${SCAN_RESULTS}| (OSV query failed for \`${ACTION}\`) | - | - | OSV |"$'\n'
+              OSV_RESULT=""
+            }
+
+            if [ -n "$OSV_RESULT" ]; then
+              OSV_VULNS=$(echo "$OSV_RESULT" | jq -r '
+                .vulns[]? |
+                "| \(.id) | \(.database_specific.severity // "UNKNOWN") | \(.summary // .details[:80]) | OSV |"
+              ' 2>/dev/null || true)
+
+              if [ -n "$OSV_VULNS" ]; then
+                OSV_COUNT=$(echo "$OSV_VULNS" | wc -l | tr -d ' ')
+                OSV_TOTAL=$((OSV_TOTAL + OSV_COUNT))
+                SCAN_RESULTS="${SCAN_RESULTS}${OSV_VULNS}"$'\n'
+              fi
+            fi
+          done
+
+          for PKG in $PY_DEPS; do
+            [ -z "$PKG" ] && continue
+            _ver="${PY_VERSIONS[$PKG]}"
+            if [ -n "$_ver" ]; then
+              DEPS="${DEPS}\`${PKG}\` (v${_ver}), "
+            else
+              DEPS="${DEPS}\`${PKG}\`, "
+            fi
+
+            GHSA_RESULT=$(gh api graphql -f query='
+              query($name: String!) {
+                securityVulnerabilities(
+                  ecosystem: PIP
+                  package: $name
+                  first: 10
+                ) {
+                  nodes {
+                    advisory {
+                      ghsaId
+                      severity
+                      summary
+                    }
+                    vulnerableVersionRange
+                    firstPatchedVersion {
+                      identifier
+                    }
+                  }
+                }
+              }
+            ' -f "name=${PKG}" 2>&1) || {
+              HAS_ERROR="true"
+              SCAN_RESULTS="${SCAN_RESULTS}| (GHSA query failed for \`${PKG}\`) | - | - | GHSA |"$'\n'
+              GHSA_RESULT=""
+            }
+
+            if [ -n "$GHSA_RESULT" ] && echo "$GHSA_RESULT" | jq -e '.errors' > /dev/null 2>&1; then
+              HAS_ERROR="true"
+              GHSA_ERR=$(echo "$GHSA_RESULT" | jq -r '.errors[0].message // "unknown error"')
+              SCAN_RESULTS="${SCAN_RESULTS}| (GHSA error for \`${PKG}\`: ${GHSA_ERR}) | - | - | GHSA |"$'\n'
+              GHSA_RESULT=""
+            fi
+
+            if [ -n "$GHSA_RESULT" ]; then
+              _target_ver="${PY_VERSIONS[$PKG]}"
+
+              if [ -n "$_target_ver" ]; then
+                while IFS=$'\t' read -r _g_id _g_sev _g_sum _g_patched; do
+                  [ -z "$_g_id" ] && continue
+                  if [ -n "$_g_patched" ]; then
+                    _lowest=$(printf '%s\n' "$_g_patched" "$_target_ver" | sort -V | head -1)
+                    if [ "$_lowest" = "$_g_patched" ]; then
+                      FILTERED_RESULTS="${FILTERED_RESULTS}| ${_g_id} | ${_g_sev} | ${_g_sum} | GHSA | ${_g_patched} |"$'\n'
+                      FILTERED_TOTAL=$((FILTERED_TOTAL + 1))
+                      continue
+                    fi
+                  fi
+                  SCAN_RESULTS="${SCAN_RESULTS}| ${_g_id} | ${_g_sev} | ${_g_sum} | GHSA |"$'\n'
+                  GHSA_TOTAL=$((GHSA_TOTAL + 1))
+                done <<< "$(echo "$GHSA_RESULT" | jq -r '
+                  .data.securityVulnerabilities.nodes[] |
+                  [.advisory.ghsaId, .advisory.severity, .advisory.summary, ((.firstPatchedVersion.identifier // "") | ltrimstr("v"))] |
+                  @tsv
+                ' 2>/dev/null || true)"
+              else
+                GHSA_VULNS=$(echo "$GHSA_RESULT" | jq -r '
+                  .data.securityVulnerabilities.nodes[] |
+                  "| \(.advisory.ghsaId) | \(.advisory.severity) | \(.advisory.summary) | GHSA |"
+                ' 2>/dev/null || true)
+
+                if [ -n "$GHSA_VULNS" ]; then
+                  GHSA_COUNT=$(echo "$GHSA_VULNS" | wc -l | tr -d ' ')
+                  GHSA_TOTAL=$((GHSA_TOTAL + GHSA_COUNT))
+                  SCAN_RESULTS="${SCAN_RESULTS}${GHSA_VULNS}"$'\n'
+                fi
+              fi
+            fi
+
+            _target_ver="${PY_VERSIONS[$PKG]}"
+            if [ -n "$_target_ver" ]; then
+              OSV_BODY=$(jq -n --arg name "$PKG" --arg eco "PyPI" --arg ver "$_target_ver" \
+                '{"package":{"name":$name,"ecosystem":$eco},"version":$ver}')
+            else
+              OSV_BODY=$(jq -n --arg name "$PKG" --arg eco "PyPI" \
+                '{"package":{"name":$name,"ecosystem":$eco}}')
+            fi
+            OSV_RESULT=$(curl -sf --max-time 30 \
+              -X POST "https://api.osv.dev/v1/query" \
+              -H "Content-Type: application/json" \
+              -d "$OSV_BODY" \
+              2>&1) || {
+              HAS_ERROR="true"
+              SCAN_RESULTS="${SCAN_RESULTS}| (OSV query failed for \`${PKG}\`) | - | - | OSV |"$'\n'
+              OSV_RESULT=""
+            }
+
+            if [ -n "$OSV_RESULT" ]; then
+              OSV_VULNS=$(echo "$OSV_RESULT" | jq -r '
+                .vulns[]? |
+                "| \(.id) | \(.database_specific.severity // "UNKNOWN") | \(.summary // .details[:80]) | OSV |"
+              ' 2>/dev/null || true)
+
+              if [ -n "$OSV_VULNS" ]; then
+                OSV_COUNT=$(echo "$OSV_VULNS" | wc -l | tr -d ' ')
+                OSV_TOTAL=$((OSV_TOTAL + OSV_COUNT))
+                SCAN_RESULTS="${SCAN_RESULTS}${OSV_VULNS}"$'\n'
+              fi
+            fi
+          done
+
+          # --- OpenSSF Scorecard (GitHub Actions only) ---
+          SCORECARD_TABLE=""
+          if [[ "$ENABLE_SCORECARD" == "true" ]]; then
+            for ACTION in $ACTIONS; do
+              [ -z "$ACTION" ] && continue
+              SC_RESULT=$(curl -sf --max-time 30 \
+                "https://api.securityscorecards.dev/projects/github.com/${ACTION}" \
+                2>/dev/null) || SC_RESULT=""
+
+              if [ -z "$SC_RESULT" ]; then
+                SCORECARD_TABLE="${SCORECARD_TABLE}| \`${ACTION}\` | Not available | - |"$'\n'
+              else
+                SC_SCORE=$(echo "$SC_RESULT" | jq -r '.score // "N/A"')
+                SC_URL="https://scorecard.dev/viewer/?uri=github.com/${ACTION}"
+                SCORECARD_TABLE="${SCORECARD_TABLE}| \`${ACTION}\` | ${SC_SCORE}/10 | [View](${SC_URL}) |"$'\n'
+              fi
+            done
+          fi
+
+          SCORECARD_SECTION=""
+          if [ -n "$SCORECARD_TABLE" ]; then
+            SC_HDR="| Action | Score | Details |"
+            SC_SEP="|--------|-------|---------|"
+            SCORECARD_SECTION="$(printf '\n### Project Health (OpenSSF Scorecard)\n\n%s\n%s\n%s' \
+              "$SC_HDR" "$SC_SEP" "$SCORECARD_TABLE")"
+          fi
+
+          # Strip trailing comma-space from DEPS
+          DEPS=$(echo "$DEPS" | sed 's/, $//')
+
+          if [ -z "$DEPS" ]; then
+            DEPS="(no dependencies extracted from diff)"
+          fi
+
+          # --- Build comment body ---
+          TOTAL=$((GHSA_TOTAL + OSV_TOTAL))
+
+          # --- Label reconciliation (Task 13b — authoritative on clean runs, additive-only on HAS_ERROR paths) ---
+          LABEL_COLOR_security_review_needed="B60205"
+          LABEL_DESC_security_review_needed="Dependency scan found advisories — manual review required"
+          LABEL_COLOR_cooldown_pending="FBCA04"
+          LABEL_DESC_cooldown_pending="One or more target versions are within the configured cooldown window"
+
+          reconcile_label() {
+            local label="$1"
+            local should_be_present="$2"
+            local color="$3"
+            local desc="$4"
+            local current has_it
+            current=$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json labels --jq '[.labels[].name]')
+            has_it=$(echo "$current" | jq -e --arg l "$label" 'contains([$l])' >/dev/null && echo true || echo false)
+
+            if [ "$should_be_present" = "true" ] && [ "$has_it" = "false" ]; then
+              gh label create "$label" --repo "$GH_REPO" --color "$color" --description "$desc" --force >/dev/null 2>&1 || true
+              gh pr edit "$PR_NUMBER" --repo "$GH_REPO" --add-label "$label" || true
+              echo "Applied label: $label"
+            elif [ "$should_be_present" = "false" ] && [ "$has_it" = "true" ] && [ -z "${HAS_ERROR:-}" ]; then
+              gh pr edit "$PR_NUMBER" --repo "$GH_REPO" --remove-label "$label" || true
+              echo "Removed stale label: $label"
+            elif [ "$should_be_present" = "false" ] && [ "$has_it" = "true" ]; then
+              echo "Preserving label $label: scan had API errors, verdict is unreliable"
+            fi
+          }
+
+          _needs_security=$([ "$TOTAL" -gt 0 ] && echo true || echo false)
+          _needs_cooldown=$([ "$COOLDOWN_FAILURES" -gt 0 ] && echo true || echo false)
+          reconcile_label "security-review-needed" "$_needs_security" "$LABEL_COLOR_security_review_needed" "$LABEL_DESC_security_review_needed"
+          reconcile_label "cooldown-pending"       "$_needs_cooldown" "$LABEL_COLOR_cooldown_pending"       "$LABEL_DESC_cooldown_pending"
+
+          # Guard-triggered runs must not compose a clean-scan narrative — the
+          # gate state machine below flips status to `error`, and the comment
+          # needs to agree (rather than claim "No known exploits" + auto-merge
+          # enabled on a run we refused to scan). The EXTRACTION_WARNING_SECTION
+          # prepended later (~line 960) still carries the detailed path list.
+          if [ "$GUARD_TRIGGERED" = "true" ]; then
+            RESULTS_HEADER="Dependency extraction failed — manual review required."
+            TABLE_HDR="| Source | Vulnerabilities |"
+            TABLE_SEP="|--------|----------------|"
+            ROW1="| GitHub Advisory (GHSA) | (not scanned) |"
+            ROW2="| OSV.dev | (not scanned) |"
+            RESULTS_TABLE="$(printf '%s\n%s\n%s\n%s' "$TABLE_HDR" "$TABLE_SEP" "$ROW1" "$ROW2")"
+            RESULTS_FOOTER="> Auto-merge not enabled — parser could not determine target versions from diff or PR body."
+          elif [ "$TOTAL" -gt 0 ]; then
+            RESULTS_HEADER="**${TOTAL} advisory/ies found** affecting target versions — review before merging."
+            TABLE_HDR="| ID | Severity | Summary | Source |"
+            TABLE_SEP="|----|----------|---------|--------|"
+            RESULTS_TABLE="$(printf '%s\n%s\n%s' "$TABLE_HDR" "$TABLE_SEP" "$SCAN_RESULTS")"
+            RESULTS_FOOTER="> Review the advisories above before deciding to merge."
+          elif [ -n "$HAS_ERROR" ]; then
+            gh api "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
+              -f state=error \
+              -f context="dependency-safety / gate" \
+              -f description="Scan failed due to API errors — re-run or push to retry."
+            exit 0
+          else
+            RESULTS_HEADER="No known exploits found affecting the target versions."
+            TABLE_HDR="| Source | Vulnerabilities |"
+            TABLE_SEP="|--------|----------------|"
+            ROW1="| GitHub Advisory (GHSA) | 0 affecting target |"
+            ROW2="| OSV.dev | 0 affecting target |"
+            RESULTS_TABLE="$(printf '%s\n%s\n%s\n%s' "$TABLE_HDR" "$TABLE_SEP" "$ROW1" "$ROW2")"
+            if [[ "$AUTO_MERGE" == "true" ]]; then
+              RESULTS_FOOTER="> Auto-merge has been enabled. This PR will merge once all status checks pass."
+            else
+              RESULTS_FOOTER="> This PR is now eligible for manual review and merge."
+            fi
+          fi
+
+          # Build collapsed historical section (non-blocking, for transparency)
+          HISTORICAL_SECTION=""
+          if [ "$FILTERED_TOTAL" -gt 0 ]; then
+            HIST_HDR="| ID | Severity | Summary | Source | Patched In |"
+            HIST_SEP="|----|----------|---------|--------|------------|"
+            HISTORICAL_SECTION="$(printf '\n\n<details>\n<summary>%d historical advisory/ies (patched at or before target version — not blocking)</summary>\n\n%s\n%s\n%s</details>' \
+              "$FILTERED_TOTAL" "$HIST_HDR" "$HIST_SEP" "$FILTERED_RESULTS")"
+          fi
+
+          # --- Release Age section (Task 12 — fixes #25 UX) ---
+          RELEASE_AGE_SECTION=""
+          if [ -n "$AGE_TSV" ]; then
+            AGE_TABLE_HDR="| Package | Version | Published | Age | Status |"
+            AGE_TABLE_SEP="|---------|---------|-----------|-----|--------|"
+            AGE_ROWS=""
+            MAX_FAIL_EPOCH=0
+            while IFS=$'\t' read -r _name _ver _eco _iso _days _verdict _reason; do
+              [ -z "$_name" ] && continue
+              case "$_verdict" in
+                pass)  _status="✅ passed" ;;
+                fail)  if [ -n "$_reason" ]; then _status="❌ blocked (${_reason})"; else _status="❌ blocked"; fi ;;
+                error) _status="⚠️ error (${_reason})" ;;
+                *)     _status="?" ;;
+              esac
+              if [ "$_iso" = "-" ]; then
+                _published_short="-"
+              else
+                _published_short="${_iso%T*}"
+              fi
+              AGE_ROWS="${AGE_ROWS}| \`${_name}\` | v${_ver} | ${_published_short} | ${_days}d | ${_status} |"$'\n'
+
+              # Track max fail epoch for "earliest unblock" footer
+              if [ "$_verdict" = "fail" ] && [ "$_iso" != "-" ]; then
+                _pub_epoch=$(date -u -d "$_iso" +%s 2>/dev/null \
+                  || date -u -d "${_iso}Z" +%s 2>/dev/null \
+                  || date -u -jf '%Y-%m-%dT%H:%M:%SZ' "$_iso" +%s 2>/dev/null \
+                  || date -u -jf '%Y-%m-%dT%H:%M:%S' "${_iso%Z}" +%s 2>/dev/null \
+                  || echo 0)
+                if [ "$_pub_epoch" -gt "$MAX_FAIL_EPOCH" ]; then
+                  MAX_FAIL_EPOCH="$_pub_epoch"
+                fi
+              fi
+            done <<< "$AGE_TSV"
+
+            AGE_FOOTER=""
+            if [ "$COOLDOWN_FAILURES" -gt 0 ] && [ "$MAX_FAIL_EPOCH" -gt 0 ]; then
+              _unblock_epoch=$(( MAX_FAIL_EPOCH + COOLDOWN_DAYS * 86400 ))
+              _unblock_iso=$(date -u -d "@$_unblock_epoch" '+%Y-%m-%d' 2>/dev/null \
+                || date -u -r "$_unblock_epoch" '+%Y-%m-%d' 2>/dev/null \
+                || echo "unknown")
+              AGE_FOOTER="$(printf '\n> %d package(s) within cooldown window. Earliest unblock: %s.' "$COOLDOWN_FAILURES" "$_unblock_iso")"
+            fi
+
+            RELEASE_AGE_SECTION="$(printf '\n### Release Age (cooldown: %s days)\n\n%s\n%s\n%s%s' \
+              "$COOLDOWN_DAYS" "$AGE_TABLE_HDR" "$AGE_TABLE_SEP" "$AGE_ROWS" "$AGE_FOOTER")"
+          fi
+
+          # --- Extraction warning section (Task 12 — surfaces #27 silent drops) ---
+          EXTRACTION_WARNING_SECTION=""
+          if [ -n "$EXTRACTION_WARNING" ]; then
+            EXTRACTION_WARNING_SECTION="$(printf '\n> %s\n' "$EXTRACTION_WARNING")"
+          fi
+
+          COMMENT_BODY="$(printf '%s%s\n\n%s\n\n%s\n\n%s\n\n%s\n\n%s%s%s%s' \
+            "## Dependency Safety Scan" \
+            "$EXTRACTION_WARNING_SECTION" \
+            "**Packages scanned:** ${DEPS}" \
+            "### Results" \
+            "$RESULTS_HEADER" \
+            "$RESULTS_TABLE" \
+            "$RESULTS_FOOTER" \
+            "$HISTORICAL_SECTION" \
+            "$RELEASE_AGE_SECTION" \
+            "$SCORECARD_SECTION")"
+
+          # --- Comment management: update-or-create with change detection ---
+          COMMENTS_JSON=$(gh api "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" --paginate)
+          EXISTING_COMMENT_ID=$(echo "$COMMENTS_JSON" | jq -r "
+            [.[] | select(
+              (.body | contains(\"<!-- dependency-safety-\")) or
+              (.body | contains(\"## Dependency Safety Scan\"))
+            )][0].id // empty")
+
+          PREV_IDS=""
+          if [ -n "$EXISTING_COMMENT_ID" ]; then
+            PREV_BODY=$(echo "$COMMENTS_JSON" | jq -r "
+              [.[] | select(.id == ${EXISTING_COMMENT_ID})][0].body")
+            PREV_ACTIVE=$(echo "$PREV_BODY" | sed '/<details>/,$d')
+            PREV_IDS=$(echo "$PREV_ACTIVE" | \
+              grep -oE '(GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}|PYSEC-[0-9]+-[0-9]+)' | \
+              sort -u | tr '\n' ',' | sed 's/,$//' || true)
+          fi
+
+          CURRENT_IDS=$(echo "$SCAN_RESULTS" | \
+            grep -oE '(GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}|PYSEC-[0-9]+-[0-9]+)' | \
+            sort -u | tr '\n' ',' | sed 's/,$//' || true)
+
+          SCAN_MARKER="<!-- dependency-safety-${PR_NUMBER} -->"
+          TIMESTAMP="Last scanned: $(date -u +'%Y-%m-%d %H:%M') UTC"
+          DIVIDER="---"
+          COMMENT_BODY="$(printf '%s\n%s\n\n%s\n_%s_' \
+            "$SCAN_MARKER" \
+            "$COMMENT_BODY" \
+            "$DIVIDER" \
+            "$TIMESTAMP")"
+
+          if [ -n "$EXISTING_COMMENT_ID" ]; then
+            gh api "repos/${GH_REPO}/issues/comments/${EXISTING_COMMENT_ID}" \
+              -X PATCH \
+              -f body="$COMMENT_BODY"
+            echo "Updated existing scan comment (ID: ${EXISTING_COMMENT_ID})"
+          else
+            gh pr comment "$PR_NUMBER" \
+              --repo "$GH_REPO" \
+              --body "$COMMENT_BODY"
+            echo "Created new scan comment"
+          fi
+
+          if [ -n "$EXISTING_COMMENT_ID" ] && [ "$PREV_IDS" != "$CURRENT_IDS" ]; then
+            CHANGE_NOTE="Advisory status changed since last scan — review updated findings above."
+            gh pr comment "$PR_NUMBER" \
+              --repo "$GH_REPO" \
+              --body "$CHANGE_NOTE"
+            echo "Posted change notification"
+          fi
+
+          # --- Gate state machine (Task 11 — combines advisory + cooldown verdicts) ---
+          if [ "$GUARD_TRIGGERED" = "true" ]; then
+            # Fail-loud guard: parser could not extract deps from a lockfile-touching
+            # diff, and the PR-body fallback also produced nothing. Refuse to issue
+            # a green gate — manual review required (fix for issue #52).
+            GATE_STATE="error"
+            STATUS_DESC="Could not extract dependencies from diff. Manual review required."
+            AUTO_MERGE_OK=false
+          elif [ "$TOTAL" -gt 0 ]; then
+            # Advisory failure wins — strictest signal (existing v2.0.1 semantic: gate=success with "review needed")
+            GATE_STATE="success"
+            STATUS_DESC="${TOTAL} advisory/ies found (version-filtered). Manual review required."
+            AUTO_MERGE_OK=false
+          elif [ "$COOLDOWN_FAILURES" -gt 0 ]; then
+            if [ "$FAIL_ON_COOLDOWN" = "true" ]; then
+              GATE_STATE="failure"
+            else
+              GATE_STATE="pending"
+            fi
+            STATUS_DESC="${COOLDOWN_FAILURES} package(s) within ${COOLDOWN_DAYS}-day cooldown window. Waiting for age."
+            AUTO_MERGE_OK=false
+          else
+            GATE_STATE="success"
+            STATUS_DESC="Clean scan (version-filtered, cooldown ≥ ${COOLDOWN_DAYS}d). Ready for merge."
+            AUTO_MERGE_OK=true
+          fi
+
+          # --- Conditional auto-merge ---
+          if [ "$AUTO_MERGE" = "true" ] && [ "$AUTO_MERGE_OK" = "true" ]; then
+            if gh pr merge --auto --squash "$PR_NUMBER" --repo "$GH_REPO"; then
+              STATUS_DESC="${STATUS_DESC} Auto-merge enabled."
+              echo "Auto-merge enabled for PR #${PR_NUMBER}"
+            else
+              STATUS_DESC="${STATUS_DESC} Auto-merge unavailable — merge manually."
+              echo "WARNING: gh pr merge failed for PR #${PR_NUMBER}"
+            fi
+          fi
+
+          # --- Set final status ---
+          gh api "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
+            -f state="$GATE_STATE" \
+            -f context="dependency-safety / gate" \
+            -f description="$STATUS_DESC"

--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -1085,43 +1085,92 @@ jobs:
           reconcile_label "dependency-age-violation" "$HAS_AGE_VIOLATION"   "$LABEL_COLOR_dependency_age_violation" "$LABEL_DESC_dependency_age_violation"
           reconcile_label "dependency-safety-error"  "$HAS_SAFETY_ERROR"    "$LABEL_COLOR_dependency_safety_error"  "$LABEL_DESC_dependency_safety_error"
 
-          # Guard-triggered runs must not compose a clean-scan narrative — the
-          # gate state machine below flips status to `error`, and the comment
-          # needs to agree (rather than claim "No known exploits" + auto-merge
-          # enabled on a run we refused to scan). The EXTRACTION_WARNING_SECTION
-          # prepended later (~line 960) still carries the detailed path list.
+          # --- Conditional auto-merge ---
+          # AUTO_MERGE_OK is the FINAL boolean from safety-verdict.sh —
+          # do NOT additionally gate on $AUTO_MERGE here (the script already did).
+          # Sets AUTO_MERGE_COMMENT_NOTE on SETUP failure (consumed by the
+          # comment composition below). "Required checks not yet satisfied" is
+          # NOT a setup failure — that is the normal case --auto handles.
+          # Must run BEFORE comment composition so the comment can attach the note.
+          AUTO_MERGE_COMMENT_NOTE=""
+          if [ "$AUTO_MERGE_OK" = "true" ]; then
+            if gh pr merge --auto --squash "$PR_NUMBER" --repo "$GH_REPO"; then
+              echo "Auto-merge enabled for PR #${PR_NUMBER}"
+            else
+              AUTO_MERGE_COMMENT_NOTE="Auto-merge could not be enabled: gh pr merge --auto rejected the request (auto-merge disabled, insufficient permission, or PR not mergeable). Merge manually."
+              echo "WARNING: gh pr merge failed for PR #${PR_NUMBER} — see comment note"
+            fi
+          fi
+
+          # --- Compose results section: table (from scan state) + header/footer (from verdict priority) ---
+          # The two are independent so that a multi-condition PR (e.g. age violation + advisories)
+          # shows both signals: header per priority, table reflecting actual scan data.
+
+          # ---- Results table (from scan state only) ----
           if [ "$GUARD_TRIGGERED" = "true" ]; then
-            RESULTS_HEADER="Dependency extraction failed — manual review required."
+            # Extraction failed — no scan ran.
             TABLE_HDR="| Source | Vulnerabilities |"
             TABLE_SEP="|--------|----------------|"
             ROW1="| GitHub Advisory (GHSA) | (not scanned) |"
             ROW2="| OSV.dev | (not scanned) |"
             RESULTS_TABLE="$(printf '%s\n%s\n%s\n%s' "$TABLE_HDR" "$TABLE_SEP" "$ROW1" "$ROW2")"
-            RESULTS_FOOTER="> Auto-merge not enabled — parser could not determine target versions from diff or PR body."
           elif [ "$TOTAL" -gt 0 ]; then
-            RESULTS_HEADER="**${TOTAL} advisory/ies found** affecting target versions — review before merging."
+            # Advisories present — show the actual scan results. This branch wins over
+            # "scan errored with partial results" because partial > nothing.
             TABLE_HDR="| ID | Severity | Summary | Source |"
             TABLE_SEP="|----|----------|---------|--------|"
             RESULTS_TABLE="$(printf '%s\n%s\n%s' "$TABLE_HDR" "$TABLE_SEP" "$SCAN_RESULTS")"
-            RESULTS_FOOTER="> Review the advisories above before deciding to merge."
-          elif [ -n "$HAS_ERROR" ]; then
-            gh api "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
-              -f state=error \
-              -f context="dependency-safety / gate" \
-              -f description="Scan failed due to API errors — re-run or push to retry."
-            exit 0
+          elif [ "$HAS_SAFETY_ERROR" = "true" ]; then
+            # Scan errored AND no advisories tallied — table is empty/unknown.
+            TABLE_HDR="| ID | Severity | Summary | Source |"
+            TABLE_SEP="|----|----------|---------|--------|"
+            RESULTS_TABLE="$(printf '%s\n%s\n| (scan failed — see logs) | - | - | - |' "$TABLE_HDR" "$TABLE_SEP")"
           else
-            RESULTS_HEADER="No known exploits found affecting the target versions."
+            # Clean scan.
             TABLE_HDR="| Source | Vulnerabilities |"
             TABLE_SEP="|--------|----------------|"
             ROW1="| GitHub Advisory (GHSA) | 0 affecting target |"
             ROW2="| OSV.dev | 0 affecting target |"
             RESULTS_TABLE="$(printf '%s\n%s\n%s\n%s' "$TABLE_HDR" "$TABLE_SEP" "$ROW1" "$ROW2")"
-            if [[ "$AUTO_MERGE" == "true" ]]; then
-              RESULTS_FOOTER="> Auto-merge has been enabled. This PR will merge once all status checks pass."
-            else
-              RESULTS_FOOTER="> This PR is now eligible for manual review and merge."
+          fi
+
+          # ---- Header + footer (from verdict priority — must match safety-verdict.sh order) ----
+          # Priority: guard > error > strict-age > advisories > non-strict-age > clean.
+          # Spec §6.1 — keep this order in sync with the script.
+          if [ "$GUARD_TRIGGERED" = "true" ]; then
+            RESULTS_HEADER="Dependency extraction failed — manual review required."
+            RESULTS_FOOTER="> Parser could not extract dependencies. Manual review required."
+          elif [ "$HAS_SAFETY_ERROR" = "true" ]; then
+            RESULTS_HEADER="Scan completed with errors — see workflow logs."
+            RESULTS_FOOTER="> Scan errors prevented a clean verdict. Re-run or push to retry."
+          elif [ "$HAS_AGE_VIOLATION" = "true" ] && [ "$FAIL_ON_AGE_VIOLATION" = "true" ]; then
+            RESULTS_HEADER="${AGE_VIOLATION_COUNT} package(s) younger than ${MINIMUM_RELEASE_AGE_DAYS}-day cooldown — Dependabot native cooldown invariant violated."
+            RESULTS_FOOTER="> Re-run by rebasing or recreating the PR after the age-compliant date below."
+            if [ "$TOTAL" -gt 0 ]; then
+              # Cross-reference: advisories are present too. Don't lose that signal under the age-violation header.
+              RESULTS_FOOTER="${RESULTS_FOOTER}"$'\n'"> Also: ${TOTAL} advisory/ies affect target versions — see table above."
             fi
+          elif [ "$TOTAL" -gt 0 ]; then
+            RESULTS_HEADER="**${TOTAL} advisory/ies found** affecting target versions — review before merging."
+            RESULTS_FOOTER="> Review the advisories above before deciding to merge."
+          elif [ "$HAS_AGE_VIOLATION" = "true" ]; then
+            # fail_on_age_violation=false — advisory mode, not blocking.
+            RESULTS_HEADER="${AGE_VIOLATION_COUNT} package(s) below ${MINIMUM_RELEASE_AGE_DAYS}-day cooldown (advisory mode — not blocking)."
+            RESULTS_FOOTER="> Age violation reported in advisory mode (not blocking). Auto-merge suppressed."
+          else
+            RESULTS_HEADER="No known exploits found affecting the target versions."
+            if [ "$AUTO_MERGE_OK" = "true" ]; then
+              RESULTS_FOOTER="> Auto-merge enabled. PR will merge once all required checks pass."
+            else
+              RESULTS_FOOTER="> Ready for manual review and merge."
+            fi
+          fi
+
+          # Attach auto-merge SETUP failure note (from the auto-merge block above) to the footer.
+          # Auto-merge "required checks not satisfied" is NOT an error and not surfaced
+          # here — only SETUP failures (gh pr merge --auto rejected by API).
+          if [ -n "${AUTO_MERGE_COMMENT_NOTE:-}" ]; then
+            RESULTS_FOOTER="${RESULTS_FOOTER}"$'\n'"> ${AUTO_MERGE_COMMENT_NOTE}"
           fi
 
           # Build collapsed historical section (non-blocking, for transparency)
@@ -1169,16 +1218,17 @@ jobs:
             done <<< "$AGE_TSV"
 
             AGE_FOOTER=""
-            if [ "$COOLDOWN_FAILURES" -gt 0 ] && [ "$MAX_FAIL_EPOCH" -gt 0 ]; then
-              _unblock_epoch=$(( MAX_FAIL_EPOCH + COOLDOWN_DAYS * 86400 ))
+            if [ "$AGE_VIOLATION_COUNT" -gt 0 ] && [ "$MAX_FAIL_EPOCH" -gt 0 ]; then
+              _unblock_epoch=$(( MAX_FAIL_EPOCH + MINIMUM_RELEASE_AGE_DAYS * 86400 ))
               _unblock_iso=$(date -u -d "@$_unblock_epoch" '+%Y-%m-%d' 2>/dev/null \
                 || date -u -r "$_unblock_epoch" '+%Y-%m-%d' 2>/dev/null \
                 || echo "unknown")
-              AGE_FOOTER="$(printf '\n> %d package(s) within cooldown window. Earliest unblock: %s.' "$COOLDOWN_FAILURES" "$_unblock_iso")"
+              AGE_FOOTER="$(printf '\n> %d package(s) below minimum. Earliest age-compliant date: %s.\n> Re-run by rebasing or recreating the PR after that date.' \
+                "$AGE_VIOLATION_COUNT" "$_unblock_iso")"
             fi
 
-            RELEASE_AGE_SECTION="$(printf '\n### Release Age (cooldown: %s days)\n\n%s\n%s\n%s%s' \
-              "$COOLDOWN_DAYS" "$AGE_TABLE_HDR" "$AGE_TABLE_SEP" "$AGE_ROWS" "$AGE_FOOTER")"
+            RELEASE_AGE_SECTION="$(printf '\n### Release Age (minimum: %s days)\n\n%s\n%s\n%s%s' \
+              "$MINIMUM_RELEASE_AGE_DAYS" "$AGE_TABLE_HDR" "$AGE_TABLE_SEP" "$AGE_ROWS" "$AGE_FOOTER")"
           fi
 
           # --- Extraction warning section (Task 12 — surfaces #27 silent drops) ---
@@ -1248,22 +1298,6 @@ jobs:
               --repo "$GH_REPO" \
               --body "$CHANGE_NOTE"
             echo "Posted change notification"
-          fi
-
-          # --- Conditional auto-merge ---
-          # AUTO_MERGE_OK is the FINAL boolean from safety-verdict.sh —
-          # do NOT additionally gate on $AUTO_MERGE here (the script already did).
-          # Sets AUTO_MERGE_COMMENT_NOTE on SETUP failure (consumed by Task 5's
-          # comment composition). "Required checks not yet satisfied" is NOT a
-          # setup failure — that is the normal case --auto handles.
-          AUTO_MERGE_COMMENT_NOTE=""
-          if [ "$AUTO_MERGE_OK" = "true" ]; then
-            if gh pr merge --auto --squash "$PR_NUMBER" --repo "$GH_REPO"; then
-              echo "Auto-merge enabled for PR #${PR_NUMBER}"
-            else
-              AUTO_MERGE_COMMENT_NOTE="Auto-merge could not be enabled: gh pr merge --auto rejected the request (auto-merge disabled, insufficient permission, or PR not mergeable). Merge manually."
-              echo "WARNING: gh pr merge failed for PR #${PR_NUMBER} — see comment note"
-            fi
           fi
 
           # --- Set final status ---

--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -1049,8 +1049,10 @@ jobs:
           # --- Label reconciliation (Task 13b — authoritative on clean runs, additive-only on HAS_ERROR paths) ---
           LABEL_COLOR_security_review_needed="B60205"
           LABEL_DESC_security_review_needed="Dependency scan found advisories — manual review required"
-          LABEL_COLOR_cooldown_pending="FBCA04"
-          LABEL_DESC_cooldown_pending="One or more target versions are within the configured cooldown window"
+          LABEL_COLOR_dependency_age_violation="FBCA04"
+          LABEL_DESC_dependency_age_violation="Target version younger than the configured minimum release age (Dependabot native cooldown invariant)"
+          LABEL_COLOR_dependency_safety_error="6E7781"
+          LABEL_DESC_dependency_safety_error="dependency-safety scan could not complete reliably — see scan comment"
 
           reconcile_label() {
             local label="$1"
@@ -1073,10 +1075,15 @@ jobs:
             fi
           }
 
-          _needs_security=$([ "$TOTAL" -gt 0 ] && echo true || echo false)
-          _needs_cooldown=$([ "$COOLDOWN_FAILURES" -gt 0 ] && echo true || echo false)
-          reconcile_label "security-review-needed" "$_needs_security" "$LABEL_COLOR_security_review_needed" "$LABEL_DESC_security_review_needed"
-          reconcile_label "cooldown-pending"       "$_needs_cooldown" "$LABEL_COLOR_cooldown_pending"       "$LABEL_DESC_cooldown_pending"
+          # Label booleans come straight from the verdict (HAS_*) — single source of truth.
+          # The reconcile_label function preserves stale labels when HAS_ERROR is set
+          # (conservative-preserve rule, spec §6.2).
+          #
+          # This workflow MUST NOT touch `cooldown-pending` — that label is owned
+          # exclusively by the legacy dependency-cooldown.yml during Phase 2 migration.
+          reconcile_label "security-review-needed"    "$HAS_SECURITY_REVIEW" "$LABEL_COLOR_security_review_needed"    "$LABEL_DESC_security_review_needed"
+          reconcile_label "dependency-age-violation" "$HAS_AGE_VIOLATION"   "$LABEL_COLOR_dependency_age_violation" "$LABEL_DESC_dependency_age_violation"
+          reconcile_label "dependency-safety-error"  "$HAS_SAFETY_ERROR"    "$LABEL_COLOR_dependency_safety_error"  "$LABEL_DESC_dependency_safety_error"
 
           # Guard-triggered runs must not compose a clean-scan narrative — the
           # gate state machine below flips status to `error`, and the comment

--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -11,14 +11,14 @@ on:
         type: boolean
         default: false
         description: "Auto-merge clean PRs after scan completes"
-      cooldown_days:
+      minimum_release_age_days:
         type: number
-        default: 7
-        description: "Minimum release age in days before auto-merge is allowed. 0 disables the release-age gate entirely (pre-v2.0.2 behavior)."
-      fail_on_cooldown:
+        default: 5
+        description: "Floor for target-version release age. Verified at scan time; should match cooldown.default-days in your dependabot.yml."
+      fail_on_age_violation:
         type: boolean
-        default: false
-        description: "If true, cooldown blocks set the gate to failure instead of pending. Use when branch protection requires a hard-red blocker."
+        default: true
+        description: "If true, age violation sets gate to failure. If false, gate is success with a dependency-age-violation label only. Auto-merge is suppressed in either case."
 
 jobs:
   scan:
@@ -66,8 +66,12 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           ENABLE_SCORECARD: ${{ inputs.enable_scorecard }}
           AUTO_MERGE: ${{ inputs.auto_merge }}
-          COOLDOWN_DAYS: ${{ inputs.cooldown_days }}
-          FAIL_ON_COOLDOWN: ${{ inputs.fail_on_cooldown }}
+          # COOLDOWN_DAYS is intentionally named for the inlined check-release-age.sh,
+          # which is shared with dependency-cooldown.yml and requires that env name.
+          # MINIMUM_RELEASE_AGE_DAYS feeds safety-verdict.sh and human-readable strings.
+          COOLDOWN_DAYS: ${{ inputs.minimum_release_age_days }}
+          MINIMUM_RELEASE_AGE_DAYS: ${{ inputs.minimum_release_age_days }}
+          FAIL_ON_AGE_VIOLATION: ${{ inputs.fail_on_age_violation }}
         run: |
           # --- BEGIN inline:scripts/extract-deps.sh ---
           extract_deps() (
@@ -475,6 +479,136 @@ jobs:
           )
           # --- END inline:scripts/check-release-age.sh ---
 
+          # --- BEGIN inline:scripts/safety-verdict.sh ---
+          safety_verdict() (
+          # safety-verdict.sh — translate dependency-safety scan facts to a gate verdict.
+          #
+          # Pure logic: no network, no `gh` calls, no I/O beyond stdin/stdout.
+          # Fail-closed: invalid/missing env → diagnostic on stderr, non-zero exit.
+          # The workflow MUST treat non-zero exit as: gate_state=error,
+          # has_safety_error=true, auto_merge_ok=false.
+          #
+          # Inputs (env vars, all required):
+          #   GUARD_TRIGGERED         true|false
+          #   AGE_ERROR_COUNT         int >=0
+          #   AGE_VIOLATION_COUNT     int >=0
+          #   SCAN_ERROR_COUNT        int >=0  (GHSA/OSV only — scorecard failures excluded)
+          #   ADVISORY_COUNT          int >=0  (post version-aware filtering)
+          #   FAIL_ON_AGE_VIOLATION   true|false
+          #   MINIMUM_RELEASE_AGE_DAYS int >=0
+          #   AUTO_MERGE              true|false
+          #
+          # Output (stdout, single TSV line, six fields, no trailing newline beyond one):
+          #   gate_state\tauto_merge_ok\thas_safety_error\thas_age_violation\thas_security_review\tstatus_desc
+          #
+          # Bash 3.2 compatible (macOS system bash).
+
+          set -uo pipefail
+
+          die() {
+            printf 'safety-verdict.sh: %s\n' "$1" >&2
+            exit 2
+          }
+
+          require_bool() {
+            local name="$1"
+            local val
+            eval "val=\${$name-__unset__}"
+            case "$val" in
+              __unset__) die "missing required env: $name" ;;
+              true|false) ;;
+              *) die "$name must be 'true' or 'false', got: $val" ;;
+            esac
+          }
+
+          require_nonneg_int() {
+            local name="$1"
+            local val
+            eval "val=\${$name-__unset__}"
+            if [ "$val" = "__unset__" ]; then
+              die "missing required env: $name"
+            fi
+            case "$val" in
+              ''|*[!0-9]*) die "$name must be a non-negative integer, got: $val" ;;
+            esac
+          }
+
+          require_bool GUARD_TRIGGERED
+          require_bool FAIL_ON_AGE_VIOLATION
+          require_bool AUTO_MERGE
+          require_nonneg_int AGE_ERROR_COUNT
+          require_nonneg_int AGE_VIOLATION_COUNT
+          require_nonneg_int SCAN_ERROR_COUNT
+          require_nonneg_int ADVISORY_COUNT
+          require_nonneg_int MINIMUM_RELEASE_AGE_DAYS
+
+          error_total=$(( AGE_ERROR_COUNT + SCAN_ERROR_COUNT ))
+
+          # --- gate_state (priority order) ---
+          if [ "$GUARD_TRIGGERED" = "true" ]; then
+            gate_state="error"
+          elif [ "$error_total" -gt 0 ]; then
+            gate_state="error"
+          elif [ "$AGE_VIOLATION_COUNT" -gt 0 ] && [ "$FAIL_ON_AGE_VIOLATION" = "true" ]; then
+            gate_state="failure"
+          else
+            gate_state="success"
+          fi
+
+          # --- label booleans (independent facts) ---
+          if [ "$GUARD_TRIGGERED" = "true" ] || [ "$error_total" -gt 0 ]; then
+            has_safety_error="true"
+          else
+            has_safety_error="false"
+          fi
+
+          if [ "$AGE_VIOLATION_COUNT" -gt 0 ]; then
+            has_age_violation="true"
+          else
+            has_age_violation="false"
+          fi
+
+          if [ "$ADVISORY_COUNT" -gt 0 ]; then
+            has_security_review="true"
+          else
+            has_security_review="false"
+          fi
+
+          # --- auto_merge_ok (final boolean) ---
+          if [ "$AUTO_MERGE" = "true" ] \
+             && [ "$GUARD_TRIGGERED" = "false" ] \
+             && [ "$error_total" -eq 0 ] \
+             && [ "$AGE_VIOLATION_COUNT" -eq 0 ] \
+             && [ "$ADVISORY_COUNT" -eq 0 ]; then
+            auto_merge_ok="true"
+          else
+            auto_merge_ok="false"
+          fi
+
+          # --- status_desc (≤140 chars, composed per priority winner) ---
+          if [ "$GUARD_TRIGGERED" = "true" ]; then
+            status_desc="Could not extract dependencies from diff. Manual review required."
+          elif [ "$error_total" -gt 0 ]; then
+            status_desc="Scan errors: ${AGE_ERROR_COUNT} age lookup(s), ${SCAN_ERROR_COUNT} advisory query/ies. Re-run or push to retry."
+          elif [ "$AGE_VIOLATION_COUNT" -gt 0 ] && [ "$FAIL_ON_AGE_VIOLATION" = "true" ]; then
+            status_desc="${AGE_VIOLATION_COUNT} package(s) younger than ${MINIMUM_RELEASE_AGE_DAYS}d cooldown — Dependabot native cooldown invariant violated."
+          elif [ "$ADVISORY_COUNT" -gt 0 ]; then
+            status_desc="${ADVISORY_COUNT} advisory/ies found (version-filtered). Manual review required."
+          elif [ "$AGE_VIOLATION_COUNT" -gt 0 ]; then
+            status_desc="${AGE_VIOLATION_COUNT} package(s) below ${MINIMUM_RELEASE_AGE_DAYS}d cooldown (advisory mode). Auto-merge suppressed."
+          elif [ "$auto_merge_ok" = "true" ]; then
+            status_desc="Clean scan (≥${MINIMUM_RELEASE_AGE_DAYS}d, no advisories). Auto-merge enabled."
+          else
+            status_desc="Clean scan (≥${MINIMUM_RELEASE_AGE_DAYS}d, no advisories). Ready for merge."
+          fi
+
+          printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$gate_state" "$auto_merge_ok" \
+            "$has_safety_error" "$has_age_violation" "$has_security_review" \
+            "$status_desc"
+          )
+          # --- END inline:scripts/safety-verdict.sh ---
+
           DIFF=$(gh pr diff "$PR_NUMBER" --repo "$GH_REPO")
 
           DEPS=""
@@ -853,6 +987,65 @@ jobs:
           # --- Build comment body ---
           TOTAL=$((GHSA_TOTAL + OSV_TOTAL))
 
+          # --- Compute verdict via safety_verdict (inline copy of scripts/safety-verdict.sh) ---
+          # Split COOLDOWN_FAILURES into age_error_count vs age_violation_count by
+          # re-reading AGE_TSV (verdicts: 'fail' = violation, 'error' = lookup error).
+          AGE_VIOLATION_COUNT=$(echo "$AGE_TSV" | awk -F'\t' '$6=="fail"'  | wc -l | tr -d ' ')
+          AGE_ERROR_COUNT=$(    echo "$AGE_TSV" | awk -F'\t' '$6=="error"' | wc -l | tr -d ' ')
+
+          # SCAN_ERROR_COUNT = GHSA/OSV failures (scorecard failures are NOT blocking).
+          # The existing code sets HAS_ERROR=true on any GHSA/OSV failure but doesn't
+          # count individual failures; we conservatively report 1 if any occurred.
+          if [ -n "${HAS_ERROR:-}" ]; then
+            SCAN_ERROR_COUNT=1
+          else
+            SCAN_ERROR_COUNT=0
+          fi
+
+          # Map GUARD_TRIGGERED to lowercase string the script expects.
+          if [ "$GUARD_TRIGGERED" = "true" ]; then
+            _gt_bool="true"
+          else
+            _gt_bool="false"
+          fi
+
+          # Call safety_verdict with `if ...; then`. NOT VAR=$(...); RC=$?
+          # — under `bash -e` a failing command substitution can abort the
+          # step before $? is captured, defeating fail-closed semantics.
+          if VERDICT_TSV=$(GUARD_TRIGGERED="$_gt_bool" \
+                           AGE_ERROR_COUNT="$AGE_ERROR_COUNT" \
+                           AGE_VIOLATION_COUNT="$AGE_VIOLATION_COUNT" \
+                           SCAN_ERROR_COUNT="$SCAN_ERROR_COUNT" \
+                           ADVISORY_COUNT="$TOTAL" \
+                           FAIL_ON_AGE_VIOLATION="$FAIL_ON_AGE_VIOLATION" \
+                           MINIMUM_RELEASE_AGE_DAYS="$MINIMUM_RELEASE_AGE_DAYS" \
+                           AUTO_MERGE="$AUTO_MERGE" \
+                           safety_verdict); then
+            VERDICT_RC=0
+          else
+            VERDICT_RC=$?
+          fi
+
+          if [ "$VERDICT_RC" -ne 0 ] || [ -z "$VERDICT_TSV" ]; then
+            # Fail-closed: synthesize an error verdict so the gate is red and
+            # auto-merge is suppressed even if the script crashed unexpectedly.
+            GATE_STATE="error"
+            AUTO_MERGE_OK="false"
+            HAS_SAFETY_ERROR="true"
+            HAS_AGE_VIOLATION="false"
+            HAS_SECURITY_REVIEW="false"
+            STATUS_DESC="Internal: verdict script rejected inputs — see workflow logs."
+          else
+            IFS=$'\t' read -r GATE_STATE AUTO_MERGE_OK HAS_SAFETY_ERROR \
+                              HAS_AGE_VIOLATION HAS_SECURITY_REVIEW STATUS_DESC \
+                              <<< "$VERDICT_TSV"
+          fi
+
+          # Map verdict's HAS_SAFETY_ERROR to the legacy HAS_ERROR variable that
+          # reconcile_label() inspects for the conservative-preserve rule.
+          # Escalates only — never demotes a HAS_ERROR=true that the scan loop set.
+          if [ "$HAS_SAFETY_ERROR" = "true" ]; then HAS_ERROR="true"; fi
+
           # --- Label reconciliation (Task 13b — authoritative on clean runs, additive-only on HAS_ERROR paths) ---
           LABEL_COLOR_security_review_needed="B60205"
           LABEL_DESC_security_review_needed="Dependency scan found advisories — manual review required"
@@ -1050,41 +1243,19 @@ jobs:
             echo "Posted change notification"
           fi
 
-          # --- Gate state machine (Task 11 — combines advisory + cooldown verdicts) ---
-          if [ "$GUARD_TRIGGERED" = "true" ]; then
-            # Fail-loud guard: parser could not extract deps from a lockfile-touching
-            # diff, and the PR-body fallback also produced nothing. Refuse to issue
-            # a green gate — manual review required (fix for issue #52).
-            GATE_STATE="error"
-            STATUS_DESC="Could not extract dependencies from diff. Manual review required."
-            AUTO_MERGE_OK=false
-          elif [ "$TOTAL" -gt 0 ]; then
-            # Advisory failure wins — strictest signal (existing v2.0.1 semantic: gate=success with "review needed")
-            GATE_STATE="success"
-            STATUS_DESC="${TOTAL} advisory/ies found (version-filtered). Manual review required."
-            AUTO_MERGE_OK=false
-          elif [ "$COOLDOWN_FAILURES" -gt 0 ]; then
-            if [ "$FAIL_ON_COOLDOWN" = "true" ]; then
-              GATE_STATE="failure"
-            else
-              GATE_STATE="pending"
-            fi
-            STATUS_DESC="${COOLDOWN_FAILURES} package(s) within ${COOLDOWN_DAYS}-day cooldown window. Waiting for age."
-            AUTO_MERGE_OK=false
-          else
-            GATE_STATE="success"
-            STATUS_DESC="Clean scan (version-filtered, cooldown ≥ ${COOLDOWN_DAYS}d). Ready for merge."
-            AUTO_MERGE_OK=true
-          fi
-
           # --- Conditional auto-merge ---
-          if [ "$AUTO_MERGE" = "true" ] && [ "$AUTO_MERGE_OK" = "true" ]; then
+          # AUTO_MERGE_OK is the FINAL boolean from safety-verdict.sh —
+          # do NOT additionally gate on $AUTO_MERGE here (the script already did).
+          # Sets AUTO_MERGE_COMMENT_NOTE on SETUP failure (consumed by Task 5's
+          # comment composition). "Required checks not yet satisfied" is NOT a
+          # setup failure — that is the normal case --auto handles.
+          AUTO_MERGE_COMMENT_NOTE=""
+          if [ "$AUTO_MERGE_OK" = "true" ]; then
             if gh pr merge --auto --squash "$PR_NUMBER" --repo "$GH_REPO"; then
-              STATUS_DESC="${STATUS_DESC} Auto-merge enabled."
               echo "Auto-merge enabled for PR #${PR_NUMBER}"
             else
-              STATUS_DESC="${STATUS_DESC} Auto-merge unavailable — merge manually."
-              echo "WARNING: gh pr merge failed for PR #${PR_NUMBER}"
+              AUTO_MERGE_COMMENT_NOTE="Auto-merge could not be enabled: gh pr merge --auto rejected the request (auto-merge disabled, insufficient permission, or PR not mergeable). Merge manually."
+              echo "WARNING: gh pr merge failed for PR #${PR_NUMBER} — see comment note"
             fi
           fi
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # shared-workflows
 
-Reusable GitHub Actions workflows for dependency management and security scanning.
+Reusable GitHub Actions workflows for dependency safety verification and release management.
 
 ## Features
 
-- **Dual-layer cool-down enforcement** — Dependabot's native `cooldown.default-days` gates PR creation; the workflow's `cooldown_days` input enforces release age on every scan, closing the rebase-bypass path that native cool-down alone leaves open
+- **Native-cooldown verification** — Dependabot's native `cooldown.default-days` owns the wait; `dependency-safety.yml` verifies the invariant on every scan and fails deterministically on violation
 - **Version-aware advisory filtering** — advisories already patched at or below the PR's target version are collapsed into a non-blocking "historical" section
 - **GHSA + OSV dual-source scan** — every package is queried against both GitHub Advisory and OSV.dev; mismatches surface both
 - **OpenSSF Scorecard integration** — Scorecard results for each GitHub Action appear in the scan comment
-- **Update-or-create scan comments** — a single stable comment per PR; change detection posts a reply only when advisory IDs actually change
-- **Optional auto-merge** — clean scans flip on `gh pr merge --auto`; dirty scans apply a `security-review-needed` label instead
+- **Update-or-create scan comments** — a single stable comment per PR; change detection posts a top-level PR comment only when advisory IDs actually change
+- **Optional auto-merge** — clean scans flip on `gh pr merge --auto`; dirty scans apply labels (`security-review-needed`, `dependency-age-violation`, or `dependency-safety-error`) instead
 - **Grouped PR support** — handles both single-package and grouped Dependabot PRs
 
 ## Prerequisites
@@ -22,7 +22,7 @@ Reusable GitHub Actions workflows for dependency management and security scannin
 
 ### 1. Configure Dependabot cool-down
 
-The waiting period is owned by Dependabot itself — the workflow only scans PRs once they're already open. Add `cooldown:` to `.github/dependabot.yml`:
+The waiting period is owned by Dependabot itself — the workflow only verifies that the invariant holds. Add `cooldown:` to `.github/dependabot.yml`:
 
 ```yaml
 # .github/dependabot.yml
@@ -33,18 +33,18 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 7
+      default-days: 5
 ```
 
 See [Dependabot cool-down docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown--) for per-severity and per-ecosystem overrides.
 
 ### 2. Add the caller workflow
 
-One workflow file invokes the reusable scan on every Dependabot PR:
+One workflow file invokes the reusable verifier on every Dependabot PR:
 
 ```yaml
-# .github/workflows/dependency-cooldown.yml
-name: Dependency Cool-Down
+# .github/workflows/dependency-safety.yml
+name: Dependency Safety
 
 on:
   pull_request:
@@ -58,12 +58,12 @@ permissions:
   issues: write
 
 concurrency:
-  group: cooldown-${{ github.event.pull_request.number }}
+  group: safety-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
-  cooldown:
-    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown.yml@v1
+  safety:
+    uses: j7an/shared-workflows/.github/workflows/dependency-safety.yml@v2
     secrets: inherit
     with:
       auto_merge: true
@@ -76,9 +76,9 @@ jobs:
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enable_scorecard` | boolean | `true` | Include OpenSSF Scorecard results for GitHub Actions in the scan comment |
-| `auto_merge` | boolean | `false` | On clean scans, enable `gh pr merge --auto`; on dirty scans, apply the `security-review-needed` label |
-| `cooldown_days` | number | `7` | Minimum release age in days before auto-merge is allowed. Set to `0` to disable workflow-side release-age enforcement (pre-v2.0.2 behavior — relies entirely on Dependabot's native cooldown) |
-| `fail_on_cooldown` | boolean | `false` | If `true`, cooldown blocks set the gate status to `failure` instead of `pending`. Use when branch protection requires a hard-red blocker rather than a self-healing pending state |
+| `auto_merge` | boolean | `false` | On clean scans, enable `gh pr merge --auto`; on dirty scans, apply the appropriate label |
+| `minimum_release_age_days` | number | `5` | Floor for target-version release age. Verified at scan time; should match `cooldown.default-days` in `dependabot.yml` |
+| `fail_on_age_violation` | boolean | `true` | If `true`, age violations set the gate status to `failure`. If `false`, the gate is `success` with a `dependency-age-violation` label and a comment; auto-merge is suppressed in either case |
 
 ## Supported Ecosystems
 
@@ -92,21 +92,19 @@ Grouped Dependabot PRs (multiple packages in one PR) are supported — each pack
 ## How It Works
 
 ```
-Dependabot queues an update
+Dependabot's native cooldown holds an update for `cooldown.default-days`
     │
     ▼
-Native cooldown holds it for `default-days`
+Dependabot opens the PR (target version is now ≥ cooldown days old)
     │
     ▼
-Dependabot opens the PR
-    │
-    ▼
-Cool-down workflow fires on pull_request
+dependency-safety.yml fires on pull_request
     ├── Non-dependabot PR? → status "success" (no-op)
-    ├── Status → "pending" ("Scanning dependencies...")
+    ├── Status → "pending" ("Scanning dependencies for safety...")
     ├── Parses diff to extract package names + target versions
     │     ├── Falls back to PR body text when inline versions are absent
     │     └── Supports github-actions, pip, and uv ecosystems
+    ├── Verifies release age — fails if any target < minimum_release_age_days
     ├── For each package:
     │     ├── GHSA GraphQL query (by ecosystem)
     │     ├── OSV.dev POST query (with version if known)
@@ -114,11 +112,12 @@ Cool-down workflow fires on pull_request
     ├── Version-aware filter:
     │     ├── Advisories with firstPatchedVersion ≤ target → historical bucket
     │     └── Advisories affecting target version → blocking bucket
+    ├── Computes deterministic verdict (safety-verdict.sh)
+    ├── Reconciles labels (security-review-needed, dependency-age-violation, dependency-safety-error)
     ├── Update-or-create single scan comment
-    ├── If advisory IDs changed since last scan → post change-notification reply
-    ├── auto_merge=true + 0 blocking advisories → gh pr merge --auto
-    ├── auto_merge=true + ≥1 blocking advisory → label `security-review-needed`
-    └── Status → "success" (description carries the outcome)
+    ├── If advisory IDs changed since last scan → post change-notification top-level PR comment
+    ├── If clean and auto_merge=true → gh pr merge --auto
+    └── Sets final gate status (success / failure / error)
 ```
 
 ### Version-aware filtering
@@ -129,106 +128,46 @@ PR #23 added filtering so that advisories Dependabot has already fixed don't blo
 - Only advisories affecting the *target* version count toward the blocking total.
 - When the target version can't be determined (no inline comment and no match in the PR body), the workflow falls back to reporting all advisories for the package — safer default.
 
-## Cool-down configuration
+## Gate states and labels
 
-The workflow enforces cool-down at two layers, each independently configurable:
+The `dependency-safety / gate` commit status uses three states:
 
-### Layer 1 — Dependabot native cool-down (PR creation)
+| State | When |
+|-------|------|
+| `success` | Clean scan, OR advisories present (label `security-review-needed`), OR age violation in advisory mode (label `dependency-age-violation`, `fail_on_age_violation: false`) |
+| `failure` | Strict age violation (`fail_on_age_violation: true`) — the Dependabot native cooldown invariant was violated |
+| `error` | Dependency extraction failed, or GHSA/OSV/age-lookup APIs errored — the verdict is unreliable; manual review required |
 
-Configured in `.github/dependabot.yml`. Dependabot holds new PRs until the target version is at least `cooldown.default-days` old. This gate runs once, at PR creation. **It does NOT re-check on `@dependabot rebase`** — a rebase re-resolves to the latest version and skips this gate entirely.
-
-```yaml
-# .github/dependabot.yml
-updates:
-  - package-ecosystem: "github-actions"
-    cooldown:
-      default-days: 7
-```
-
-See the [cool-down options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown--) for per-severity (`semver-major-days`, `semver-minor-days`, `semver-patch-days`) and package include/exclude lists.
-
-### Layer 2 — Workflow-side release-age gate (every scan)
-
-Configured via the `cooldown_days` input on the caller workflow (default `7`). The workflow re-evaluates release age on every scan, including after `@dependabot rebase`. If any target version is younger than `cooldown_days`, the workflow:
-
-- Applies the `cooldown-pending` label
-- Sets the `dependency-cooldown / gate` status to `pending` (or `failure` if `fail_on_cooldown: true`)
-- Skips `gh pr merge --auto` even if the advisory scan is clean
-
-Once the next scan finds all versions past the threshold, the label is removed and the gate flips to `success`. To disable workflow-side enforcement entirely (pre-v2.0.2 behavior), set `cooldown_days: 0` in the caller workflow.
-
-### Bypass
-
-There is no per-PR bypass label. To ship a zero-day fix immediately:
-
-- Lower `cooldown.default-days` in `.github/dependabot.yml` for the affected ecosystem, OR
-- Set `cooldown_days: 0` in the caller workflow temporarily, OR
-- Merge manually (the gate state is informational; you control your branch protection rules)
-
-Commit history on `dependabot.yml` and your caller workflow is the audit trail.
-
-## Labels
-
-The workflow manages two labels on Dependabot PRs. **Both are reconciled on every scan** — applied when the condition is true, removed when it becomes false.
+Labels:
 
 | Label | Color | Applied when | Removed when |
 |-------|-------|--------------|--------------|
-| `security-review-needed` | red (`B60205`) | Advisory scan finds vulnerabilities affecting target versions | Re-scan finds zero applicable advisories |
-| `cooldown-pending` | amber (`FBCA04`) | Any target version is younger than `cooldown_days` | Re-scan finds all versions past the threshold |
+| `security-review-needed` | red (`B60205`) | Advisory scan finds vulnerabilities affecting target versions | Re-scan finds zero applicable advisories AND no `error` state |
+| `dependency-age-violation` | amber (`FBCA04`) | Any target version is younger than `minimum_release_age_days` | All versions pass age check AND no `error` state |
+| `dependency-safety-error` | grey (`6E7781`) | Scan extraction failed or API errors occurred | Clean scan completes without errors |
 
-The reconciliation is authoritative — a PR that was dirty at first scan and clean after rebase will have neither label at merge time.
+Reconciliation is authoritative when the scan succeeds. On the `error` path, labels are preserved (not removed) since the verdict is unreliable.
 
-## Scheduled re-scan for long-pending PRs (v2.4.0+)
+## Migration From Legacy Cooldown
 
-A Dependabot PR that opens *during* its dependency's cooldown window scans once and then sits in the `pending` gate state until either Dependabot rebases or a human prods `@dependabot recreate`. To rescan automatically on a schedule, consumers can add a thin caller workflow that invokes `cooldown-rescan.yml`:
+If you're migrating from `dependency-cooldown.yml`:
 
-```yaml
-# .github/workflows/dependency-cooldown-rescan.yml
-name: Dependency Cooldown Rescan
+1. **Add native cooldown** to `.github/dependabot.yml` (`cooldown.default-days: 5` or higher).
+2. **Replace the caller `uses:`** line:
+   ```diff
+   - uses: j7an/shared-workflows/.github/workflows/dependency-cooldown.yml@v2
+   + uses: j7an/shared-workflows/.github/workflows/dependency-safety.yml@v2
+   ```
+3. **Rename the input** `cooldown_days` → `minimum_release_age_days`.
+4. **Drop `fail_on_cooldown`** — replaced by `fail_on_age_violation` with different semantics (failure-on-violation, not pending-on-violation).
+5. **Remove any caller workflow** that uses `cooldown-rescan.yml` (no rescan companion under the new model — the verifier is single-shot per PR event).
+6. **Optional:** add `rebase-strategy: disabled` to your `dependabot.yml` ecosystem block. This avoids `@dependabot rebase` pulling in newer versions that have not yet aged through native cooldown.
 
-on:
-  schedule:
-    - cron: "0 6 * * *"   # daily at 06:00 UTC; tune per consumer
-  workflow_dispatch:
+After migration, the `cooldown-pending` label (managed by the legacy workflow) will become stale on the PR; the new workflow does not touch it, so remove it manually if desired.
 
-permissions:
-  contents: read
-  pull-requests: read
-  actions: write
-  statuses: read
+## Legacy Workflows
 
-jobs:
-  rescan:
-    uses: j7an/shared-workflows/.github/workflows/cooldown-rescan.yml@v2
-```
-
-How it works: on each invocation, the rescan workflow lists open Dependabot PRs in the caller repo, finds those whose `dependency-cooldown / gate` commit status is `pending`, and reruns the most recent `dependency-cooldown.yml` workflow run for each via `gh run rerun`. The replayed run uses the original `pull_request` payload (so the head SHA is stable) but with the current runtime clock — release-age gates re-evaluate freshly.
-
-The workflow only triggers PRs with a `pending` gate. PRs in `success` or `failure` are left alone.
-
-### Cadence
-
-Cadence is owned by the caller. Sweep at least once per cooldown-window step (e.g., a 7-day cooldown is comfortably handled by a daily sweep; a 1-day cooldown wants every-few-hours). GitHub may delay scheduled runs by up to ~30 minutes under load, so use `workflow_dispatch:` as the manual escape hatch.
-
-### Dry-run rollout
-
-For initial validation, pass `dry_run: true` so the sweep logs decisions without calling `gh run rerun`:
-
-```yaml
-jobs:
-  rescan:
-    uses: j7an/shared-workflows/.github/workflows/cooldown-rescan.yml@v2
-    with:
-      dry_run: true
-```
-
-Trigger via `workflow_dispatch`, inspect the `$GITHUB_STEP_SUMMARY` table, then remove the `with:` block once the filter logic looks right.
-
-### Inputs
-
-| Input | Type | Default | Description |
-|-------|------|---------|-------------|
-| `dry_run` | boolean | `false` | When `true`, log decisions to `$GITHUB_STEP_SUMMARY` but do not call `gh run rerun`. Use for initial-rollout validation and incident diagnostics. |
+`dependency-cooldown.yml` and `cooldown-rescan.yml` implement the pre-2026 workflow-owned waiting model: the workflow itself held PRs in `pending` state for the cooldown window, and a separate rescan workflow swept stale PRs on a schedule. These remain available during the sibling-migration window and will be removed in a future major release once known consumers have moved to `dependency-safety.yml`. See [Migration From Legacy Cooldown](#migration-from-legacy-cooldown) above.
 
 ## Security Analysis (Zizmor)
 
@@ -291,9 +230,7 @@ Tags are managed automatically — merging a PR to this repo creates a semver ta
 
 ## Known caller-side constraints
 
-The reusable workflows in this repo are **self-contained at runtime**: they must
-not fetch `j7an/shared-workflows` source at runtime, and they must not reference
-caller-scoped context variables as if they were reusable-workflow-scoped.
+The reusable workflows in this repo are **self-contained at runtime**: they must not fetch `j7an/shared-workflows` source at runtime, and they must not reference caller-scoped context variables as if they were reusable-workflow-scoped.
 
 The following are forbidden inside any `workflow_call` file:
 
@@ -303,19 +240,9 @@ The following are forbidden inside any `workflow_call` file:
 | `ref: ${{ github.sha }}` | Same problem — resolves to caller context |
 | `ref: ${{ github.ref }}` | Same problem — resolves to caller's branch/tag ref |
 
-This policy exists because violating it caused [#29](https://github.com/j7an/shared-workflows/issues/29):
-v2.0.2 shipped with a broken `actions/checkout` step that failed deterministically
-on every cross-repo consumer PR. The CI gate that should have caught it was
-structurally incapable of doing so, because `ci-cooldown.yml` self-consumes via
-local path (`uses: ./...`), which makes the caller repo the same as the checkout
-target and masks caller-context bugs by coincidence.
+This policy exists because violating it caused [#29](https://github.com/j7an/shared-workflows/issues/29): v2.0.2 shipped with a broken `actions/checkout` step that failed deterministically on every cross-repo consumer PR. The CI gate that should have caught it was structurally incapable of doing so, because `ci-cooldown.yml` self-consumed via local path (`uses: ./...`), which makes the caller repo the same as the checkout target and masks caller-context bugs by coincidence.
 
-If a future reusable workflow needs to execute a script that's under version
-control in this repo, **inline the script into the workflow YAML**. The bats test
-suite under `tests/` provides unit-test coverage against the standalone
-`scripts/*.sh` files, and `scripts/check-inline-sync.sh` verifies the inline
-copies stay in sync — so test feedback is preserved without introducing a runtime
-source-fetch dependency.
+If a future reusable workflow needs to execute a script that's under version control in this repo, **inline the script into the workflow YAML**. The bats test suite under `tests/` provides unit-test coverage against the standalone `scripts/*.sh` files, and `scripts/check-inline-sync.sh` verifies the inline copies stay in sync — so test feedback is preserved without introducing a runtime source-fetch dependency.
 
 ### For authors adding a new reusable workflow
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ Reusable GitHub Actions workflows for dependency safety verification and release
 - **Native cool-down** configured in `.github/dependabot.yml` (see Quick Start)
 - **No Renovate** — this workflow only scans `dependabot[bot]` PRs; other actors are passed through with a success status
 
+> **Scope: version-update PRs.** Dependabot's native `cooldown:` setting applies
+> only to *version updates*, not [security updates][gh-cooldown-scope]. The
+> default `fail_on_age_violation: true` therefore treats young security-fix PRs
+> as invariant violations even though native cooldown never held them. For
+> repos with Dependabot security updates enabled, choose one:
+>
+> - **Advisory mode (interim):** set `fail_on_age_violation: false` so age
+>   violations apply the `dependency-age-violation` label instead of failing
+>   the gate. The trade-off: the strict invariant is weakened for *all*
+>   Dependabot PRs, not just security ones.
+> - **Wait for follow-up detection** that treats security-update PRs as a
+>   distinct class (tracked separately; not in this release).
+>
+> [gh-cooldown-scope]: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown--
+
 ## Quick Start
 
 ### 1. Configure Dependabot cool-down
@@ -70,6 +85,11 @@ jobs:
 ```
 
 `contents: write` is only required when `auto_merge: true`; otherwise `contents: read` is sufficient.
+
+> **Note:** `@v2` resolves to `dependency-safety.yml` only after a release of
+> this repo that contains it. Before that, pin to the explicit tag where the
+> workflow first shipped (`@vX.Y.Z`). Releases in this repo are dispatched
+> manually — see [Versioning](#versioning).
 
 ## Inputs
 
@@ -161,7 +181,8 @@ If you're migrating from `dependency-cooldown.yml`:
 3. **Rename the input** `cooldown_days` → `minimum_release_age_days`.
 4. **Drop `fail_on_cooldown`** — replaced by `fail_on_age_violation` with different semantics (failure-on-violation, not pending-on-violation).
 5. **Remove any caller workflow** that uses `cooldown-rescan.yml` (no rescan companion under the new model — the verifier is single-shot per PR event).
-6. **Optional:** add `rebase-strategy: disabled` to your `dependabot.yml` ecosystem block. This avoids `@dependabot rebase` pulling in newer versions that have not yet aged through native cooldown.
+6. **Update branch protection / rulesets.** The commit-status context changes from `dependency-cooldown / gate` to `dependency-safety / gate`. Required-status-check rules on the old context will wait forever once you cut over. In Settings → Branches (or Rules), remove `dependency-cooldown / gate` from the required checks list and add `dependency-safety / gate` in its place. The two contexts can coexist briefly if you keep both workflows running during a Phase 2 transition.
+7. **Optional:** add `rebase-strategy: disabled` to your `dependabot.yml` ecosystem block. This avoids `@dependabot rebase` pulling in newer versions that have not yet aged through native cooldown.
 
 After migration, the `cooldown-pending` label (managed by the legacy workflow) will become stale on the PR; the new workflow does not touch it, so remove it manually if desired.
 
@@ -226,7 +247,7 @@ jobs:
 | `@vX.Y` | Patch fixes only within minor `X.Y` | Want patches but not new features |
 | `@vX.Y.Z` | Nothing (frozen) | Need exact reproducibility or rollback |
 
-Tags are managed automatically — merging a PR to this repo creates a semver tag based on conventional commit prefixes and updates the floating tags.
+Releases are cut manually via the `release-self.yml` workflow dispatch. Merging a PR to `main` does **not** create a tag on its own. When a maintainer dispatches `release-self.yml` (with `bump: auto`), it scans Conventional Commits since the last tag, computes the next semver tag, and updates the floating `vX` / `vX.Y` tags to point at the new commit.
 
 ## Known caller-side constraints
 

--- a/scripts/check-inline-sync.sh
+++ b/scripts/check-inline-sync.sh
@@ -15,6 +15,10 @@ INLINE_PAIRS=(
   ".github/workflows/dependency-cooldown.yml:scripts/check-release-age.sh"
   ".github/workflows/dependency-cooldown.yml:scripts/diff-touches-lockfile.sh"
   ".github/workflows/dependency-cooldown.yml:scripts/pr-body-to-deps.sh"
+  ".github/workflows/dependency-safety.yml:scripts/extract-deps.sh"
+  ".github/workflows/dependency-safety.yml:scripts/check-release-age.sh"
+  ".github/workflows/dependency-safety.yml:scripts/diff-touches-lockfile.sh"
+  ".github/workflows/dependency-safety.yml:scripts/pr-body-to-deps.sh"
   ".github/workflows/tag-release.yml:scripts/bump-version-files.sh"
 )
 

--- a/scripts/check-inline-sync.sh
+++ b/scripts/check-inline-sync.sh
@@ -19,6 +19,7 @@ INLINE_PAIRS=(
   ".github/workflows/dependency-safety.yml:scripts/check-release-age.sh"
   ".github/workflows/dependency-safety.yml:scripts/diff-touches-lockfile.sh"
   ".github/workflows/dependency-safety.yml:scripts/pr-body-to-deps.sh"
+  ".github/workflows/dependency-safety.yml:scripts/safety-verdict.sh"
   ".github/workflows/tag-release.yml:scripts/bump-version-files.sh"
 )
 

--- a/scripts/safety-verdict.sh
+++ b/scripts/safety-verdict.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# safety-verdict.sh — translate dependency-safety scan facts to a gate verdict.
+#
+# Pure logic: no network, no `gh` calls, no I/O beyond stdin/stdout.
+# Fail-closed: invalid/missing env → diagnostic on stderr, non-zero exit.
+# The workflow MUST treat non-zero exit as: gate_state=error,
+# has_safety_error=true, auto_merge_ok=false.
+#
+# Inputs (env vars, all required):
+#   GUARD_TRIGGERED         true|false
+#   AGE_ERROR_COUNT         int >=0
+#   AGE_VIOLATION_COUNT     int >=0
+#   SCAN_ERROR_COUNT        int >=0  (GHSA/OSV only — scorecard failures excluded)
+#   ADVISORY_COUNT          int >=0  (post version-aware filtering)
+#   FAIL_ON_AGE_VIOLATION   true|false
+#   MINIMUM_RELEASE_AGE_DAYS int >=0
+#   AUTO_MERGE              true|false
+#
+# Output (stdout, single TSV line, six fields, no trailing newline beyond one):
+#   gate_state\tauto_merge_ok\thas_safety_error\thas_age_violation\thas_security_review\tstatus_desc
+#
+# Bash 3.2 compatible (macOS system bash).
+
+set -uo pipefail
+
+die() {
+  printf 'safety-verdict.sh: %s\n' "$1" >&2
+  exit 2
+}
+
+require_bool() {
+  local name="$1"
+  local val
+  eval "val=\${$name-__unset__}"
+  case "$val" in
+    __unset__) die "missing required env: $name" ;;
+    true|false) ;;
+    *) die "$name must be 'true' or 'false', got: $val" ;;
+  esac
+}
+
+require_nonneg_int() {
+  local name="$1"
+  local val
+  eval "val=\${$name-__unset__}"
+  if [ "$val" = "__unset__" ]; then
+    die "missing required env: $name"
+  fi
+  case "$val" in
+    ''|*[!0-9]*) die "$name must be a non-negative integer, got: $val" ;;
+  esac
+}
+
+require_bool GUARD_TRIGGERED
+require_bool FAIL_ON_AGE_VIOLATION
+require_bool AUTO_MERGE
+require_nonneg_int AGE_ERROR_COUNT
+require_nonneg_int AGE_VIOLATION_COUNT
+require_nonneg_int SCAN_ERROR_COUNT
+require_nonneg_int ADVISORY_COUNT
+require_nonneg_int MINIMUM_RELEASE_AGE_DAYS
+
+error_total=$(( AGE_ERROR_COUNT + SCAN_ERROR_COUNT ))
+
+# --- gate_state (priority order) ---
+if [ "$GUARD_TRIGGERED" = "true" ]; then
+  gate_state="error"
+elif [ "$error_total" -gt 0 ]; then
+  gate_state="error"
+elif [ "$AGE_VIOLATION_COUNT" -gt 0 ] && [ "$FAIL_ON_AGE_VIOLATION" = "true" ]; then
+  gate_state="failure"
+else
+  gate_state="success"
+fi
+
+# --- label booleans (independent facts) ---
+if [ "$GUARD_TRIGGERED" = "true" ] || [ "$error_total" -gt 0 ]; then
+  has_safety_error="true"
+else
+  has_safety_error="false"
+fi
+
+if [ "$AGE_VIOLATION_COUNT" -gt 0 ]; then
+  has_age_violation="true"
+else
+  has_age_violation="false"
+fi
+
+if [ "$ADVISORY_COUNT" -gt 0 ]; then
+  has_security_review="true"
+else
+  has_security_review="false"
+fi
+
+# --- auto_merge_ok (final boolean) ---
+if [ "$AUTO_MERGE" = "true" ] \
+   && [ "$GUARD_TRIGGERED" = "false" ] \
+   && [ "$error_total" -eq 0 ] \
+   && [ "$AGE_VIOLATION_COUNT" -eq 0 ] \
+   && [ "$ADVISORY_COUNT" -eq 0 ]; then
+  auto_merge_ok="true"
+else
+  auto_merge_ok="false"
+fi
+
+# --- status_desc (≤140 chars, composed per priority winner) ---
+if [ "$GUARD_TRIGGERED" = "true" ]; then
+  status_desc="Could not extract dependencies from diff. Manual review required."
+elif [ "$error_total" -gt 0 ]; then
+  status_desc="Scan errors: ${AGE_ERROR_COUNT} age lookup(s), ${SCAN_ERROR_COUNT} advisory query/ies. Re-run or push to retry."
+elif [ "$AGE_VIOLATION_COUNT" -gt 0 ] && [ "$FAIL_ON_AGE_VIOLATION" = "true" ]; then
+  status_desc="${AGE_VIOLATION_COUNT} package(s) younger than ${MINIMUM_RELEASE_AGE_DAYS}d cooldown — Dependabot native cooldown invariant violated."
+elif [ "$ADVISORY_COUNT" -gt 0 ]; then
+  status_desc="${ADVISORY_COUNT} advisory/ies found (version-filtered). Manual review required."
+elif [ "$AGE_VIOLATION_COUNT" -gt 0 ]; then
+  status_desc="${AGE_VIOLATION_COUNT} package(s) below ${MINIMUM_RELEASE_AGE_DAYS}d cooldown (advisory mode). Auto-merge suppressed."
+elif [ "$auto_merge_ok" = "true" ]; then
+  status_desc="Clean scan (≥${MINIMUM_RELEASE_AGE_DAYS}d, no advisories). Auto-merge enabled."
+else
+  status_desc="Clean scan (≥${MINIMUM_RELEASE_AGE_DAYS}d, no advisories). Ready for merge."
+fi
+
+printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+  "$gate_state" "$auto_merge_ok" \
+  "$has_safety_error" "$has_age_violation" "$has_security_review" \
+  "$status_desc"

--- a/tests/safety-verdict.bats
+++ b/tests/safety-verdict.bats
@@ -1,0 +1,158 @@
+#!/usr/bin/env bats
+
+# Helper: invoke safety-verdict.sh with full env, capture stdout (status).
+# Tests parse the single TSV line into named fields for assertions.
+run_verdict() {
+  run bash scripts/safety-verdict.sh
+}
+
+# Helper: split last-output TSV line into named globals.
+parse_tsv() {
+  IFS=$'\t' read -r GATE_STATE AUTO_MERGE_OK HAS_SAFETY_ERROR \
+                    HAS_AGE_VIOLATION HAS_SECURITY_REVIEW STATUS_DESC \
+                    <<< "$output"
+}
+
+# Default env: clean state. Individual tests override.
+setup() {
+  export GUARD_TRIGGERED=false
+  export AGE_ERROR_COUNT=0
+  export AGE_VIOLATION_COUNT=0
+  export SCAN_ERROR_COUNT=0
+  export ADVISORY_COUNT=0
+  export FAIL_ON_AGE_VIOLATION=true
+  export MINIMUM_RELEASE_AGE_DAYS=5
+  export AUTO_MERGE=false
+}
+
+@test "clean + AUTO_MERGE=true → success, auto_merge_ok=true" {
+  export AUTO_MERGE=true
+  run_verdict
+  [ "$status" -eq 0 ]
+  parse_tsv
+  [ "$GATE_STATE" = "success" ]
+  [ "$AUTO_MERGE_OK" = "true" ]
+  [ "$HAS_SAFETY_ERROR" = "false" ]
+  [ "$HAS_AGE_VIOLATION" = "false" ]
+  [ "$HAS_SECURITY_REVIEW" = "false" ]
+  [[ "$STATUS_DESC" == *"Auto-merge enabled"* ]]
+}
+
+@test "clean + AUTO_MERGE=false → success, auto_merge_ok=false" {
+  run_verdict
+  [ "$status" -eq 0 ]
+  parse_tsv
+  [ "$GATE_STATE" = "success" ]
+  [ "$AUTO_MERGE_OK" = "false" ]
+  [[ "$STATUS_DESC" == *"Ready for merge"* ]]
+}
+
+@test "advisory only → success, has_security_review=true, auto_merge_ok=false" {
+  export ADVISORY_COUNT=2
+  export AUTO_MERGE=true
+  run_verdict
+  [ "$status" -eq 0 ]
+  parse_tsv
+  [ "$GATE_STATE" = "success" ]
+  [ "$AUTO_MERGE_OK" = "false" ]
+  [ "$HAS_SECURITY_REVIEW" = "true" ]
+  [[ "$STATUS_DESC" == *"2 advisory"* ]]
+}
+
+@test "age violation + FAIL_ON_AGE_VIOLATION=true → failure" {
+  export AGE_VIOLATION_COUNT=1
+  run_verdict
+  [ "$status" -eq 0 ]
+  parse_tsv
+  [ "$GATE_STATE" = "failure" ]
+  [ "$AUTO_MERGE_OK" = "false" ]
+  [ "$HAS_AGE_VIOLATION" = "true" ]
+  [[ "$STATUS_DESC" == *"younger than 5d"* ]]
+}
+
+@test "age violation + FAIL_ON_AGE_VIOLATION=false → success, label still applied, auto_merge_ok=false" {
+  export AGE_VIOLATION_COUNT=3
+  export FAIL_ON_AGE_VIOLATION=false
+  export AUTO_MERGE=true
+  run_verdict
+  [ "$status" -eq 0 ]
+  parse_tsv
+  [ "$GATE_STATE" = "success" ]
+  [ "$AUTO_MERGE_OK" = "false" ]
+  [ "$HAS_AGE_VIOLATION" = "true" ]
+  [[ "$STATUS_DESC" == *"advisory mode"* ]]
+}
+
+@test "age lookup error → error, has_safety_error=true" {
+  export AGE_ERROR_COUNT=1
+  run_verdict
+  [ "$status" -eq 0 ]
+  parse_tsv
+  [ "$GATE_STATE" = "error" ]
+  [ "$AUTO_MERGE_OK" = "false" ]
+  [ "$HAS_SAFETY_ERROR" = "true" ]
+  [[ "$STATUS_DESC" == *"Scan errors"* ]]
+}
+
+@test "scan error (GHSA/OSV) → error, has_safety_error=true" {
+  export SCAN_ERROR_COUNT=2
+  run_verdict
+  [ "$status" -eq 0 ]
+  parse_tsv
+  [ "$GATE_STATE" = "error" ]
+  [ "$HAS_SAFETY_ERROR" = "true" ]
+}
+
+@test "guard triggered → error, has_safety_error=true" {
+  export GUARD_TRIGGERED=true
+  run_verdict
+  [ "$status" -eq 0 ]
+  parse_tsv
+  [ "$GATE_STATE" = "error" ]
+  [ "$HAS_SAFETY_ERROR" = "true" ]
+  [[ "$STATUS_DESC" == *"Could not extract"* ]]
+}
+
+@test "multi: scan_error + age_violation + advisory → error wins, all labels true" {
+  export SCAN_ERROR_COUNT=1
+  export AGE_VIOLATION_COUNT=1
+  export ADVISORY_COUNT=1
+  export AUTO_MERGE=true
+  run_verdict
+  [ "$status" -eq 0 ]
+  parse_tsv
+  [ "$GATE_STATE" = "error" ]
+  [ "$AUTO_MERGE_OK" = "false" ]
+  [ "$HAS_SAFETY_ERROR" = "true" ]
+  [ "$HAS_AGE_VIOLATION" = "true" ]
+  [ "$HAS_SECURITY_REVIEW" = "true" ]
+}
+
+@test "clean age + multiple advisories → success, only has_security_review=true" {
+  export ADVISORY_COUNT=5
+  run_verdict
+  [ "$status" -eq 0 ]
+  parse_tsv
+  [ "$GATE_STATE" = "success" ]
+  [ "$HAS_SAFETY_ERROR" = "false" ]
+  [ "$HAS_AGE_VIOLATION" = "false" ]
+  [ "$HAS_SECURITY_REVIEW" = "true" ]
+}
+
+@test "missing required env → non-zero exit (fail-closed)" {
+  unset GUARD_TRIGGERED
+  run_verdict
+  [ "$status" -ne 0 ]
+}
+
+@test "invalid bool env → non-zero exit (fail-closed)" {
+  export GUARD_TRIGGERED=maybe
+  run_verdict
+  [ "$status" -ne 0 ]
+}
+
+@test "negative int env → non-zero exit (fail-closed)" {
+  export ADVISORY_COUNT=-1
+  run_verdict
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary

Adds `dependency-safety.yml`, a reusable workflow that verifies the
Dependabot-cooldown invariant on each scan instead of enforcing its own
waiting period. Native Dependabot `cooldown.default-days: 5` owns the
wait; the workflow scans, comments, labels, and optionally auto-merges,
failing deterministically when a young target version slips through.

- New: `dependency-safety.yml`, `safety-verdict.sh`, `safety-verdict.bats`, `ci-safety.yml`
- Removed: `ci-cooldown.yml` (replaced by `ci-safety.yml`)
- Modified: `.github/dependabot.yml` (cooldown 7→5), `check-inline-sync.sh` (5→10 pairs), `README.md` (rewrite), `.claude/CLAUDE.md` (docs)
- Untouched: `dependency-cooldown.yml`, `cooldown-rescan.yml` (Phase 2 migration window)

## Test plan

- [x] `bats tests/safety-verdict.bats` — 13 scenarios pass
- [x] `bats tests/` — full suite passes (106/106)
- [x] `./scripts/check-inline-sync.sh` — all 10 pairs sync
- [x] `./scripts/lint-workflow-call.sh` — passes
- [ ] After merge: next Dependabot PR to this repo runs through `ci-safety.yml` and produces a clean verdict (or expected age-violation if a bumped action is young)

Fixes #59.