### PR TITLE
fix(ci): rename ci-safety workflow to break name collision

### DIFF
--- a/.github/workflows/ci-safety.yml
+++ b/.github/workflows/ci-safety.yml
@@ -1,4 +1,4 @@
-name: Dependency Safety
+name: CI Safety
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary

- Rename `ci-safety.yml`'s `name:` from `Dependency Safety` → `CI Safety` to disambiguate it from the reusable `dependency-safety.yml` workflow it consumes (which also declares `name: Dependency Safety`).
- The reusable workflow's name is unchanged; consumer repos see no difference.
- Cosmetic on this repo's Actions tab: the dogfood row will now read "CI Safety" instead of "Dependency Safety".

## Why

After #71 merged, a phantom startup-failure run appeared on the merge commit: [run 26556546736](https://github.com/j7an/shared-workflows/actions/runs/26556546736) — 0 jobs, no logs, `event: push` against a workflow (`dependency-safety.yml`) whose `on:` block contains only `workflow_call:`.

Diagnosis: GitHub registered `ci-safety.yml` first as workflow id `281950779` with name `Dependency Safety`. When `dependency-safety.yml` was added at the same time, GitHub couldn't reuse the name and fell back to registering id `281959865` with the file path as the display name. That unresolvable name causes GitHub's check-suite scheduler to emit phantom startup-failure runs (0 jobs, no logs) on pushes that modify `dependency-safety.yml`. The same phantom failure also fired on the `fix/gate-status-target-url` branch push ([run 26556360487](https://github.com/j7an/shared-workflows/actions/runs/26556360487)) but wasn't tied to PR #71's check rollup so it didn't show up in `gh pr checks`.

Sister `workflow_call`-only workflows (`tag-release.yml`, `release.yml`) have unique names and produce no phantom runs, confirming that the collision — not "workflow_call-only-ness" — is what triggers the bug.

## Test plan

- [ ] CI: `ci-scripts.yml` (bats + inline-sync + workflow-call lint) is green on this PR.
- [ ] CI: the `CI Safety` workflow (formerly "Dependency Safety") runs on this PR's non-bot early-exit path and passes.
- [ ] **After merge:** confirm no new phantom failure run appears on the merge commit for `.github/workflows/dependency-safety.yml`. (If GitHub's workflow registry needs a beat to re-resolve names, may take one merge cycle to take effect.)
- [ ] **Deferred to next Dependabot PR:** confirm the reusable `Dependency Safety` workflow still runs end-to-end on a real Dependabot PR and the `dependency-safety / gate` status row remains clickable (validates the #71 fix is unaffected).