### PR TITLE
feat(publish-npm): reusable npm trusted-publishing workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -468,6 +468,99 @@ The workflow run summary includes a per-entry table:
 | `server.json` | `.packages[0].version` | `0.8.1` -> `0.10.0` | updated |
 | `package.json` | `.version` | `0.10.0` | already up to date |
 
+## `publish-npm.yml`
+
+Builds one npm tarball with `npm pack --json`, publishes that verified tarball
+to npm through npm trusted publishing, verifies registry visibility, optionally
+runs a caller-owned install check, and creates or updates a GitHub Release with
+the same `*.tgz` attached.
+
+### Trusted Publishing status
+
+This reusable workflow is intentionally supported for npm trusted publishing
+under npm's current GitHub Actions semantics.
+
+This differs from the PyPI guidance below. PyPI currently does not authorize a
+cross-repo reusable workflow as the Trusted Publisher workflow, so new PyPI
+package repos should use the caller-owned template. npm validates the caller workflow filename for `workflow_call` releases, not the reusable workflow
+that contains the `npm publish` command. That means each package repo configures
+npm trusted publishing against its own caller workflow, while the shared publish
+logic can live in `j7an/shared-workflows`.
+
+If npm changes this validation model to require the workflow containing
+`npm publish`, revisit this workflow and move npm publishing to a caller-owned
+template.
+
+### Inputs
+
+| Input | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `tag` | string | yes | - | Semver tag to publish, such as `v1.2.3`. |
+| `package-name` | string | yes | - | npm package name used for registry verification. |
+| `test-command` | string | no | `""` | Optional pre-pack command run in the caller checkout. |
+| `pack-contents-script` | string | no | `""` | Optional script run as `sh <script> pack.json` after `npm pack --json`. |
+| `verify-command` | string | no | `""` | Optional post-registry verification command run with `PACKAGE` and `VERSION` in the environment. |
+
+If `npm pack` depends on installed dependencies, generated files, or lifecycle
+scripts such as `prepare` or `prepack`, include the required setup in
+`test-command`, for example `npm ci && npm test && npm run build`. The reusable
+workflow does not run `npm ci` by default because not every npm package uses a
+lockfile or a build step.
+
+### Caller setup
+
+The caller workflow must grant:
+
+```yaml
+permissions:
+  contents: write
+  id-token: write
+```
+
+Configure the npm trusted publisher in the package settings, not in this repo:
+
+- Repository: the package repo, for example `j7an/superpowers-wrapper`
+- Workflow filename: the workflow filename in the package repo, for example
+  `release.yml`
+- Environment: `npm`
+- Allowed actions: `npm publish` only, not `npm stage publish`
+
+npm trusted publishing requires npm CLI `>= 11.5.1`; the reusable workflow
+enforces that floor before publishing. Do not pass `--provenance` or set
+`NPM_CONFIG_PROVENANCE`. npm generates provenance automatically for a public package
+published from a public repository through trusted publishing.
+
+### Example caller
+
+```yaml
+name: Publish npm
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    uses: j7an/shared-workflows/.github/workflows/publish-npm.yml@v4
+    with:
+      tag: ${{ github.ref_name }}
+      package-name: superpowers-wrapper
+      test-command: sh tests/run.sh
+      pack-contents-script: tests/assert_pack_contents.sh
+      verify-command: |
+        OUT=$(npx --yes "${PACKAGE}@${VERSION}" --version)
+        test "$OUT" = "$VERSION"
+```
+
+For packages without a CLI or install smoke test, omit `verify-command`. The
+workflow still verifies that `npm view <package>@<version> version` returns
+success before creating the GitHub Release.
+
 ## `publish-pypi.yml`
 
 Builds a Python package with `uv build`, stages on TestPyPI with install

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -482,9 +482,10 @@ under npm's current GitHub Actions semantics.
 
 This differs from the PyPI guidance below. PyPI currently does not authorize a
 cross-repo reusable workflow as the Trusted Publisher workflow, so new PyPI
-package repos should use the caller-owned template. npm validates the caller workflow filename for `workflow_call` releases, not the reusable workflow
-that contains the `npm publish` command. That means each package repo configures
-npm trusted publishing against its own caller workflow, while the shared publish
+package repos should use the caller-owned template. npm validates the caller
+workflow filename for `workflow_call` releases, not the reusable workflow that
+contains the `npm publish` command. That means each package repo configures npm
+trusted publishing against its own caller workflow, while the shared publish
 logic can live in `j7an/shared-workflows`.
 
 If npm changes this validation model to require the workflow containing
@@ -527,8 +528,8 @@ Configure the npm trusted publisher in the package settings, not in this repo:
 
 npm trusted publishing requires npm CLI `>= 11.5.1`; the reusable workflow
 enforces that floor before publishing. Do not pass `--provenance` or set
-`NPM_CONFIG_PROVENANCE`. npm generates provenance automatically for a public package
-published from a public repository through trusted publishing.
+`NPM_CONFIG_PROVENANCE`. npm generates provenance automatically for a public
+package published from a public repository through trusted publishing.
 
 ### Example caller
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -57,7 +57,6 @@ jobs:
           TAG: ${{ inputs.tag }}
         run: |
           TAG_SHA=$(git rev-list -n1 "$TAG")
-          git fetch origin main
           if ! git merge-base --is-ancestor "$TAG_SHA" origin/main; then
             echo "::error::Tag ${TAG} (${TAG_SHA}) is not an ancestor of origin/main - refusing to publish"
             exit 1

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,222 @@
+name: Publish npm
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        type: string
+        required: true
+        description: "Semver tag to publish, such as v1.2.3"
+      package-name:
+        type: string
+        required: true
+        description: "npm package name used for post-publish registry verification"
+      test-command:
+        type: string
+        required: false
+        default: ""
+        description: "Optional caller repo command to run before packing"
+      pack-contents-script:
+        type: string
+        required: false
+        default: ""
+        description: "Optional caller repo script run as 'sh <script> pack.json' after npm pack"
+      verify-command:
+        type: string
+        required: false
+        default: ""
+        description: "Optional post-registry verification command run with PACKAGE and VERSION in env"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-npm-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout at tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+
+      - name: Verify tag is ancestor of main
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          TAG_SHA=$(git rev-list -n1 "$TAG")
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$TAG_SHA" origin/main; then
+            echo "::error::Tag ${TAG} (${TAG_SHA}) is not an ancestor of origin/main - refusing to publish"
+            exit 1
+          fi
+          echo "Tag ${TAG} (${TAG_SHA}) is an ancestor of main - proceeding."
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+
+      - name: Verify tag version matches package.json
+        id: version
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          VERSION=$(printf '%s' "$TAG" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9][A-Za-z0-9.-]*)?$' || true)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not parse semver version from tag '$TAG'"
+            exit 1
+          fi
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ${VERSION} != package.json version ${PKG_VERSION} - refusing to publish"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Run caller test command
+        env:
+          TEST_COMMAND: ${{ inputs.test-command }}
+        run: |
+          if [ -n "$TEST_COMMAND" ]; then
+            sh -c "$TEST_COMMAND"
+          else
+            echo "No caller test command configured; skipping."
+          fi
+
+      - name: Pack once and assert tarball contents
+        env:
+          PACK_CONTENTS_SCRIPT: ${{ inputs.pack-contents-script }}
+        run: |
+          npm pack --json > pack.json
+          if [ -n "$PACK_CONTENTS_SCRIPT" ]; then
+            sh "$PACK_CONTENTS_SCRIPT" pack.json
+          fi
+          TARBALL_COUNT=$(find . -maxdepth 1 -type f -name '*.tgz' | wc -l | tr -d ' ')
+          if [ "$TARBALL_COUNT" != "1" ]; then
+            echo "::error::Expected exactly one npm tarball, found ${TARBALL_COUNT}"
+            find . -maxdepth 1 -type f -name '*.tgz' -print
+            exit 1
+          fi
+          ls -lh ./*.tgz
+
+      - name: Upload tarball artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-dist
+          path: "*.tgz"
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      id-token: write   # OIDC for npm trusted publishing
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+
+      - name: Enforce publish runtime floors
+        run: |
+          NODE_V=$(node --version | sed 's/^v//')
+          NPM_V=$(npm --version)
+          printf '24.0.0\n%s\n' "$NODE_V" | sort -V -C || { echo "::error::node ${NODE_V} is below the Node 24 LTS publish floor"; exit 1; }
+          printf '11.5.1\n%s\n' "$NPM_V" | sort -V -C || { echo "::error::npm ${NPM_V} is below the 11.5.1 trusted-publishing floor"; exit 1; }
+          echo "node ${NODE_V} / npm ${NPM_V} meet the publish runtime floors"
+
+      - name: Download tarball artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-dist
+          path: .
+
+      - name: Publish to npm
+        run: npm publish ./*.tgz
+
+      - name: Verify on registry and run caller verification
+        env:
+          PACKAGE: ${{ inputs.package-name }}
+          VERSION: ${{ needs.build.outputs.version }}
+          VERIFY_COMMAND: ${{ inputs.verify-command }}
+        run: |
+          SLEEPS="30 60 90 120 150"
+          ATTEMPT=0
+          for s in $SLEEPS; do
+            ATTEMPT=$((ATTEMPT + 1))
+            echo "Attempt ${ATTEMPT}/5: sleeping ${s}s before registry check..."
+            sleep "$s"
+            if npm view "${PACKAGE}@${VERSION}" version; then
+              echo "Registry lists ${PACKAGE}@${VERSION}"
+              if [ -n "$VERIFY_COMMAND" ]; then
+                sh -c "$VERIFY_COMMAND"
+              else
+                echo "No caller verify command configured; registry check is the final verification."
+              fi
+              exit 0
+            fi
+            echo "Attempt ${ATTEMPT} failed - will retry."
+          done
+          echo "::error::Registry verification failed after 5 attempts"
+          exit 1
+
+  github-release:
+    needs: [build, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # create GitHub release, upload tarball asset
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout at tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+
+      - name: Download tarball artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-dist
+          path: .
+
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          ls ./*.tgz >/dev/null
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, uploading tarball asset"
+            gh release upload "$TAG" ./*.tgz --clobber
+            exit 0
+          fi
+          ARGS=( "$TAG" --title "$TAG" --generate-notes --verify-tag )
+          if [[ "$VERSION" == *-* ]]; then
+            ARGS+=( --prerelease )
+          fi
+          ARGS+=( ./*.tgz )
+          gh release create "${ARGS[@]}"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Verify tag is ancestor of main
         env:
@@ -151,7 +152,15 @@ jobs:
           path: .
 
       - name: Publish to npm
-        run: npm publish ./*.tgz
+        env:
+          PACKAGE: ${{ inputs.package-name }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          if npm view "${PACKAGE}@${VERSION}" version >/dev/null 2>&1; then
+            echo "${PACKAGE}@${VERSION} already exists on npm; skipping npm publish."
+            exit 0
+          fi
+          npm publish ./*.tgz
 
       - name: Verify on registry and run caller verification
         env:
@@ -159,24 +168,36 @@ jobs:
           VERSION: ${{ needs.build.outputs.version }}
           VERIFY_COMMAND: ${{ inputs.verify-command }}
         run: |
+          run_caller_verification() {
+            if [ -n "$VERIFY_COMMAND" ]; then
+              sh -c "$VERIFY_COMMAND"
+            else
+              echo "No caller verify command configured; registry check is the final verification."
+            fi
+          }
+
+          ATTEMPT=1
+          echo "Attempt 1/6: checking registry before sleep..."
+          if npm view "${PACKAGE}@${VERSION}" version; then
+            echo "Registry lists ${PACKAGE}@${VERSION}"
+            run_caller_verification
+            exit 0
+          fi
+          echo "Attempt ${ATTEMPT} failed - will retry."
+
           SLEEPS="30 60 90 120 150"
-          ATTEMPT=0
           for s in $SLEEPS; do
             ATTEMPT=$((ATTEMPT + 1))
-            echo "Attempt ${ATTEMPT}/5: sleeping ${s}s before registry check..."
+            echo "Attempt ${ATTEMPT}/6: sleeping ${s}s before registry check..."
             sleep "$s"
             if npm view "${PACKAGE}@${VERSION}" version; then
               echo "Registry lists ${PACKAGE}@${VERSION}"
-              if [ -n "$VERIFY_COMMAND" ]; then
-                sh -c "$VERIFY_COMMAND"
-              else
-                echo "No caller verify command configured; registry check is the final verification."
-              fi
+              run_caller_verification
               exit 0
             fi
             echo "Attempt ${ATTEMPT} failed - will retry."
           done
-          echo "::error::Registry verification failed after 5 attempts"
+          echo "::error::Registry verification failed after 6 attempts"
           exit 1
 
   github-release:
@@ -195,6 +216,7 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download tarball artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/tests/publish-npm-docs.bats
+++ b/tests/publish-npm-docs.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# publish-npm-docs.bats - docs contract checks for publish-npm.yml
+
+README=".github/workflows/README.md"
+
+publish_npm_section() {
+  awk '
+    /^## `publish-npm.yml`$/ { flag=1; print; next }
+    /^## `/ && flag { exit }
+    flag { print }
+  ' "$README"
+}
+
+assert_contains() {
+  local text="$1"
+  local expected="$2"
+  [[ "$text" == *"$expected"* ]]
+}
+
+@test "README documents publish-npm.yml" {
+  section="$(publish_npm_section)"
+  assert_contains "$section" '## `publish-npm.yml`'
+  assert_contains "$section" 'npm trusted publishing'
+}
+
+@test "README records npm-vs-PyPI reusable workflow distinction" {
+  section="$(publish_npm_section)"
+  assert_contains "$section" 'npm validates the caller workflow filename'
+  assert_contains "$section" 'If npm changes this validation model'
+  assert_contains "$section" 'caller-owned template'
+}
+
+@test "README documents npm trusted publisher caller setup" {
+  section="$(publish_npm_section)"
+  assert_contains "$section" 'workflow filename in the package repo'
+  assert_contains "$section" 'Environment: `npm`'
+  assert_contains "$section" 'Allowed actions: `npm publish` only'
+}
+
+@test "README documents provenance caveat" {
+  section="$(publish_npm_section)"
+  assert_contains "$section" 'public package'
+  assert_contains "$section" 'public repository'
+  assert_contains "$section" 'Do not pass `--provenance`'
+}
+
+@test "README caller example pins released shared-workflows tag line" {
+  section="$(publish_npm_section)"
+  assert_contains "$section" 'j7an/shared-workflows/.github/workflows/publish-npm.yml@v4'
+  ! printf '%s\n' "$section" | grep -q '@main'
+  ! printf '%s\n' "$section" | grep -q '@v5'
+}
+
+@test "README shows generic optional verify command, not hard-coded workflow behavior" {
+  section="$(publish_npm_section)"
+  assert_contains "$section" 'verify-command'
+  assert_contains "$section" 'npx --yes "${PACKAGE}@${VERSION}" --version'
+  assert_contains "$section" 'omit `verify-command`'
+}
+
+@test "README documents caller-owned install and build setup before npm pack" {
+  section="$(publish_npm_section)"
+  assert_contains "$section" 'prepare` or `prepack`'
+  assert_contains "$section" 'npm ci && npm test && npm run build'
+  assert_contains "$section" 'does not run `npm ci` by default'
+}

--- a/tests/publish-npm-docs.bats
+++ b/tests/publish-npm-docs.bats
@@ -17,6 +17,10 @@ assert_contains() {
   [[ "$text" == *"$expected"* ]]
 }
 
+normalize_ws() {
+  tr '\n' ' ' | tr -s ' '
+}
+
 @test "README documents publish-npm.yml" {
   section="$(publish_npm_section)"
   assert_contains "$section" '## `publish-npm.yml`'
@@ -25,7 +29,8 @@ assert_contains() {
 
 @test "README records npm-vs-PyPI reusable workflow distinction" {
   section="$(publish_npm_section)"
-  assert_contains "$section" 'npm validates the caller workflow filename'
+  normalized="$(printf '%s\n' "$section" | normalize_ws)"
+  assert_contains "$normalized" 'npm validates the caller workflow filename'
   assert_contains "$section" 'If npm changes this validation model'
   assert_contains "$section" 'caller-owned template'
 }
@@ -39,8 +44,9 @@ assert_contains() {
 
 @test "README documents provenance caveat" {
   section="$(publish_npm_section)"
-  assert_contains "$section" 'public package'
-  assert_contains "$section" 'public repository'
+  normalized="$(printf '%s\n' "$section" | normalize_ws)"
+  assert_contains "$normalized" 'public package'
+  assert_contains "$normalized" 'public repository'
   assert_contains "$section" 'Do not pass `--provenance`'
 }
 
@@ -63,4 +69,22 @@ assert_contains() {
   assert_contains "$section" 'prepare` or `prepack`'
   assert_contains "$section" 'npm ci && npm test && npm run build'
   assert_contains "$section" 'does not run `npm ci` by default'
+}
+
+@test "README publish-npm prose lines stay wrapped" {
+  section="$(publish_npm_section)"
+  in_fence=0
+  while IFS= read -r line; do
+    if [[ "$line" == '```'* ]]; then
+      if [ "$in_fence" -eq 0 ]; then
+        in_fence=1
+      else
+        in_fence=0
+      fi
+      continue
+    fi
+    [ "$in_fence" -eq 1 ] && continue
+    [[ "$line" == '|'* ]] && continue
+    [ "${#line}" -le 88 ]
+  done <<< "$section"
 }

--- a/tests/publish-npm-workflow-contract.bats
+++ b/tests/publish-npm-workflow-contract.bats
@@ -70,12 +70,12 @@ run_blocks() {
   grep -qF 'cancel-in-progress: false' "$YAML"
 }
 
-@test "build job checks out the tag and verifies it is on main" {
+@test "build job checks out full tag history and verifies it is on main" {
   job="$(build_job)"
   assert_contains "$job" 'ref: ${{ inputs.tag }}'
   assert_contains "$job" 'fetch-depth: 0'
   assert_contains "$job" 'persist-credentials: false'
-  assert_contains "$job" 'git fetch origin main'
+  assert_lacks "$job" 'git fetch origin main'
   assert_contains "$job" 'merge-base --is-ancestor'
 }
 

--- a/tests/publish-npm-workflow-contract.bats
+++ b/tests/publish-npm-workflow-contract.bats
@@ -1,0 +1,153 @@
+#!/usr/bin/env bats
+# publish-npm-workflow-contract.bats - static contract checks for publish-npm.yml
+
+YAML=".github/workflows/publish-npm.yml"
+
+workflow_inputs_block() {
+  sed -n '/^  workflow_call:$/,/^permissions:$/p' "$YAML"
+}
+
+build_job() {
+  sed -n '/^  build:$/,/^  publish:$/p' "$YAML"
+}
+
+publish_job() {
+  sed -n '/^  publish:$/,/^  github-release:$/p' "$YAML"
+}
+
+github_release_job() {
+  sed -n '/^  github-release:$/,$p' "$YAML"
+}
+
+input_block() {
+  local input="$1"
+  workflow_inputs_block | sed -n "/^      ${input}:$/,/^      [a-zA-Z0-9_-]*:$/p"
+}
+
+assert_contains() {
+  local text="$1"
+  local expected="$2"
+  [[ "$text" == *"$expected"* ]]
+}
+
+assert_lacks() {
+  local text="$1"
+  local forbidden="$2"
+  [[ "$text" != *"$forbidden"* ]]
+}
+
+run_blocks() {
+  awk '
+    /^        run: \|$/ { in_run=1; next }
+    in_run && /^      - / { in_run=0; next }
+    in_run && /^    [A-Za-z0-9_-]+:/ { in_run=0; next }
+    in_run { print }
+  ' "$YAML"
+}
+
+@test "publish-npm.yml is workflow_call only with generic inputs" {
+  grep -q '^  workflow_call:$' "$YAML"
+  ! grep -qE '^  (push|pull_request|workflow_dispatch|schedule):' "$YAML"
+
+  inputs="$(workflow_inputs_block)"
+  assert_contains "$inputs" "tag:"
+  assert_contains "$inputs" "package-name:"
+  assert_contains "$inputs" "test-command:"
+  assert_contains "$inputs" "pack-contents-script:"
+  assert_contains "$inputs" "verify-command:"
+}
+
+@test "optional caller hooks default to empty strings" {
+  assert_contains "$(input_block test-command)" 'default: ""'
+  assert_contains "$(input_block pack-contents-script)" 'default: ""'
+  assert_contains "$(input_block verify-command)" 'default: ""'
+}
+
+@test "publish-npm.yml serializes releases by tag" {
+  grep -q '^concurrency:$' "$YAML"
+  grep -qF 'group: publish-npm-${{ inputs.tag }}' "$YAML"
+  grep -qF 'cancel-in-progress: false' "$YAML"
+}
+
+@test "build job checks out the tag and verifies it is on main" {
+  job="$(build_job)"
+  assert_contains "$job" 'ref: ${{ inputs.tag }}'
+  assert_contains "$job" 'fetch-depth: 0'
+  assert_contains "$job" 'git fetch origin main'
+  assert_contains "$job" 'merge-base --is-ancestor'
+}
+
+@test "build job gates tag version against package.json version" {
+  job="$(build_job)"
+  assert_contains "$job" "require('./package.json').version"
+  assert_contains "$job" 'refusing to publish'
+  assert_contains "$job" 'version=$VERSION'
+}
+
+@test "build job uses Node 24 and optional caller pre-pack hooks" {
+  job="$(build_job)"
+  assert_contains "$job" 'node-version: "24"'
+  assert_contains "$job" 'TEST_COMMAND: ${{ inputs.test-command }}'
+  assert_contains "$job" 'if [ -n "$TEST_COMMAND" ]; then'
+  assert_contains "$job" 'PACK_CONTENTS_SCRIPT: ${{ inputs.pack-contents-script }}'
+  assert_contains "$job" 'sh "$PACK_CONTENTS_SCRIPT" pack.json'
+}
+
+@test "build job packs once and uploads npm-dist tarball artifact" {
+  job="$(build_job)"
+  assert_contains "$job" 'npm pack --json > pack.json'
+  assert_contains "$job" "name: npm-dist"
+  assert_contains "$job" 'path: "*.tgz"'
+  assert_contains "$job" 'if-no-files-found: error'
+}
+
+@test "publish job declares OIDC permission and npm environment" {
+  job="$(publish_job)"
+  assert_contains "$job" 'environment: npm'
+  assert_contains "$job" 'id-token: write'
+}
+
+@test "publish job uses Node 24 and enforces npm trusted-publishing floor" {
+  job="$(publish_job)"
+  assert_contains "$job" 'node-version: "24"'
+  assert_contains "$job" '24.0.0'
+  assert_contains "$job" '11.5.1'
+}
+
+@test "publish job publishes the downloaded tarball without explicit provenance config" {
+  job="$(publish_job)"
+  assert_contains "$job" 'name: npm-dist'
+  assert_contains "$job" 'npm publish ./*.tgz'
+  ! grep -qE -- '--provenance|NPM_CONFIG_PROVENANCE' "$YAML"
+}
+
+@test "publish job verifies registry visibility and optional caller verify-command" {
+  job="$(publish_job)"
+  assert_contains "$job" 'npm view "${PACKAGE}@${VERSION}" version'
+  assert_contains "$job" 'VERIFY_COMMAND: ${{ inputs.verify-command }}'
+  assert_contains "$job" 'if [ -n "$VERIFY_COMMAND" ]; then'
+  assert_contains "$job" 'sh -c "$VERIFY_COMMAND"'
+}
+
+@test "GitHub Release job attaches the verified tarball and handles existing releases" {
+  job="$(github_release_job)"
+  assert_contains "$job" 'needs: [build, publish]'
+  assert_contains "$job" 'contents: write'
+  assert_contains "$job" 'name: npm-dist'
+  assert_contains "$job" 'gh release upload "$TAG" ./*.tgz --clobber'
+  assert_contains "$job" 'ARGS+=( ./*.tgz )'
+  assert_contains "$job" '--generate-notes'
+  assert_contains "$job" '--verify-tag'
+}
+
+@test "GitHub Release prerelease classification uses parsed version, not full tag" {
+  job="$(github_release_job)"
+  assert_contains "$job" 'VERSION: ${{ needs.build.outputs.version }}'
+  assert_contains "$job" '[[ "$VERSION" == *-* ]]'
+  assert_lacks "$job" '[[ "$TAG" == *-* ]]'
+}
+
+@test "inputs reach shell run blocks through env indirection" {
+  runs="$(run_blocks)"
+  assert_lacks "$runs" '${{ inputs.'
+}

--- a/tests/publish-npm-workflow-contract.bats
+++ b/tests/publish-npm-workflow-contract.bats
@@ -39,6 +39,7 @@ assert_lacks() {
 run_blocks() {
   awk '
     /^        run: \|$/ { in_run=1; next }
+    /^        run: / { sub(/^        run: /, ""); print; next }
     in_run && /^      - / { in_run=0; next }
     in_run && /^    [A-Za-z0-9_-]+:/ { in_run=0; next }
     in_run { print }
@@ -73,6 +74,7 @@ run_blocks() {
   job="$(build_job)"
   assert_contains "$job" 'ref: ${{ inputs.tag }}'
   assert_contains "$job" 'fetch-depth: 0'
+  assert_contains "$job" 'persist-credentials: false'
   assert_contains "$job" 'git fetch origin main'
   assert_contains "$job" 'merge-base --is-ancestor'
 }
@@ -117,12 +119,15 @@ run_blocks() {
 @test "publish job publishes the downloaded tarball without explicit provenance config" {
   job="$(publish_job)"
   assert_contains "$job" 'name: npm-dist'
+  assert_contains "$job" 'if npm view "${PACKAGE}@${VERSION}" version >/dev/null 2>&1; then'
+  assert_contains "$job" 'already exists on npm; skipping npm publish.'
   assert_contains "$job" 'npm publish ./*.tgz'
   ! grep -qE -- '--provenance|NPM_CONFIG_PROVENANCE' "$YAML"
 }
 
 @test "publish job verifies registry visibility and optional caller verify-command" {
   job="$(publish_job)"
+  assert_contains "$job" 'Attempt 1/6: checking registry before sleep...'
   assert_contains "$job" 'npm view "${PACKAGE}@${VERSION}" version'
   assert_contains "$job" 'VERIFY_COMMAND: ${{ inputs.verify-command }}'
   assert_contains "$job" 'if [ -n "$VERIFY_COMMAND" ]; then'
@@ -134,6 +139,7 @@ run_blocks() {
   assert_contains "$job" 'needs: [build, publish]'
   assert_contains "$job" 'contents: write'
   assert_contains "$job" 'name: npm-dist'
+  assert_contains "$job" 'persist-credentials: false'
   assert_contains "$job" 'gh release upload "$TAG" ./*.tgz --clobber'
   assert_contains "$job" 'ARGS+=( ./*.tgz )'
   assert_contains "$job" '--generate-notes'
@@ -149,5 +155,6 @@ run_blocks() {
 
 @test "inputs reach shell run blocks through env indirection" {
   runs="$(run_blocks)"
+  assert_contains "$runs" 'npm publish ./*.tgz'
   assert_lacks "$runs" '${{ inputs.'
 }

--- a/tests/security-scan-workflow-contract.bats
+++ b/tests/security-scan-workflow-contract.bats
@@ -240,7 +240,7 @@ codeql_queries'
   assert_contains "$block" "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0"
   assert_contains "$block" "fetch-depth: 0"
   assert_contains "$block" "persist-credentials: false"
-  assert_contains "$block" "trufflesecurity/trufflehog@30d5bb91af1a771378349dbbb0c82129392acf70 # v3.95.6"
+  assert_contains "$block" "trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f # v3.95.8"
   assert_contains "$block" "continue-on-error: true"
   assert_contains "$block" "extra_args: --results=verified"
   assert_contains "$block" "steps.trufflehog.outcome == 'failure'"


### PR DESCRIPTION
Adds `publish-npm.yml` as a `workflow_call` reusable npm publisher:

- tag ancestry guard and tag/package version gate
- build-once `npm pack --json` tarball artifact
- OIDC npm publish from the `npm` environment without explicit provenance flags
- registry visibility check plus optional caller verification
- GitHub Release tarball attachment from the same verified artifact

Documents the npm-vs-PyPI Trusted Publishing distinction and caller setup in `.github/workflows/README.md`.

Also updates the security-scan contract test to match the TruffleHog pin already bumped on `origin/main`.

Fixes #98
