### PR TITLE
fix(safety): revert target_url additions that broke ci-safety dogfood

### DIFF
--- a/.github/workflows/dep-safety.yml
+++ b/.github/workflows/dep-safety.yml
@@ -52,15 +52,13 @@ jobs:
             gh api "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
               -f state="success" \
               -f context="dependency-safety / gate" \
-              -f description="Non-bot PR — no cool-down required" \
-              -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              -f description="Non-bot PR — no cool-down required"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             gh api "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
               -f state="pending" \
               -f context="dependency-safety / gate" \
-              -f description="Scanning dependencies for known exploits..." \
-              -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              -f description="Scanning dependencies for known exploits..."
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -1896,5 +1894,4 @@ jobs:
           gh api "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
             -f state="$GATE_STATE" \
             -f context="dependency-safety / gate" \
-            -f description="$STATUS_DESC" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            -f description="$STATUS_DESC"


### PR DESCRIPTION
## Summary

Revert the three `-f target_url=...` arguments added by #71 to `gh api .../statuses/${HEAD_SHA}` calls in `dep-safety.yml`. The expressions `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}` inside a `workflow_call`-only workflow's `run:` block cause GitHub Actions' scheduler to abort caller invocations before any job launches — a 0-job startup_failure with no logs.

## How we got here

PR #71 added `target_url` to make the `dependency-safety / gate` PR status row clickable. The diff was 9 lines, lint passed, CI was green. But starting at the moment that branch was first pushed (2026-05-28 05:21), `ci-safety.yml`'s dogfood stopped running. Every PR since produced a phantom 0-job failure on both `ci-safety.yml` (the caller) and `dep-safety.yml` (the called workflow). PRs #72-#75 attempted to fix this via name-collision repair (#72), file-touch refreshes (#73), `name:` value changes (#74), and finally a file rename to force fresh workflow_id registration (#75). None worked — the new `dep-safety.yml` workflow_id (`284671829`) registered with the same broken state as its predecessor (`281959865`).

This PR localizes the regression by reverting just the 9 lines from #71 while keeping every other change (file rename, `name:` value, doc header) intact. **The dogfood ran successfully on this PR's first push** (`safety / scan` pass, 10s — see the `CI Safety` check on this PR). That's the first real ci-safety job since 2026-05-28.

The `target_url` expressions are the cause. The 9-line revert is the fix.

## Trade-off

The `dependency-safety / gate` PR status row goes back to being unclickable. That's the pre-#71 state — accepted as the price of a working dogfood. A follow-up PR will try a workaround using shell env vars (`${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`) instead of `${{ }}` expressions; if GitHub's scheduler quirk is specifically about template-expression analysis in `run:` blocks, the env-var form may sidestep it and restore clickability without re-breaking the dogfood. Filed separately so this fix can merge immediately.

## What's not changed

- File still at the new path `dep-safety.yml` (rename from #75 retained)
- Workflow `name:` still `Dependency Safety (reusable)` (from #74)
- Doc header (from #73), `ci-safety.yml` local `uses:` path (from #75), bats test path references (from #75) all intact
- Status check context, label names, HTML comment markers all unchanged (no consumer breakage)

## Refs

Phantom run IDs across the affected merges: `26556360487`, `26556546736`, `26556922328`, `26557123379`, `26557436258`, `26558104480`.

Workflow registrations after this PR merges:
- `281950779` — `ci-safety.yml`, name "CI Safety" ✅
- `284671829` — `dep-safety.yml`, name still falls back to path (zombie of the bug, but no longer affects dogfood once these lines are gone) ❓
- `281959865` — old `dependency-safety.yml`, zombie at the rename's previous path ❓

The two zombie registrations no longer match any file on `main`, so they should be inert. We can decide whether to ask GitHub to clean them up later.