### PR TITLE
fix(safety): rename workflow name to force registry refresh

### DIFF
--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -3,7 +3,7 @@
 # and by this repo's own ci-safety.yml (dogfood; registered as "CI Safety"
 # to keep this workflow's display name unambiguous).
 
-name: Dependency Safety
+name: Dependency Safety (reusable)
 
 on:
   workflow_call:


### PR DESCRIPTION
## Summary

- Change `dependency-safety.yml`'s `name:` from `Dependency Safety` → `Dependency Safety (reusable)`.
- Diagnostic PR: tests whether GitHub's workflow registry re-resolves the display name when the YAML `name:` value itself changes.

## Why

The `ci-safety.yml` dogfood has been silently broken since 2026-05-28 — every PR produces a 0-job phantom failure because workflow ID `281959865` (`dependency-safety.yml`) has a stale registered display name (`".github/workflows/dependency-safety.yml"`, the file-path fallback). Three prior attempts to refresh it failed:

1. **#72** (rename `ci-safety.yml` to break the original name collision) — refreshed `ci-safety.yml`'s record but not this one.
2. **API `disable`/`enable`** cycle — state went `active → disabled_manually → active`, `updated_at` advanced, but `name` field stayed at the path fallback.
3. **#73** (5-line doc comment to force a file-touch) — `updated_at` advanced again, but `name` still stuck.

This implies GitHub re-resolves the registered name only when the actual YAML `name:` value differs from what's recorded — file-touch alone isn't enough, and API state cycles don't trigger resolution at all.

## Test plan

- [ ] CI green on this PR (5/5 standard checks — phantom failures expected to keep firing until merge).
- [ ] **After merge:** verify the registry refreshed:
  ```bash
  gh api repos/j7an/shared-workflows/actions/workflows/281959865 --jq '{id, name, updated_at}'
  ```
  - If `name` is `"Dependency Safety (reusable)"` → resolver runs on `name:` value changes. Decide whether to rename back via a follow-up PR.
  - If `name` is still `".github/workflows/dependency-safety.yml"` → GitHub-side bug confirmed. Open support ticket with workflow ID and run IDs `26556546736`, `26557110156`, `26557123379`, `26557302648`.
- [ ] **After merge:** verify the next PR (or Dependabot PR) successfully runs the `safety / scan` job again — confirming the dogfood pipeline is restored.

## Rollback

The display name change is cosmetic. If we want to rename back to `Dependency Safety` after confirming the refresh works, a follow-up one-line PR does it. Consumer repos see the row label change, but the `uses:` path is unaffected — no breaking change.