### PR TITLE
test: prevent literal action pin snapshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ A reusable workflow cannot reliably check out *its own* repo's scripts: in a `wo
 
 - **Bash 3.2 compatible** — scripts run on macOS system bash; no associative arrays, no `mapfile`/`readarray`.
 - **Actions are SHA-pinned** with a trailing `# vX.Y.Z` comment. When bumping, dereference the tag to the *commit* SHA, not the tag-object SHA.
-- Workflow contract tests for action pins should assert semantic policy: expected action target, full-length commit SHA, and trailing `# vX.Y.Z` comment. Do not snapshot the current SHA/version literally unless exact equality is the behavior being protected; when exact equality is intentional, say why in the test name or nearby comment and keep Dependabot grouping aligned.
+- Workflow contract tests for action pins must assert semantic policy: expected action target, full-length lowercase commit SHA, and trailing `# vX.Y.Z` comment. Never snapshot the current action SHA/version pair in Bats source. Use `tests/helpers/action-pin-assertions.bash`; `tests/action-pin-test-policy.bats` enforces this rule.
 - **Conventional Commits drive release bumps** — `tag-release.yml`'s `auto` mode infers patch/minor/major from commit subjects since the last tag. A stray `feat:` in an otherwise-`fix:` PR flips a patch release to minor.
 - `scripts/*.sh` read stdin and write TSV/line-oriented stdout; exit `2` signals malformed input, exit `0` covers the zero-rows case. See each script's header comment for its exact schema.
 - Specs and plans under `docs/superpowers/` are working notes — untracked, never committed. `.worktrees/` (gitignored) holds isolated checkouts for parallel feature work.

--- a/tests/action-pin-test-policy.bats
+++ b/tests/action-pin-test-policy.bats
@@ -58,6 +58,18 @@
   fi
 }
 
+@test "action pin helper rejects a malformed duplicate matching reference" {
+  sha=$(printf '%040d' 1)
+  block=$(printf '%s\n%s\n' \
+    "        uses: actions/checkout@$sha # v7.0.0" \
+    "        uses: actions/checkout@v7 # v7.0.0")
+
+  if assert_action_pin "$block" "actions/checkout"; then
+    echo "expected malformed duplicate action reference to fail"
+    return 1
+  fi
+}
+
 find_literal_action_pin_snapshots() {
   awk '
     /[[:alnum:]_.-]+\/[[:alnum:]_.\/-]+@[0-9A-Fa-f]{40}[[:space:]]+#[[:space:]]+v[0-9]+\.[0-9]+\.[0-9]+([^0-9.]|$)/ {

--- a/tests/action-pin-test-policy.bats
+++ b/tests/action-pin-test-policy.bats
@@ -13,6 +13,20 @@
   assert_action_pin "$block" "github/codeql-action/analyze"
 }
 
+@test "action pin helper accepts a single-quoted scalar" {
+  sha=$(printf '%040d' 1)
+  block="        uses: 'github/codeql-action/analyze@$sha' # v4.99.0"
+
+  assert_action_pin "$block" "github/codeql-action/analyze"
+}
+
+@test "action pin helper accepts a double-quoted scalar" {
+  sha=$(printf '%040d' 1)
+  block="        uses: \"github/codeql-action/analyze@$sha\" # v4.99.0"
+
+  assert_action_pin "$block" "github/codeql-action/analyze"
+}
+
 @test "action pin helper rejects malformed pins" {
   sha=$(printf '%040d' 1)
 
@@ -66,6 +80,30 @@
 
   if assert_action_pin "$block" "actions/checkout"; then
     echo "expected malformed duplicate action reference to fail"
+    return 1
+  fi
+}
+
+@test "action pin helper rejects a malformed single-quoted duplicate" {
+  sha=$(printf '%040d' 1)
+  block=$(printf '%s\n%s\n' \
+    "        uses: actions/checkout@$sha # v7.0.0" \
+    "        uses: 'actions/checkout@v7' # v7.0.0")
+
+  if assert_action_pin "$block" "actions/checkout"; then
+    echo "expected malformed single-quoted duplicate action reference to fail"
+    return 1
+  fi
+}
+
+@test "action pin helper rejects a malformed double-quoted duplicate" {
+  sha=$(printf '%040d' 1)
+  block=$(printf '%s\n%s\n' \
+    "        uses: actions/checkout@$sha # v7.0.0" \
+    "        uses: \"actions/checkout@v7\" # v7.0.0")
+
+  if assert_action_pin "$block" "actions/checkout"; then
+    echo "expected malformed double-quoted duplicate action reference to fail"
     return 1
   fi
 }

--- a/tests/action-pin-test-policy.bats
+++ b/tests/action-pin-test-policy.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+# action-pin-test-policy.bats - semantic helper and source-policy contracts for
+# workflow action-pin tests.
+
+. "$BATS_TEST_DIRNAME/helpers/action-pin-assertions.bash"
+
+@test "action pin helper accepts Dependabot SHA and version bumps" {
+  sha=$(printf '%040d' 1)
+  block=$(printf '%s\n%s\n' \
+    '      - name: Perform CodeQL analysis' \
+    "        uses: github/codeql-action/analyze@$sha # v4.99.0")
+
+  assert_action_pin "$block" "github/codeql-action/analyze"
+}
+
+@test "action pin helper rejects malformed pins" {
+  sha=$(printf '%040d' 1)
+
+  block='        uses: github/codeql-action/analyze@v4.99.0 # v4.99.0'
+  if assert_action_pin "$block" "github/codeql-action/analyze"; then
+    echo "expected non-SHA action ref to fail"
+    return 1
+  fi
+
+  block="        uses: github/codeql-action/analyze@$sha # v4"
+  if assert_action_pin "$block" "github/codeql-action/analyze"; then
+    echo "expected malformed version comment to fail"
+    return 1
+  fi
+
+  block="        uses: github/codeql-action/analyze@$sha"
+  if assert_action_pin "$block" "github/codeql-action/analyze"; then
+    echo "expected missing version comment to fail"
+    return 1
+  fi
+}
+
+@test "action pin helper requires an exact dotted target match" {
+  sha=$(printf '%040d' 1)
+  block="    uses: google/osv-scanner-action/Xgithub/workflows/osv-scanner-reusableXyml@$sha # v2.99.0"
+
+  if assert_action_pin "$block" "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml"; then
+    echo "expected exact dotted target match"
+    return 1
+  fi
+}
+
+@test "action pin helper requires exactly one matching reference" {
+  first_sha=$(printf '%040d' 1)
+  second_sha=$(printf '%040d' 2)
+  block=$(printf '%s\n%s\n' \
+    "        uses: actions/checkout@$first_sha # v7.0.0" \
+    "        uses: actions/checkout@$second_sha # v7.1.0")
+
+  if assert_action_pin "$block" "actions/checkout"; then
+    echo "expected duplicate action references to fail"
+    return 1
+  fi
+}
+
+find_literal_action_pin_snapshots() {
+  awk '
+    /[[:alnum:]_.-]+\/[[:alnum:]_.\/-]+@[0-9A-Fa-f]{40}[[:space:]]+#[[:space:]]+v[0-9]+\.[0-9]+\.[0-9]+([^0-9.]|$)/ {
+      printf "%s:%d:%s\n", FILENAME, FNR, $0
+    }
+  ' "$@"
+}
+
+@test "literal action-pin detector reports source path and line" {
+  source_file="$BATS_TEST_TMPDIR/literal-action-pin.bats"
+  sha=$(printf '%040d' 1)
+  line="assert_contains \"\$block\" \"actions/checkout@$sha # v7.0.0\""
+  printf '%s\n' "$line" >"$source_file"
+
+  run find_literal_action_pin_snapshots "$source_file"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$source_file:1:$line" ]
+}
+
+@test "literal action-pin detector requires the complete triple" {
+  source_file="$BATS_TEST_TMPDIR/non-literal-action-pins.bats"
+  sha=$(printf '%040d' 2)
+  head_sha=deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+  printf '%s\n' \
+    "HEAD_SHA=$head_sha" \
+    "uses: actions/checkout@$sha" \
+    "uses: actions/checkout@v7 # v7.0.0" \
+    'assert_action_pin "$block" "actions/checkout"' \
+    >"$source_file"
+
+  run find_literal_action_pin_snapshots "$source_file"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "workflow contract tests do not snapshot literal action pins" {
+  violations=$(find_literal_action_pin_snapshots "$BATS_TEST_DIRNAME"/*.bats)
+  if [ -n "$violations" ]; then
+    printf 'literal action-pin snapshots found:\n%s\n' "$violations"
+    return 1
+  fi
+}

--- a/tests/action-pin-test-policy.bats
+++ b/tests/action-pin-test-policy.bats
@@ -110,7 +110,7 @@
 
 find_literal_action_pin_snapshots() {
   awk '
-    /[[:alnum:]_.-]+\/[[:alnum:]_.\/-]+@[0-9A-Fa-f]{40}[[:space:]]+#[[:space:]]+v[0-9]+\.[0-9]+\.[0-9]+([^0-9.]|$)/ {
+    /[[:alnum:]_.-]+\/[[:alnum:]_.\/-]+@[0-9A-Fa-f]{40}(\\?["'"'"'])?[[:space:]]+#[[:space:]]+v[0-9]+\.[0-9]+\.[0-9]+([^0-9.]|$)/ {
       printf "%s:%d:%s\n", FILENAME, FNR, $0
     }
   ' "$@"
@@ -120,6 +120,42 @@ find_literal_action_pin_snapshots() {
   source_file="$BATS_TEST_TMPDIR/literal-action-pin.bats"
   sha=$(printf '%040d' 1)
   line="assert_contains \"\$block\" \"actions/checkout@$sha # v7.0.0\""
+  printf '%s\n' "$line" >"$source_file"
+
+  run find_literal_action_pin_snapshots "$source_file"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$source_file:1:$line" ]
+}
+
+@test "literal action-pin detector reports a single-quoted action scalar" {
+  source_file="$BATS_TEST_TMPDIR/single-quoted-action-pin.bats"
+  sha=$(printf '%040d' 3)
+  line=$(printf "uses: '%s@%s' # %s" "actions/checkout" "$sha" "v7.0.0")
+  printf '%s\n' "$line" >"$source_file"
+
+  run find_literal_action_pin_snapshots "$source_file"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$source_file:1:$line" ]
+}
+
+@test "literal action-pin detector reports a double-quoted action scalar" {
+  source_file="$BATS_TEST_TMPDIR/double-quoted-action-pin.bats"
+  sha=$(printf '%040d' 0 | tr 0 A)
+  line=$(printf 'uses: "%s@%s" # %s' "actions/checkout" "$sha" "v7.0.0")
+  printf '%s\n' "$line" >"$source_file"
+
+  run find_literal_action_pin_snapshots "$source_file"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$source_file:1:$line" ]
+}
+
+@test "literal action-pin detector reports a raw escaped closing quote" {
+  source_file="$BATS_TEST_TMPDIR/escaped-quote-action-pin.bats"
+  sha=$(printf '%040d' 5)
+  line=$(printf 'block="uses: \\"%s@%s\\" # %s"' "actions/checkout" "$sha" "v7.0.0")
   printf '%s\n' "$line" >"$source_file"
 
   run find_literal_action_pin_snapshots "$source_file"

--- a/tests/helpers/action-pin-assertions.bash
+++ b/tests/helpers/action-pin-assertions.bash
@@ -13,6 +13,13 @@ assert_action_pin() {
       sub(/^[[:space:]]*-[[:space:]]+uses:[[:space:]]*/, "", line)
       sub(/^[[:space:]]*uses:[[:space:]]*/, "", line)
 
+      quote = substr(line, 1, 1)
+      if (quote == "\"" || quote == "\047") {
+        line = substr(line, 2)
+      } else {
+        quote = ""
+      }
+
       if (index(line, target "@") != 1) {
         next
       }
@@ -25,6 +32,12 @@ assert_action_pin() {
 
       ref = substr(line, 1, separator - 1)
       comment = substr(line, separator + 3)
+      if (quote != "") {
+        if (substr(ref, length(ref), 1) != quote) {
+          next
+        }
+        ref = substr(ref, 1, length(ref) - 1)
+      }
       sha = substr(ref, length(target) + 2)
       if (sha ~ /^[0-9a-f]{40}$/ && comment ~ /^v[0-9]+\.[0-9]+\.[0-9]+$/) {
         valid_count++

--- a/tests/helpers/action-pin-assertions.bash
+++ b/tests/helpers/action-pin-assertions.bash
@@ -1,0 +1,37 @@
+# Shared semantic assertions for SHA-pinned workflow actions.
+
+assert_action_pin() {
+  local block=$1
+  local target=$2
+  local matches
+
+  matches=$(printf '%s\n' "$block" | awk -v target="$target" '
+    {
+      line = $0
+      sub(/^[[:space:]]*-[[:space:]]+uses:[[:space:]]*/, "", line)
+      sub(/^[[:space:]]*uses:[[:space:]]*/, "", line)
+
+      separator = index(line, " # ")
+      if (separator == 0) {
+        next
+      }
+
+      ref = substr(line, 1, separator - 1)
+      comment = substr(line, separator + 3)
+      if (index(ref, target "@") != 1) {
+        next
+      }
+
+      sha = substr(ref, length(target) + 2)
+      if (sha ~ /^[0-9a-f]{40}$/ && comment ~ /^v[0-9]+\.[0-9]+\.[0-9]+$/) {
+        count++
+      }
+    }
+    END { print count + 0 }
+  ')
+
+  if [ "$matches" -ne 1 ]; then
+    printf 'expected exactly one semantic action pin for:\n%s\n' "$target"
+    return 1
+  fi
+}

--- a/tests/helpers/action-pin-assertions.bash
+++ b/tests/helpers/action-pin-assertions.bash
@@ -3,13 +3,20 @@
 assert_action_pin() {
   local block=$1
   local target=$2
-  local matches
+  local counts
+  local reference_count
+  local valid_count
 
-  matches=$(printf '%s\n' "$block" | awk -v target="$target" '
+  counts=$(printf '%s\n' "$block" | awk -v target="$target" '
     {
       line = $0
       sub(/^[[:space:]]*-[[:space:]]+uses:[[:space:]]*/, "", line)
       sub(/^[[:space:]]*uses:[[:space:]]*/, "", line)
+
+      if (index(line, target "@") != 1) {
+        next
+      }
+      reference_count++
 
       separator = index(line, " # ")
       if (separator == 0) {
@@ -18,19 +25,17 @@ assert_action_pin() {
 
       ref = substr(line, 1, separator - 1)
       comment = substr(line, separator + 3)
-      if (index(ref, target "@") != 1) {
-        next
-      }
-
       sha = substr(ref, length(target) + 2)
       if (sha ~ /^[0-9a-f]{40}$/ && comment ~ /^v[0-9]+\.[0-9]+\.[0-9]+$/) {
-        count++
+        valid_count++
       }
     }
-    END { print count + 0 }
+    END { print reference_count + 0, valid_count + 0 }
   ')
+  reference_count=${counts%% *}
+  valid_count=${counts#* }
 
-  if [ "$matches" -ne 1 ]; then
+  if [ "$reference_count" -ne 1 ] || [ "$valid_count" -ne 1 ]; then
     printf 'expected exactly one semantic action pin for:\n%s\n' "$target"
     return 1
   fi

--- a/tests/pre-commit-autoupdate-workflow-contract.bats
+++ b/tests/pre-commit-autoupdate-workflow-contract.bats
@@ -2,6 +2,8 @@
 # pre-commit-autoupdate-workflow-contract.bats - static contract tests for the
 # reusable pre-commit autoupdate workflow.
 
+. "$BATS_TEST_DIRNAME/helpers/action-pin-assertions.bash"
+
 YAML=".github/workflows/pre-commit-autoupdate.yml"
 WORKFLOW_README=".github/workflows/README.md"
 ROOT_README="README.md"
@@ -190,13 +192,15 @@ title'
   assert_eq "$(job_permissions_block autoupdate)" $'    permissions:\n      contents: write\n      pull-requests: write'
 }
 
-@test "third-party actions are pinned with version comments" {
+@test "single-instance third-party actions use semantic pins" {
   block=$(job_block autoupdate)
-  assert_contains "$block" "step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4"
-  assert_contains "$block" "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0"
-  assert_contains "$block" "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0"
-  assert_contains "$block" "astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0"
-  assert_contains "$block" "peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1"
+  for target in \
+    step-security/harden-runner \
+    actions/create-github-app-token \
+    actions/checkout \
+    astral-sh/setup-uv; do
+    assert_action_pin "$block" "$target"
+  done
 }
 
 @test "App token minting is conditional and requests contents plus pull-requests write" {
@@ -210,7 +214,7 @@ title'
 
 @test "checkout does not persist credentials" {
   block=$(step_block "Checkout repository")
-  assert_contains "$block" "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0"
+  assert_action_pin "$block" "actions/checkout"
   assert_contains "$block" "persist-credentials: false"
 }
 
@@ -265,6 +269,8 @@ title'
   restricted=$(step_block "Open restricted PR with updates")
   unrestricted=$(step_block "Open unrestricted PR with updates")
 
+  assert_action_pin "$restricted" "peter-evans/create-pull-request"
+  assert_action_pin "$unrestricted" "peter-evans/create-pull-request"
   assert_contains "$restricted" "inputs.restrict_paths"
   assert_contains "$restricted" 'add-paths: ${{ inputs.config_path }}'
   assert_contains "$restricted" "delete-branch: true"

--- a/tests/security-scan-workflow-contract.bats
+++ b/tests/security-scan-workflow-contract.bats
@@ -2,6 +2,8 @@
 # security-scan-workflow-contract.bats - static contract tests for the
 # reusable security scanning workflow.
 
+. "$BATS_TEST_DIRNAME/helpers/action-pin-assertions.bash"
+
 YAML=".github/workflows/security-scan.yml"
 README=".github/workflows/README.md"
 
@@ -30,71 +32,6 @@ assert_lacks() {
       ;;
     *) return 0 ;;
   esac
-}
-
-assert_action_pin() {
-  matches=$(printf '%s\n' "$1" | awk -v target="$2" '
-    {
-      line = $0
-      sub(/^[[:space:]]*-[[:space:]]+uses:[[:space:]]*/, "", line)
-      sub(/^[[:space:]]*uses:[[:space:]]*/, "", line)
-
-      separator = index(line, " # ")
-      if (separator == 0) {
-        next
-      }
-
-      ref = substr(line, 1, separator - 1)
-      comment = substr(line, separator + 3)
-      if (index(ref, target "@") != 1) {
-        next
-      }
-
-      sha = substr(ref, length(target) + 2)
-      if (sha ~ /^[0-9a-f]{40}$/ && comment ~ /^v[0-9]+\.[0-9]+\.[0-9]+$/) {
-        count++
-      }
-    }
-    END { print count + 0 }
-  ')
-
-  if [ "$matches" -ne 1 ]; then
-    printf 'expected exactly one semantic action pin for:\n%s\n' "$2"
-    return 1
-  fi
-}
-
-@test "action pin helper accepts Dependabot SHA and version bumps" {
-  block=$'      - name: Perform CodeQL analysis\n        uses: github/codeql-action/analyze@1111111111111111111111111111111111111111 # v4.99.0'
-  assert_action_pin "$block" "github/codeql-action/analyze"
-}
-
-@test "action pin helper rejects malformed pins" {
-  block=$'      - name: Perform CodeQL analysis\n        uses: github/codeql-action/analyze@v4.99.0 # v4.99.0'
-  if assert_action_pin "$block" "github/codeql-action/analyze"; then
-    echo "expected non-SHA action ref to fail"
-    return 1
-  fi
-
-  block=$'      - name: Perform CodeQL analysis\n        uses: github/codeql-action/analyze@1111111111111111111111111111111111111111 # v4'
-  if assert_action_pin "$block" "github/codeql-action/analyze"; then
-    echo "expected malformed version comment to fail"
-    return 1
-  fi
-
-  block=$'      - name: Perform CodeQL analysis\n        uses: github/codeql-action/analyze@1111111111111111111111111111111111111111'
-  if assert_action_pin "$block" "github/codeql-action/analyze"; then
-    echo "expected missing version comment to fail"
-    return 1
-  fi
-}
-
-@test "action pin helper requires an exact dotted target match" {
-  block=$'    uses: google/osv-scanner-action/Xgithub/workflows/osv-scanner-reusableXyml@1111111111111111111111111111111111111111 # v2.99.0'
-  if assert_action_pin "$block" "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml"; then
-    echo "expected exact dotted target match"
-    return 1
-  fi
 }
 
 on_block() {
@@ -163,13 +100,15 @@ first_step_uses() {
 
 @test "first_step_uses returns the first uses line for semantic pin checks" {
   tmp_yaml=$(mktemp "${TMPDIR:-/tmp}/security-scan-first-step.XXXXXX")
-  cat >"$tmp_yaml" <<'EOF'
+  checkout_sha=$(printf '%040d' 1)
+  harden_runner_sha=$(printf '%040d' 2)
+  cat >"$tmp_yaml" <<EOF
 jobs:
   sample:
     steps:
-      - uses: actions/checkout@1111111111111111111111111111111111111111 # v7.0.0
+      - uses: actions/checkout@$checkout_sha # v7.0.0
       - name: Harden runner
-        uses: step-security/harden-runner@2222222222222222222222222222222222222222 # v2.99.0
+        uses: step-security/harden-runner@$harden_runner_sha # v2.99.0
 EOF
 
   original_yaml=$YAML


### PR DESCRIPTION
## Summary

- replace brittle action SHA/version snapshots in workflow contract tests with a shared semantic pin assertion
- add a self-scanning Bats source-policy guard that rejects literal action pin snapshots, including quoted and escaped forms
- preserve workflow placement and behavior checks while tightening the durable guidance in `AGENTS.md`

## Why

Dependabot action bumps update workflow pins independently of contract-test snapshots. Exact version assertions therefore fail on legitimate bumps, as seen in PR #112. The new contracts validate the stable policy instead: exact action target, one reference, lowercase 40-character commit SHA, and a trailing semantic-version comment.

## Testing

- `bats tests/action-pin-test-policy.bats` — 15 tests passed
- `bats tests/security-scan-workflow-contract.bats` — 17 tests passed
- `bats tests/pre-commit-autoupdate-workflow-contract.bats` — 15 tests passed
- `bats tests/` — 366 tests passed
- `./scripts/check-inline-sync.sh`
- `./scripts/lint-workflow-call.sh`
- `./scripts/lint-workflows.sh`
- `git diff --check origin/main...HEAD`
