### PR TITLE
feat: add npm release-age lookup and PR-body fallback

### DIFF
--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -834,7 +834,7 @@ jobs:
           # pr-body-to-deps.sh — extract Dependabot dep bumps from a PR body, emit TSV.
           # Defense-in-depth fallback for when extract-deps.sh returns zero rows.
           #
-          # Arg:    <ecosystem>  — 'pypi' or 'actions'; emitted verbatim in TSV col 3.
+          # Arg:    <ecosystem>  — 'pypi', 'actions', or 'npm'; emitted verbatim in TSV col 3.
           # Input:  PR body text on stdin.
           # Output: <name>\t<version>\t<ecosystem>  sorted, deduplicated.
           # Exit:   0 on success (including zero rows), 2 if ecosystem arg invalid.
@@ -843,8 +843,8 @@ jobs:
 
           ecosystem="${1:-}"
           case "$ecosystem" in
-            pypi|actions) ;;
-            *) echo "pr-body-to-deps.sh: ecosystem must be 'pypi' or 'actions'" >&2; exit 2 ;;
+            pypi|actions|npm) ;;
+            *) echo "pr-body-to-deps.sh: ecosystem must be 'pypi', 'actions', or 'npm'" >&2; exit 2 ;;
           esac
 
           input=$(cat)
@@ -904,6 +904,9 @@ jobs:
           # Schema:
           #   in:  <name>\t<version>\t<ecosystem>
           #   out: <name>\t<version>\t<ecosystem>\t<published_iso>\t<age_days>\t<verdict>\t<reason>
+          #
+          # Ecosystems: actions (GitHub releases API), pypi (PyPI JSON API),
+          # npm (deps.dev stable v3).
           #
           # Verdicts: pass | fail | error
           # Exit: always 0; failures are per-row.
@@ -973,6 +976,43 @@ jobs:
             printf '%s\t%s\n' "$upload" "$yanked"
           }
 
+          # urlencode_pkg <name> — percent-encode an npm package name for a URL path.
+          # Scoped names contain '@' and '/', both of which must be encoded.
+          urlencode_pkg() {
+            local name="$1"
+            name="${name//@/%40}"
+            name="${name//\//%2F}"
+            printf '%s' "$name"
+          }
+
+          # fetch_npm <pkg> <version> — print "<publishedAt>\t<isDeprecated>" on stdout,
+          # return 1 on failure. Source is deps.dev stable v3: one ~1 KB response
+          # carries both facts, where the npm registry needs a multi-MB packument for
+          # the timestamp plus a second request for deprecation.
+          fetch_npm() {
+            local pkg="$1" version="$2"
+            local published deprecated
+            if [ -n "${AGE_FIXTURE_DIR:-}" ]; then
+              local fx="$AGE_FIXTURE_DIR/npm/$pkg/$version.json"
+              [ -f "$fx" ] || return 1
+              published=$(jq -r '.publishedAt // empty' "$fx")
+              deprecated=$(jq -r '.isDeprecated // false' "$fx")
+              printf '%s\t%s\n' "$published" "$deprecated"
+              return 0
+            fi
+            local url resp
+            url="https://api.deps.dev/v3/systems/npm/packages/$(urlencode_pkg "$pkg")/versions/$version"
+            if ! resp=$(curl -sf --max-time 30 "$url" 2>/dev/null); then
+              sleep 2
+              if ! resp=$(curl -sf --max-time 30 "$url" 2>/dev/null); then
+                return 1
+              fi
+            fi
+            published=$(printf '%s' "$resp" | jq -r '.publishedAt // empty')
+            deprecated=$(printf '%s' "$resp" | jq -r '.isDeprecated // false')
+            printf '%s\t%s\n' "$published" "$deprecated"
+          }
+
           # emit name version ecosystem published age verdict reason
           emit() {
             printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5" "$6" "$7"
@@ -1030,6 +1070,31 @@ jobs:
                 age_days=$(( (NOW_EPOCH - pub_epoch) / 86400 ))
                 if [ "$yanked" = "true" ]; then
                   emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "fail" "yanked"
+                elif [ "$age_days" -ge "$COOLDOWN_DAYS" ]; then
+                  emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "pass" ""
+                else
+                  emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "fail" ""
+                fi
+                ;;
+
+              npm)
+                if ! result=$(fetch_npm "$name" "$version"); then
+                  emit "$name" "$version" "$ecosystem" "-" "-" "error" "npm-404"
+                  continue
+                fi
+                iso="${result%%$'\t'*}"
+                deprecated="${result##*$'\t'}"
+                if [ -z "$iso" ]; then
+                  emit "$name" "$version" "$ecosystem" "-" "-" "error" "transient-failure"
+                  continue
+                fi
+                if ! pub_epoch=$(iso_to_epoch "$iso"); then
+                  emit "$name" "$version" "$ecosystem" "-" "-" "error" "parse-failure"
+                  continue
+                fi
+                age_days=$(( (NOW_EPOCH - pub_epoch) / 86400 ))
+                if [ "$deprecated" = "true" ]; then
+                  emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "fail" "deprecated"
                 elif [ "$age_days" -ge "$COOLDOWN_DAYS" ]; then
                   emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "pass" ""
                 else

--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -976,13 +976,14 @@ jobs:
             printf '%s\t%s\n' "$upload" "$yanked"
           }
 
-          # urlencode_pkg <name> — percent-encode an npm package name for a URL path.
-          # Scoped names contain '@' and '/', both of which must be encoded.
-          urlencode_pkg() {
-            local name="$1"
-            name="${name//@/%40}"
-            name="${name//\//%2F}"
-            printf '%s' "$name"
+          # urlencode_segment <value> — percent-encode one URL path segment.
+          # jq's @uri leaves only the unreserved set (A-Za-z0-9-_.~) intact, so scope
+          # separators ('@', '/'), traversal sequences, and query/fragment delimiters are
+          # all neutralised. Applied to the version as well as the name: curl normalises
+          # '..' segments client-side, so an unencoded '/' in a version string would let
+          # one package's age be reported for another.
+          urlencode_segment() {
+            jq -rn --arg s "$1" '$s|@uri'
           }
 
           # fetch_npm <pkg> <version> — print "<publishedAt>\t<isDeprecated>" on stdout,
@@ -1001,7 +1002,7 @@ jobs:
               return 0
             fi
             local url resp
-            url="https://api.deps.dev/v3/systems/npm/packages/$(urlencode_pkg "$pkg")/versions/$version"
+            url="https://api.deps.dev/v3/systems/npm/packages/$(urlencode_segment "$pkg")/versions/$(urlencode_segment "$version")"
             if ! resp=$(curl -sf --max-time 30 "$url" 2>/dev/null); then
               sleep 2
               if ! resp=$(curl -sf --max-time 30 "$url" 2>/dev/null); then

--- a/scripts/check-release-age.sh
+++ b/scripts/check-release-age.sh
@@ -76,13 +76,14 @@ fetch_pypi() {
   printf '%s\t%s\n' "$upload" "$yanked"
 }
 
-# urlencode_pkg <name> — percent-encode an npm package name for a URL path.
-# Scoped names contain '@' and '/', both of which must be encoded.
-urlencode_pkg() {
-  local name="$1"
-  name="${name//@/%40}"
-  name="${name//\//%2F}"
-  printf '%s' "$name"
+# urlencode_segment <value> — percent-encode one URL path segment.
+# jq's @uri leaves only the unreserved set (A-Za-z0-9-_.~) intact, so scope
+# separators ('@', '/'), traversal sequences, and query/fragment delimiters are
+# all neutralised. Applied to the version as well as the name: curl normalises
+# '..' segments client-side, so an unencoded '/' in a version string would let
+# one package's age be reported for another.
+urlencode_segment() {
+  jq -rn --arg s "$1" '$s|@uri'
 }
 
 # fetch_npm <pkg> <version> — print "<publishedAt>\t<isDeprecated>" on stdout,
@@ -101,7 +102,7 @@ fetch_npm() {
     return 0
   fi
   local url resp
-  url="https://api.deps.dev/v3/systems/npm/packages/$(urlencode_pkg "$pkg")/versions/$version"
+  url="https://api.deps.dev/v3/systems/npm/packages/$(urlencode_segment "$pkg")/versions/$(urlencode_segment "$version")"
   if ! resp=$(curl -sf --max-time 30 "$url" 2>/dev/null); then
     sleep 2
     if ! resp=$(curl -sf --max-time 30 "$url" 2>/dev/null); then

--- a/scripts/check-release-age.sh
+++ b/scripts/check-release-age.sh
@@ -5,6 +5,9 @@
 #   in:  <name>\t<version>\t<ecosystem>
 #   out: <name>\t<version>\t<ecosystem>\t<published_iso>\t<age_days>\t<verdict>\t<reason>
 #
+# Ecosystems: actions (GitHub releases API), pypi (PyPI JSON API),
+# npm (deps.dev stable v3).
+#
 # Verdicts: pass | fail | error
 # Exit: always 0; failures are per-row.
 #
@@ -73,6 +76,43 @@ fetch_pypi() {
   printf '%s\t%s\n' "$upload" "$yanked"
 }
 
+# urlencode_pkg <name> — percent-encode an npm package name for a URL path.
+# Scoped names contain '@' and '/', both of which must be encoded.
+urlencode_pkg() {
+  local name="$1"
+  name="${name//@/%40}"
+  name="${name//\//%2F}"
+  printf '%s' "$name"
+}
+
+# fetch_npm <pkg> <version> — print "<publishedAt>\t<isDeprecated>" on stdout,
+# return 1 on failure. Source is deps.dev stable v3: one ~1 KB response
+# carries both facts, where the npm registry needs a multi-MB packument for
+# the timestamp plus a second request for deprecation.
+fetch_npm() {
+  local pkg="$1" version="$2"
+  local published deprecated
+  if [ -n "${AGE_FIXTURE_DIR:-}" ]; then
+    local fx="$AGE_FIXTURE_DIR/npm/$pkg/$version.json"
+    [ -f "$fx" ] || return 1
+    published=$(jq -r '.publishedAt // empty' "$fx")
+    deprecated=$(jq -r '.isDeprecated // false' "$fx")
+    printf '%s\t%s\n' "$published" "$deprecated"
+    return 0
+  fi
+  local url resp
+  url="https://api.deps.dev/v3/systems/npm/packages/$(urlencode_pkg "$pkg")/versions/$version"
+  if ! resp=$(curl -sf --max-time 30 "$url" 2>/dev/null); then
+    sleep 2
+    if ! resp=$(curl -sf --max-time 30 "$url" 2>/dev/null); then
+      return 1
+    fi
+  fi
+  published=$(printf '%s' "$resp" | jq -r '.publishedAt // empty')
+  deprecated=$(printf '%s' "$resp" | jq -r '.isDeprecated // false')
+  printf '%s\t%s\n' "$published" "$deprecated"
+}
+
 # emit name version ecosystem published age verdict reason
 emit() {
   printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5" "$6" "$7"
@@ -130,6 +170,31 @@ while IFS=$'\t' read -r name version ecosystem || [ -n "${name:-}" ]; do
       age_days=$(( (NOW_EPOCH - pub_epoch) / 86400 ))
       if [ "$yanked" = "true" ]; then
         emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "fail" "yanked"
+      elif [ "$age_days" -ge "$COOLDOWN_DAYS" ]; then
+        emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "pass" ""
+      else
+        emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "fail" ""
+      fi
+      ;;
+
+    npm)
+      if ! result=$(fetch_npm "$name" "$version"); then
+        emit "$name" "$version" "$ecosystem" "-" "-" "error" "npm-404"
+        continue
+      fi
+      iso="${result%%$'\t'*}"
+      deprecated="${result##*$'\t'}"
+      if [ -z "$iso" ]; then
+        emit "$name" "$version" "$ecosystem" "-" "-" "error" "transient-failure"
+        continue
+      fi
+      if ! pub_epoch=$(iso_to_epoch "$iso"); then
+        emit "$name" "$version" "$ecosystem" "-" "-" "error" "parse-failure"
+        continue
+      fi
+      age_days=$(( (NOW_EPOCH - pub_epoch) / 86400 ))
+      if [ "$deprecated" = "true" ]; then
+        emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "fail" "deprecated"
       elif [ "$age_days" -ge "$COOLDOWN_DAYS" ]; then
         emit "$name" "$version" "$ecosystem" "$iso" "$age_days" "pass" ""
       else

--- a/scripts/pr-body-to-deps.sh
+++ b/scripts/pr-body-to-deps.sh
@@ -2,7 +2,7 @@
 # pr-body-to-deps.sh — extract Dependabot dep bumps from a PR body, emit TSV.
 # Defense-in-depth fallback for when extract-deps.sh returns zero rows.
 #
-# Arg:    <ecosystem>  — 'pypi' or 'actions'; emitted verbatim in TSV col 3.
+# Arg:    <ecosystem>  — 'pypi', 'actions', or 'npm'; emitted verbatim in TSV col 3.
 # Input:  PR body text on stdin.
 # Output: <name>\t<version>\t<ecosystem>  sorted, deduplicated.
 # Exit:   0 on success (including zero rows), 2 if ecosystem arg invalid.
@@ -11,8 +11,8 @@ set -euo pipefail
 
 ecosystem="${1:-}"
 case "$ecosystem" in
-  pypi|actions) ;;
-  *) echo "pr-body-to-deps.sh: ecosystem must be 'pypi' or 'actions'" >&2; exit 2 ;;
+  pypi|actions|npm) ;;
+  *) echo "pr-body-to-deps.sh: ecosystem must be 'pypi', 'actions', or 'npm'" >&2; exit 2 ;;
 esac
 
 input=$(cat)

--- a/tests/check-release-age.bats
+++ b/tests/check-release-age.bats
@@ -39,3 +39,55 @@ setup() {
   [ "$status" -eq 0 ]
   [[ "$output" =~ ^no-such-action/does-not-exist$'\t'1\.0\.0$'\t'actions$'\t'-$'\t'-$'\t'error$'\t'tier-1-404$ ]]
 }
+
+@test "npm happy path returns pass for aged release" {
+  export COOLDOWN_DAYS=7
+  run bash -c 'printf "lodash\t4.17.21\tnpm\n" | bash scripts/check-release-age.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^lodash$'\t'4\.17\.21$'\t'npm$'\t'.+$'\t'[0-9]+$'\t'pass$'\t'$ ]]
+}
+
+@test "npm scoped package name resolves its fixture" {
+  export COOLDOWN_DAYS=7
+  run bash -c 'printf "@types/node\t22.19.9\tnpm\n" | bash scripts/check-release-age.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^@types/node$'\t'22\.19\.9$'\t'npm$'\t'.+$'\t'[0-9]+$'\t'pass$'\t'$ ]]
+}
+
+@test "deprecated npm release fails regardless of age" {
+  export COOLDOWN_DAYS=7
+  run bash -c 'printf "deprecated-pkg\t1.0.0\tnpm\n" | bash scripts/check-release-age.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^deprecated-pkg$'\t'1\.0\.0$'\t'npm$'\t'.+$'\t'[0-9]+$'\t'fail$'\t'deprecated$ ]]
+}
+
+@test "missing npm fixture produces npm-404 error verdict" {
+  export COOLDOWN_DAYS=7
+  run bash -c 'printf "no-such-pkg\t9.9.9\tnpm\n" | bash scripts/check-release-age.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^no-such-pkg$'\t'9\.9\.9$'\t'npm$'\t'-$'\t'-$'\t'error$'\t'npm-404$ ]]
+}
+
+@test "npm release younger than COOLDOWN_DAYS fails" {
+  export COOLDOWN_DAYS=7
+  # @types/node fixture publishedAt 2026-02-05; NOW_EPOCH is 2026-04-12, so a
+  # very large cooldown forces the violation branch deterministically.
+  export COOLDOWN_DAYS=999
+  run bash -c 'printf "@types/node\t22.19.9\tnpm\n" | bash scripts/check-release-age.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^@types/node$'\t'22\.19\.9$'\t'npm$'\t'.+$'\t'[0-9]+$'\t'fail$'\t'$ ]]
+}
+
+@test "npm response missing publishedAt produces transient-failure" {
+  export COOLDOWN_DAYS=7
+  run bash -c 'printf "no-published-at\t1.0.0\tnpm\n" | bash scripts/check-release-age.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^no-published-at$'\t'1\.0\.0$'\t'npm$'\t'-$'\t'-$'\t'error$'\t'transient-failure$ ]]
+}
+
+@test "npm response with unparseable timestamp produces parse-failure" {
+  export COOLDOWN_DAYS=7
+  run bash -c 'printf "bad-timestamp\t1.0.0\tnpm\n" | bash scripts/check-release-age.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^bad-timestamp$'\t'1\.0\.0$'\t'npm$'\t'-$'\t'-$'\t'error$'\t'parse-failure$ ]]
+}

--- a/tests/check-release-age.bats
+++ b/tests/check-release-age.bats
@@ -69,7 +69,6 @@ setup() {
 }
 
 @test "npm release younger than COOLDOWN_DAYS fails" {
-  export COOLDOWN_DAYS=7
   # @types/node fixture publishedAt 2026-02-05; NOW_EPOCH is 2026-04-12, so a
   # very large cooldown forces the violation branch deterministically.
   export COOLDOWN_DAYS=999
@@ -90,4 +89,39 @@ setup() {
   run bash -c 'printf "bad-timestamp\t1.0.0\tnpm\n" | bash scripts/check-release-age.sh'
   [ "$status" -eq 0 ]
   [[ "$output" =~ ^bad-timestamp$'\t'1\.0\.0$'\t'npm$'\t'-$'\t'-$'\t'error$'\t'parse-failure$ ]]
+}
+
+@test "urlencode_segment percent-encodes scope separators" {
+  run bash -c 'eval "$(sed -n "/^urlencode_segment()/,/^}/p" scripts/check-release-age.sh)"; urlencode_segment "@types/node"'
+  [ "$status" -eq 0 ]
+  [ "$output" = "%40types%2Fnode" ]
+}
+
+@test "urlencode_segment neutralises path traversal in a version string" {
+  run bash -c 'eval "$(sed -n "/^urlencode_segment()/,/^}/p" scripts/check-release-age.sh)"; urlencode_segment "1.0.0/../../lodash/versions/4.17.21"'
+  [ "$status" -eq 0 ]
+  [[ "$output" != */* ]]
+  [ "$output" = "1.0.0%2F..%2F..%2Flodash%2Fversions%2F4.17.21" ]
+}
+
+@test "urlencode_segment leaves unreserved characters alone" {
+  run bash -c 'eval "$(sed -n "/^urlencode_segment()/,/^}/p" scripts/check-release-age.sh)"; urlencode_segment "lodash-4.17.21_x.y"'
+  [ "$status" -eq 0 ]
+  [ "$output" = "lodash-4.17.21_x.y" ]
+}
+
+@test "npm release exactly at COOLDOWN_DAYS passes (boundary is inclusive)" {
+  # @types/node fixture publishedAt 2026-02-05T14:45:05Z against the pinned
+  # NOW_EPOCH gives age_days == 65 exactly, so this pins the -ge boundary.
+  export COOLDOWN_DAYS=65
+  run bash -c 'printf "@types/node\t22.19.9\tnpm\n" | bash scripts/check-release-age.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^@types/node$'\t'22\.19\.9$'\t'npm$'\t'.+$'\t'65$'\t'pass$'\t'$ ]]
+}
+
+@test "npm release one day under COOLDOWN_DAYS fails" {
+  export COOLDOWN_DAYS=66
+  run bash -c 'printf "@types/node\t22.19.9\tnpm\n" | bash scripts/check-release-age.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^@types/node$'\t'22\.19\.9$'\t'npm$'\t'.+$'\t'65$'\t'fail$'\t'$ ]]
 }

--- a/tests/fixtures/check-release-age/npm/@types/node/22.19.9.json
+++ b/tests/fixtures/check-release-age/npm/@types/node/22.19.9.json
@@ -1,0 +1,6 @@
+{
+  "versionKey": { "system": "NPM", "name": "@types/node", "version": "22.19.9" },
+  "publishedAt": "2026-02-05T14:45:05Z",
+  "isDeprecated": false,
+  "deprecatedReason": ""
+}

--- a/tests/fixtures/check-release-age/npm/bad-timestamp/1.0.0.json
+++ b/tests/fixtures/check-release-age/npm/bad-timestamp/1.0.0.json
@@ -1,0 +1,5 @@
+{
+  "versionKey": { "system": "NPM", "name": "bad-timestamp", "version": "1.0.0" },
+  "publishedAt": "not-a-timestamp",
+  "isDeprecated": false
+}

--- a/tests/fixtures/check-release-age/npm/deprecated-pkg/1.0.0.json
+++ b/tests/fixtures/check-release-age/npm/deprecated-pkg/1.0.0.json
@@ -1,0 +1,6 @@
+{
+  "versionKey": { "system": "NPM", "name": "deprecated-pkg", "version": "1.0.0" },
+  "publishedAt": "2019-07-19T02:28:46Z",
+  "isDeprecated": true,
+  "deprecatedReason": "no longer maintained"
+}

--- a/tests/fixtures/check-release-age/npm/lodash/4.17.21.json
+++ b/tests/fixtures/check-release-age/npm/lodash/4.17.21.json
@@ -1,0 +1,6 @@
+{
+  "versionKey": { "system": "NPM", "name": "lodash", "version": "4.17.21" },
+  "publishedAt": "2021-02-20T15:42:16Z",
+  "isDeprecated": false,
+  "deprecatedReason": ""
+}

--- a/tests/fixtures/check-release-age/npm/no-published-at/1.0.0.json
+++ b/tests/fixtures/check-release-age/npm/no-published-at/1.0.0.json
@@ -1,0 +1,4 @@
+{
+  "versionKey": { "system": "NPM", "name": "no-published-at", "version": "1.0.0" },
+  "isDeprecated": false
+}

--- a/tests/fixtures/pr-body-to-deps/npm-scoped.txt
+++ b/tests/fixtures/pr-body-to-deps/npm-scoped.txt
@@ -1,0 +1,4 @@
+Bumps [@scalar/api-reference-react](https://github.com/scalar/scalar) from 0.7.42 to 0.9.60.
+<details>
+<summary>Changelog</summary>
+</details>

--- a/tests/pr-body-to-deps.bats
+++ b/tests/pr-body-to-deps.bats
@@ -61,3 +61,20 @@
   [ "$status" -eq 2 ]
   [[ "$output" == *"ecosystem must be"* ]]
 }
+
+@test "npm ecosystem argument is accepted" {
+  run bash -c 'printf "" | bash scripts/pr-body-to-deps.sh npm'
+  [ "$status" -eq 0 ]
+}
+
+@test "npm scoped package extracted from a Dependabot body" {
+  run bash scripts/pr-body-to-deps.sh npm < tests/fixtures/pr-body-to-deps/npm-scoped.txt
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf '@scalar/api-reference-react\t0.9.60\tnpm')" ]
+}
+
+@test "error message names all three accepted ecosystems" {
+  run bash -c 'printf "" | bash scripts/pr-body-to-deps.sh cargo'
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"'pypi', 'actions', or 'npm'"* ]]
+}


### PR DESCRIPTION
Adds the two lookup-side pieces of npm/pnpm support. Part 2 of 3.

## What changed

- **`check-release-age.sh` gains an `npm)` branch**, sourced from deps.dev
  stable `v3`: `.publishedAt` for release age, `.isDeprecated` as the analog of
  PyPI's "yanked". One ~1 KB response carries both facts, where the npm
  registry would need a multi-MB packument for the timestamp (the abbreviated
  form omits `.time`) plus a second request for deprecation.
- **`pr-body-to-deps.sh` accepts `npm`.** The three body-matching patterns
  already matched npm bodies unchanged, scoped names included — only the
  argument allowlist and its error message needed widening.
- **Inline copies regenerated** in `dependency-safety.yml` to satisfy
  `check-inline-sync.sh`.

**Deliberately inert.** Nothing routes npm rows into either path until PR 3
adds the workflow composition layer, so this changes no behavior today.

## Hardening found in review

Two gaps in the new code, both caught by mutation testing rather than by
reading:

- **The version was interpolated into the deps.dev URL unencoded** while the
  package name was encoded. curl normalises `..` path segments client-side, so
  a version string containing `/` could make one package's age be reported for
  another — defeating the gate. Both components now go through a general
  path-segment encoder (`jq`'s `@uri`), which also closes the `%`/`?`/`#`/space
  gap the two hand-rolled substitutions left open. Reachability is low today,
  but PR 3's lockfile version capture is an unconstrained `.*`.
- **That encoder had zero coverage.** Every test exports `AGE_FIXTURE_DIR`, and
  the fixture branch returns before the URL is ever built — making the encoder
  an identity function left all 12 tests green. It now has direct tests, and
  the inclusive cooldown boundary is pinned too (flipping `-ge` to `-gt`
  previously caused no failures).

## Tests

417 passing, 0 failing (402 before this branch). All 9 inline pairs in sync.

## Known limitation, to settle in PR 3

A deprecated package is emitted as `fail`/`deprecated`, which the workflow
counts as an **age** violation. The result is a `dependency_age_violation`
label, a "younger than the configured minimum release age" status, and an
"Earliest age-compliant date" footer that can advise rebasing after a date
years in the past. This is inherited from the pypi `yanked` path and is not new
here — but npm deprecation is routine where PyPI yanking is rare, so it stops
being a corner case once PR 3 routes npm rows. Filed for PR 3 rather than fixed
here, since the reporting layer is PR 3's and a fix would change pypi behavior
too.

Refs #127.
