### PR TITLE
fix: clear Zizmor 1.25 findings (github-app + online-audit 401)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,3 +29,7 @@ jobs:
         with:
           min-severity: medium
           min-confidence: medium
+          # Online audits do cross-repo GitHub tag lookups; in CI the default
+          # repository-scoped GITHUB_TOKEN returns 401 for public actions
+          # (e.g. astral-sh/setup-uv). Keep this required gate deterministic.
+          online-audits: false

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -91,6 +91,9 @@ jobs:
         with:
           client-id: ${{ vars.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          # Least privilege: read for checkout, write for Git Data API
+          # content/ref/tag operations (blobs, trees, commits, refs, tags).
+          permission-contents: write
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Clears the two Zizmor 1.25.2 findings blocking the zizmor-action bump (#64):

- `tag-release.yml`: narrow the App token to `permission-contents: write` (least privilege for checkout + Git Data API content/ref/tag writes).
- `security.yml`: set `online-audits: false` with an explanatory comment. The `impostor-commit` online audit returns 401 on cross-repo tag lookups under 1.25.2 even with the action's default `${{ github.token }}`; disabling keeps the required gate deterministic and matches the documented local command (which already uses `--no-online-audits`).

Does NOT bump the `zizmor-action` SHA — PR #64 carries that and will rebase onto this fix to validate the end-to-end v0.5.6 path.

## Test Plan
- [x] `zizmor . --min-severity medium --min-confidence medium --no-progress --color never --no-online-audits` → no findings (github-app cleared) under engine 1.25.2
- [x] `./scripts/check-inline-sync.sh` passes
- [x] `./scripts/lint-workflow-call.sh` passes
- [x] `bats tests/` → 204 passing, 0 failures

Fixes #68.