### PR TITLE
docs(safety): add header noting reusable consumers

### DIFF
--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -1,3 +1,8 @@
+# Reusable workflow. Consumed by external repos via
+# `uses: j7an/shared-workflows/.github/workflows/dependency-safety.yml@v3`
+# and by this repo's own ci-safety.yml (dogfood; registered as "CI Safety"
+# to keep this workflow's display name unambiguous).
+
 name: Dependency Safety
 
 on:


### PR DESCRIPTION
## Summary

- Add a 4-line top-of-file comment to `dependency-safety.yml` documenting that the workflow is reusable, consumed both externally (`uses: j7an/shared-workflows/.github/workflows/dependency-safety.yml@v3`) and internally (by `ci-safety.yml`, registered as "CI Safety").
- File-level no-op behaviorally — comment only.

## Why (genuinely useful)

When landing in this file from search or a stack trace, the first signal a reader gets is the `name:` line and the `on: workflow_call:` block. Neither tells them this workflow is dogfooded by `ci-safety.yml` in the same repo, or why `ci-safety.yml`'s display name differs from this one. Four lines of comment makes the partnership self-documenting and avoids the next maintainer relearning the relationship by archaeology.

## Why (the registration-refresh side effect)

This commit also has a side effect: GitHub re-registers the workflow on this file change, refreshing its display name from the stale path-fallback (`".github/workflows/dependency-safety.yml"`) to its declared `name:` (`"Dependency Safety"`). That stale value was the residue of the original name collision with `ci-safety.yml` (resolved in #72), and was causing GitHub's scheduler to emit phantom startup-failure runs (0 jobs, no logs) on every push that modifies this file:

- [run 26556546736](https://github.com/j7an/shared-workflows/actions/runs/26556546736) — phantom failure on the #71 merge to main
- [run 26556959117](https://github.com/j7an/shared-workflows/actions/runs/26556959117) — phantom failure on the #72 merge to main (rename alone did not refresh this workflow's registration; only a file-level change does)

Disable/enable via the workflows API was attempted as a no-commit alternative — it changed `state` to `disabled_manually` and back to `active`, but did not refresh the registered name. Only a push that modifies the workflow file triggers the resolver to re-read the `name:` field.

## Test plan

- [ ] CI: `ci-scripts.yml` is green on this PR.
- [ ] CI: `CI Safety` workflow runs the non-bot early-exit path on this PR and passes.
- [ ] **After merge:** confirm the workflow registry shows `name: "Dependency Safety"` (not the path-fallback):
  ```bash
  gh api repos/j7an/shared-workflows/actions/workflows/281959865 --jq '{id, name, state, updated_at}'
  ```
- [ ] **After merge:** confirm no new phantom failure run appears on the merge commit for `.github/workflows/dependency-safety.yml`. If one still appears, the registry refresh didn't take and we need a different approach.
- [ ] **Deferred to next Dependabot PR:** confirm the reusable workflow still runs end-to-end and the `dependency-safety / gate` row remains clickable (validates the #71 fix is unaffected).