### PR TITLE
fix(safety): make dependency-safety/gate status clickable

### DIFF
--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -47,13 +47,15 @@ jobs:
             gh api "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
               -f state="success" \
               -f context="dependency-safety / gate" \
-              -f description="Non-bot PR — no cool-down required"
+              -f description="Non-bot PR — no cool-down required" \
+              -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             gh api "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
               -f state="pending" \
               -f context="dependency-safety / gate" \
-              -f description="Scanning dependencies for known exploits..."
+              -f description="Scanning dependencies for known exploits..." \
+              -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -1889,4 +1891,5 @@ jobs:
           gh api "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
             -f state="$GATE_STATE" \
             -f context="dependency-safety / gate" \
-            -f description="$STATUS_DESC"
+            -f description="$STATUS_DESC" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## Summary

- Add `target_url` to all three `gh api .../statuses/...` calls in `dependency-safety.yml` so the `dependency-safety / gate` PR check row becomes clickable.
- URL points at the current workflow run (`${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`) — in `workflow_call` context this resolves to the caller's run, where the `safety / scan` logs live.
- No script changes, no inline-sync impact, no test fixtures touched.

## Why

The gate row was rendered as a \`StatusContext\` with empty \`targetUrl\`, so users couldn't click through to see why a gate was failing or stuck pending. The legacy Statuses API documents \`target_url\` as optional but unused-by-default; we just hadn't been setting it.

## Test plan

- [ ] CI: \`ci-scripts.yml\` (bats + inline-sync + workflow-call lint) is green on this PR.
- [ ] CI: \`ci-safety.yml\` exercises the updated workflow's **non-bot early-exit path only** on this PR (this PR is human-authored, not Dependabot-authored, so the scan path is skipped by design); confirm the resulting \`dependency-safety / gate\` row on this PR is clickable and lands on this PR's safety workflow run.
- [ ] **Deferred to the next Dependabot PR after merge** (only way to exercise the pending/final-state code paths): hover the \`dependency-safety / gate\` row and confirm the link target is \`.../actions/runs/<id>\`; click through and confirm it lands on the \`Dependency Safety\` workflow run page; confirm the row remains clickable across the pending → final state transition.