### PR TITLE
feat: publish a workspace package from a monorepo

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -498,6 +498,8 @@ template.
 |---|---|---|---|---|
 | `tag` | string | yes | - | Semver tag to publish, such as `v1.2.3`. |
 | `package-name` | string | yes | - | npm package name used for registry verification. |
+| `package-dir` | string | no | `"."` | Directory of the package to publish, relative to the repository root. Must stay inside the checkout: absolute paths, `..` segments and control characters are rejected. |
+| `pack-command` | string | no | `npm pack --json` | Command run from `package-dir`. Must produce exactly one tarball there and JSON metadata on stdout. |
 | `test-command` | string | no | `""` | Optional pre-pack command run in the caller checkout. |
 | `pack-contents-script` | string | no | `""` | Optional script run as `sh <script> pack.json` after `npm pack --json`. |
 | `verify-command` | string | no | `""` | Optional post-registry verification command run with `PACKAGE` and `VERSION` in the environment. |
@@ -507,6 +509,54 @@ scripts such as `prepare` or `prepack`, include the required setup in
 `test-command`, for example `npm ci && npm test && npm run build`. The reusable
 workflow does not run `npm ci` by default because not every npm package uses a
 lockfile or a build step.
+
+### Working directories
+
+`test-command` runs from the repository root, so a monorepo caller can run a
+workspace-wide install and a filtered test run in one command.
+`pack-contents-script` is repository-root-relative, is invoked from the
+repository root, and receives a repository-root-relative metadata path as its
+first argument — `pack.json` for a root package, `<package-dir>/pack.json`
+otherwise. Read it from `$1` rather than hardcoding it.
+
+`pack-command` runs from `package-dir`, exactly once. Pack metadata is written
+outside the checkout and copied back only after the tarball is sealed, so it
+cannot be packed into a package that does not declare a `files` allowlist.
+
+### Scope
+
+This workflow publishes one package per invocation. A repository with several
+independently versioned packages calls it once per package, and each package
+needs its own `tag-release.yml` `tag-prefix`, such as `permissions/v`, so the
+tags never collide. Configure a trusted publisher separately for every npm
+package, using the actual calling workflow filename, the `npm` environment and
+the `npm publish` allowed action. Both the caller and this reusable workflow
+need `id-token: write`.
+
+### pnpm workspaces
+
+`npm pack` cannot resolve the `workspace:` or `catalog:` protocols. It seals
+them into the tarball unchanged and exits successfully, producing a package
+that installs for nobody. `pnpm pack` rewrites both to registry-resolvable
+versions, so pnpm callers should:
+
+- pin `packageManager` in the repository root manifest;
+- run a frozen install before packing, in `test-command`;
+- set `pack-command: pnpm pack --json`.
+
+### What the pre-upload guard checks
+
+Before uploading, the workflow reads the sealed manifest out of the tarball and
+fails if the packed name or version is not what was requested — a `prepack` or
+`prepare` script can rewrite `package.json` after the initial check — or if any
+`dependencies`, `optionalDependencies` or `peerDependencies` entry uses a
+local-path or workspace protocol. `devDependencies` are not checked, since
+consumers never install them.
+
+The guard matches a protocol prefix. It rejects the `workspace:`, `catalog:`,
+`link:`, `portal:`, `patch:`, `file:` and `git+file:` classes; it does not
+certify that a surviving specifier resolves. A malformed but allowed-prefix
+specifier such as `npm:` will pass this check and fail at install time.
 
 ### Caller setup
 
@@ -530,6 +580,11 @@ npm trusted publishing requires npm CLI `>= 11.5.1`; the reusable workflow
 enforces that floor before publishing. Do not pass `--provenance` or set
 `NPM_CONFIG_PROVENANCE`. npm generates provenance automatically for a public
 package published from a public repository through trusted publishing.
+
+npm's trusted-publishing docs also require the manifest's `repository.url`
+field to exactly match the GitHub repository publishing it. For a monorepo
+package, set `repository.directory` to the package's `package-dir`, for
+example `packages/permissions`.
 
 ### Example caller
 
@@ -561,6 +616,45 @@ jobs:
 For packages without a CLI or install smoke test, omit `verify-command`. The
 workflow still verifies that `npm view <package>@<version> version` returns
 success before creating the GitHub Release.
+
+### Example caller: monorepo package
+
+```yaml
+name: Publish npm
+
+on:
+  push:
+    tags:
+      - "permissions/v*.*.*"
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    uses: j7an/shared-workflows/.github/workflows/publish-npm.yml@v4
+    with:
+      tag: ${{ github.ref_name }}
+      package-name: "@pi-kit/permissions"
+      package-dir: packages/permissions
+      test-command: pnpm install --frozen-lockfile && pnpm test
+      pack-command: pnpm pack --json
+```
+
+The workspace package's manifest also needs a `repository.directory` field, so
+its `repository.url` matches the GitHub repository while still identifying
+which workspace it publishes:
+
+```json
+{
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/j7an/pi-kit.git",
+    "directory": "packages/permissions"
+  }
+}
+```
 
 ## `publish-pypi.yml`
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -501,7 +501,7 @@ template.
 | `package-dir` | string | no | `"."` | Directory of the package to publish, relative to the repository root. Must stay inside the checkout: absolute paths, `..` segments and control characters are rejected. |
 | `pack-command` | string | no | `npm pack --json` | Command run from `package-dir`. Must produce exactly one tarball there and JSON metadata on stdout. |
 | `test-command` | string | no | `""` | Optional pre-pack command run in the caller checkout. |
-| `pack-contents-script` | string | no | `""` | Optional script run as `sh <script> pack.json` after `npm pack --json`. |
+| `pack-contents-script` | string | no | `""` | Optional script run as `sh <script> <metadata-path>` after packing; `<metadata-path>` is `pack.json` for a root package, `<package-dir>/pack.json` otherwise. |
 | `verify-command` | string | no | `""` | Optional post-registry verification command run with `PACKAGE` and `VERSION` in the environment. |
 
 If `npm pack` depends on installed dependencies, generated files, or lifecycle
@@ -535,10 +535,10 @@ need `id-token: write`.
 
 ### pnpm workspaces
 
-`npm pack` cannot resolve the `workspace:` or `catalog:` protocols. It seals
-them into the tarball unchanged and exits successfully, producing a package
-that installs for nobody. `pnpm pack` rewrites both to registry-resolvable
-versions, so pnpm callers should:
+`npm pack` does not resolve the `workspace:` or `catalog:` protocols: in
+practice it seals them into the tarball unchanged and exits successfully,
+producing a package that installs for nobody. `pnpm pack` rewrites both to
+registry-resolvable versions, so pnpm callers should:
 
 - pin `packageManager` in the repository root manifest;
 - run a frozen install before packing, in `test-command`;
@@ -553,10 +553,12 @@ fails if the packed name or version is not what was requested — a `prepack` or
 local-path or workspace protocol. `devDependencies` are not checked, since
 consumers never install them.
 
-The guard matches a protocol prefix. It rejects the `workspace:`, `catalog:`,
-`link:`, `portal:`, `patch:`, `file:` and `git+file:` classes; it does not
-certify that a surviving specifier resolves. A malformed but allowed-prefix
-specifier such as `npm:` will pass this check and fail at install time.
+The guard matches a protocol prefix against a default-deny allowlist: anything
+outside npm's registry-resolvable protocol set is rejected, including the
+`workspace:`, `catalog:`, `link:`, `portal:`, `patch:`, `file:` and
+`git+file:` classes. It does not certify that a surviving specifier resolves.
+A malformed but allowed-prefix specifier such as `npm:` will pass this check
+and fail at install time.
 
 ### Caller setup
 
@@ -642,9 +644,9 @@ jobs:
       pack-command: pnpm pack --json
 ```
 
-The workspace package's manifest also needs a `repository.directory` field, so
-its `repository.url` matches the GitHub repository while still identifying
-which workspace it publishes:
+The workspace package's manifest should also carry a `repository.directory`
+field, so its `repository.url` matches the GitHub repository while still
+identifying which workspace it publishes:
 
 ```json
 {

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -554,11 +554,15 @@ local-path or workspace protocol. `devDependencies` are not checked, since
 consumers never install them.
 
 The guard matches a protocol prefix against a default-deny allowlist: anything
-outside npm's registry-resolvable protocol set is rejected, including the
-`workspace:`, `catalog:`, `link:`, `portal:`, `patch:`, `file:` and
-`git+file:` classes. It does not certify that a surviving specifier resolves.
-A malformed but allowed-prefix specifier such as `npm:` will pass this check
-and fail at install time.
+outside npm's non-local resolution protocols — `npm:`, the `git:` family,
+`http:`/`https:` tarballs and the `github:`, `gitlab:`, `bitbucket:` and
+`gist:` shortcuts — is rejected, including the `workspace:`, `catalog:`,
+`link:`, `portal:`, `patch:`, `file:` and `git+file:` classes. A specifier
+carrying no protocol at all but starting with `.`, `/` or `~/` is rejected
+too: npm reads `../core` as a local directory, exactly as it reads
+`file:../core`. It does not certify that a surviving specifier resolves. A
+malformed but allowed-prefix specifier such as `npm:` will pass this check and
+fail at install time.
 
 ### Caller setup
 
@@ -583,10 +587,11 @@ enforces that floor before publishing. Do not pass `--provenance` or set
 `NPM_CONFIG_PROVENANCE`. npm generates provenance automatically for a public
 package published from a public repository through trusted publishing.
 
-npm's trusted-publishing docs also require the manifest's `repository.url`
-field to exactly match the GitHub repository publishing it. For a monorepo
-package, set `repository.directory` to the package's `package-dir`, for
-example `packages/permissions`.
+Provenance generation requires the manifest's `repository.url` field to
+exactly match the GitHub repository publishing it, so the publish fails if it
+does not. For a monorepo package, `repository.directory` should also be set to
+the package's `package-dir`, for example `packages/permissions`; npm does not
+require it, but it is what identifies which workspace the package came from.
 
 ### Example caller
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -235,6 +235,8 @@ jobs:
           )
           # --- END inline:scripts/npm-package-preflight.sh ---
 
+          set -euo pipefail
+
           OUT="$RUNNER_TEMP/preflight.out"
           npm_package_preflight "$PACKAGE_DIR" "$PACKAGE_NAME" "$TAG" > "$OUT"
           cat "$OUT" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -30,7 +30,7 @@ on:
         type: string
         required: false
         default: ""
-        description: "Optional caller repo script run as 'sh <script> pack.json' after npm pack"
+        description: "Optional caller repo script run as 'sh <script> <metadata-path>' after packing; <metadata-path> is pack.json for a root package or <package-dir>/pack.json otherwise"
       verify-command:
         type: string
         required: false

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -281,6 +281,21 @@ jobs:
           mkdir -p "$STAGE"
           rm -f "$STAGE"/*.tgz
 
+          # npm's failure envelope is {"error":{"code","summary","detail"}} -
+          # verified against npm 12.0.2, which exits 7 on a failing prepack and
+          # writes that object to stdout. There is NO "message" key; it is read
+          # last only as a fallback for a packer that uses it. When no key is
+          # recognized the raw metadata is dumped rather than swallowed, so a
+          # caller never has to reproduce the failure locally to see it.
+          report_pack_error() {
+            DETAIL=$(jq -r '[.error.summary, .error.detail, .error.message] | map(select(. != null and . != "")) | join(": ")' "$PACK_JSON" 2>/dev/null || true)
+            if [ -n "$DETAIL" ]; then
+              printf '%s\n' "$DETAIL" | sed 's/^/::error::/'
+            else
+              sed 's/^/::error::/' "$PACK_JSON" 2>/dev/null || true
+            fi
+          }
+
           # Metadata is written outside GITHUB_WORKSPACE because the shell
           # truncates a redirect target BEFORE the packer runs; a file created
           # in the package directory at that moment is sealed into the tarball
@@ -288,15 +303,15 @@ jobs:
           # after packing, so the caller-visible path is unchanged.
           if ! ( cd "$PACKAGE_DIR" && sh -c "$PACK_COMMAND" ) > "$PACK_JSON"; then
             echo "::error::pack command failed in ${PACKAGE_DIR}: ${PACK_COMMAND}"
-            jq -r '.error.message // empty' "$PACK_JSON" 2>/dev/null \
-              | sed 's/^/::error::/' || true
+            report_pack_error
             exit 1
           fi
 
           # Reachable when the caller's pack-command is a pipeline, where the
           # exit status is the last element's and a packer error is masked.
           if jq -e 'type == "object" and has("error")' "$PACK_JSON" >/dev/null 2>&1; then
-            echo "::error::pack command reported an error: $(jq -r '.error.message // "unknown"' "$PACK_JSON")"
+            echo "::error::pack command reported an error"
+            report_pack_error
             exit 1
           fi
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -11,11 +11,21 @@ on:
         type: string
         required: true
         description: "npm package name used for post-publish registry verification"
+      package-dir:
+        type: string
+        required: false
+        default: "."
+        description: "Directory of the package to publish, relative to the repository root"
       test-command:
         type: string
         required: false
         default: ""
         description: "Optional caller repo command to run before packing"
+      pack-command:
+        type: string
+        required: false
+        default: "npm pack --json"
+        description: "Command run from package-dir; must produce one tarball and JSON metadata on stdout"
       pack-contents-script:
         type: string
         required: false
@@ -38,7 +48,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.version.outputs.version }}
+      version: ${{ steps.pkg.outputs.version }}
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -63,27 +73,177 @@ jobs:
           fi
           echo "Tag ${TAG} (${TAG_SHA}) is an ancestor of main - proceeding."
 
+      - name: Resolve package directory and preflight
+        id: pkg
+        env:
+          PACKAGE_DIR: ${{ inputs.package-dir }}
+          PACKAGE_NAME: ${{ inputs.package-name }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          # --- BEGIN inline:scripts/npm-package-preflight.sh ---
+          npm_package_preflight() (
+          # npm-package-preflight.sh — select and validate the package publish-npm.yml
+          # is about to publish.
+          #
+          # Resolves <package-dir> inside GITHUB_WORKSPACE, refuses anything that could
+          # reach outside the checkout, and verifies the selected manifest is the
+          # package the caller named at the version the tag names. Runs before the
+          # caller's test command and before packing so a misconfigured call fails
+          # early and cheaply.
+          #
+          # This establishes identity at the SOURCE. That guarantee does not survive
+          # packing, because prepack/prepare lifecycle scripts may rewrite the manifest,
+          # so assert-packed-manifest.sh re-establishes it against the sealed artifact.
+          #
+          # Usage:
+          #   ./scripts/npm-package-preflight.sh <package-dir> <package-name> <tag>
+          #
+          # Stdout (success only), shaped for appending to $GITHUB_OUTPUT:
+          #   dir=<repository-relative directory>
+          #   version=<semver parsed from the tag>
+          #
+          # Exit codes:
+          #   0 — package selected and validated
+          #   1 — the selected package is not publishable: private, name mismatch,
+          #       version mismatch, or an unparseable tag. Caller MUST fail.
+          #   2 — the package-dir input is malformed or unsafe: control characters,
+          #       absolute, contains '..', escapes the checkout, missing, or has no
+          #       readable package.json.
+
+          set -euo pipefail
+
+          raw_dir="${1-}"
+          expected_name="${2-}"
+          tag="${3-}"
+
+          if [ -z "$expected_name" ] || [ -z "$tag" ]; then
+            echo "::error::usage: npm-package-preflight.sh <package-dir> <package-name> <tag>" >&2
+            exit 2
+          fi
+
+          workspace="${GITHUB_WORKSPACE:-$PWD}"
+
+          # --- reject control characters -------------------------------------------
+          # 'dir=' is appended to $GITHUB_OUTPUT, whose key=value form treats a raw
+          # newline as a record separator: an embedded newline would inject a second
+          # output key and could override 'version'. Reject the whole control range
+          # rather than only CR/LF - none of it is legitimate in a path here.
+          #
+          # This is robustness, not containment: a caller who can set package-dir can
+          # already set pack-command, which is arbitrary shell. It earns its place by
+          # turning a silently corrupted $GITHUB_OUTPUT into a named error.
+          case "$raw_dir" in
+            *[[:cntrl:]]*)
+              echo "::error::package-dir contains a control character; only printable characters are allowed" >&2
+              exit 2 ;;
+          esac
+
+          # --- package-dir shape ---------------------------------------------------
+          dir="$raw_dir"
+          if [ -z "$dir" ]; then
+            dir="."
+          fi
+          while [ "${#dir}" -gt 1 ] && [ "${dir%/}" != "$dir" ]; do
+            dir="${dir%/}"
+          done
+
+          case "$dir" in
+            /*)
+              echo "::error::package-dir '${raw_dir}' is absolute; it must be relative to the repository root" >&2
+              exit 2 ;;
+          esac
+
+          # Reject '..' as a shape, not as an outcome: 'a/../a' is refused even though
+          # it would resolve back inside the checkout.
+          case "/$dir/" in
+            */../*)
+              echo "::error::package-dir '${raw_dir}' contains a '..' path segment" >&2
+              exit 2 ;;
+          esac
+
+          # --- resolve and contain -------------------------------------------------
+          # 'cd && pwd -P' is the portable canonicalization: macOS realpath is BSD and
+          # lacks GNU long options. -P resolves symlinks, so a symlinked directory
+          # pointing outside the checkout is caught by the containment test below.
+          ws_real=$(cd "$workspace" 2>/dev/null && pwd -P) || {
+            echo "::error::GITHUB_WORKSPACE '${workspace}' is not a directory" >&2
+            exit 2
+          }
+          pkg_real=$(cd "$ws_real/$dir" 2>/dev/null && pwd -P) || {
+            echo "::error::package-dir '${raw_dir}' does not exist in the checkout" >&2
+            exit 2
+          }
+          case "$pkg_real" in
+            "$ws_real") ;;
+            "$ws_real"/*) ;;
+            *)
+              echo "::error::package-dir '${raw_dir}' resolves to '${pkg_real}', outside the checkout" >&2
+              exit 2 ;;
+          esac
+
+          manifest="$pkg_real/package.json"
+          if [ ! -f "$manifest" ]; then
+            echo "::error::package-dir '${raw_dir}' has no package.json" >&2
+            exit 2
+          fi
+          if ! jq -e . "$manifest" >/dev/null 2>&1; then
+            echo "::error::${dir}/package.json is not valid JSON" >&2
+            exit 2
+          fi
+
+          # --- tag -> version --------------------------------------------------------
+          # Anchored on the trailing semver, so a tag-prefix such as "permissions/v"
+          # is ignored rather than needing to be configured here.
+          #
+          # This runs after every exit-2 (malformed input) check above, deliberately:
+          # exit 2 must always win over exit 1 when both are wrong, or a bad
+          # package-dir gets reported as "package not publishable" instead of
+          # "caller misconfigured the call".
+          #
+          # No control-character guard is needed on $tag itself: grep -oE extracts
+          # only the matched substring and discards everything else, and the matched
+          # charset [0-9A-Za-z.-] contains no '=', so no forged 'key=value' line can
+          # reach stdout through it. Widening the charset (e.g. to allow '+build'
+          # metadata) would need this guarantee re-checked.
+          version=$(printf '%s' "$tag" \
+            | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9][A-Za-z0-9.-]*)?$' || true)
+          if [ -z "$version" ]; then
+            echo "::error::Could not parse semver version from tag '${tag}'" >&2
+            exit 1
+          fi
+
+          # --- manifest policy -----------------------------------------------------
+          if [ "$(jq -r '.private // false' "$manifest")" = "true" ]; then
+            echo "::error::${dir}/package.json is marked private:true and cannot be published" >&2
+            exit 1
+          fi
+
+          actual_name=$(jq -r '.name // ""' "$manifest")
+          if [ "$actual_name" != "$expected_name" ]; then
+            echo "::error::${dir}/package.json name '${actual_name}' does not match package-name input '${expected_name}'" >&2
+            exit 1
+          fi
+
+          actual_version=$(jq -r '.version // ""' "$manifest")
+          if [ "$actual_version" != "$version" ]; then
+            echo "::error::Tag version ${version} != ${dir}/package.json version ${actual_version} - refusing to publish" >&2
+            exit 1
+          fi
+
+          printf 'dir=%s\n' "$dir"
+          printf 'version=%s\n' "$version"
+          )
+          # --- END inline:scripts/npm-package-preflight.sh ---
+
+          OUT="$RUNNER_TEMP/preflight.out"
+          npm_package_preflight "$PACKAGE_DIR" "$PACKAGE_NAME" "$TAG" > "$OUT"
+          cat "$OUT" >> "$GITHUB_OUTPUT"
+          cat "$OUT"
+
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
-
-      - name: Verify tag version matches package.json
-        id: version
-        env:
-          TAG: ${{ inputs.tag }}
-        run: |
-          VERSION=$(printf '%s' "$TAG" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9][A-Za-z0-9.-]*)?$' || true)
-          if [ -z "$VERSION" ]; then
-            echo "::error::Could not parse semver version from tag '$TAG'"
-            exit 1
-          fi
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          if [ "$VERSION" != "$PKG_VERSION" ]; then
-            echo "::error::Tag version ${VERSION} != package.json version ${PKG_VERSION} - refusing to publish"
-            exit 1
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Run caller test command
         env:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -247,6 +247,19 @@ jobs:
         with:
           node-version: "24"
 
+      - name: Enable corepack package manager shims
+        run: |
+          # Deliberately NOT bare `corepack enable`: that also shims npm, and
+          # corepack's npm shim hard-errors in a repo whose packageManager
+          # field pins pnpm - which would break existing npm-packing callers.
+          # Tolerant of a missing corepack so npm-only callers never regress.
+          if command -v corepack >/dev/null 2>&1; then
+            corepack enable pnpm yarn
+            echo "corepack shims enabled for pnpm and yarn"
+          else
+            echo "::warning::corepack unavailable; pnpm/yarn shims not installed"
+          fi
+
       - name: Run caller test command
         env:
           TEST_COMMAND: ${{ inputs.test-command }}
@@ -257,27 +270,223 @@ jobs:
             echo "No caller test command configured; skipping."
           fi
 
-      - name: Pack once and assert tarball contents
+      - name: Pack once and stage the tarball
         env:
+          PACKAGE_DIR: ${{ steps.pkg.outputs.dir }}
+          PACK_COMMAND: ${{ inputs.pack-command }}
           PACK_CONTENTS_SCRIPT: ${{ inputs.pack-contents-script }}
         run: |
-          npm pack --json > pack.json
-          if [ -n "$PACK_CONTENTS_SCRIPT" ]; then
-            sh "$PACK_CONTENTS_SCRIPT" pack.json
-          fi
-          TARBALL_COUNT=$(find . -maxdepth 1 -type f -name '*.tgz' | wc -l | tr -d ' ')
-          if [ "$TARBALL_COUNT" != "1" ]; then
-            echo "::error::Expected exactly one npm tarball, found ${TARBALL_COUNT}"
-            find . -maxdepth 1 -type f -name '*.tgz' -print
+          PACK_JSON="$RUNNER_TEMP/pack.json"
+          STAGE="$RUNNER_TEMP/dist"
+          mkdir -p "$STAGE"
+          rm -f "$STAGE"/*.tgz
+
+          # Metadata is written outside GITHUB_WORKSPACE because the shell
+          # truncates a redirect target BEFORE the packer runs; a file created
+          # in the package directory at that moment is sealed into the tarball
+          # of any package without a `files` allowlist. It is copied back
+          # after packing, so the caller-visible path is unchanged.
+          if ! ( cd "$PACKAGE_DIR" && sh -c "$PACK_COMMAND" ) > "$PACK_JSON"; then
+            echo "::error::pack command failed in ${PACKAGE_DIR}: ${PACK_COMMAND}"
+            jq -r '.error.message // empty' "$PACK_JSON" 2>/dev/null \
+              | sed 's/^/::error::/' || true
             exit 1
           fi
-          ls -lh ./*.tgz
+
+          # Reachable when the caller's pack-command is a pipeline, where the
+          # exit status is the last element's and a packer error is masked.
+          if jq -e 'type == "object" and has("error")' "$PACK_JSON" >/dev/null 2>&1; then
+            echo "::error::pack command reported an error: $(jq -r '.error.message // "unknown"' "$PACK_JSON")"
+            exit 1
+          fi
+
+          # Recursive descent handles all three metadata shapes without
+          # branching: npm's array, npm 12's name-keyed object, pnpm's flat
+          # object. An empty result means the metadata is unusable.
+          EXPECTED_TARBALL=$(jq -r '.. | .filename? // empty' "$PACK_JSON" 2>/dev/null | head -n1)
+          if [ -z "$EXPECTED_TARBALL" ]; then
+            echo "::error::pack metadata carries no tarball filename; cannot prove which artifact this run produced"
+            exit 1
+          fi
+
+          # Byte-identical to the historical argument for root-package callers.
+          if [ "$PACKAGE_DIR" = "." ]; then
+            PACK_JSON_REL="pack.json"
+          else
+            PACK_JSON_REL="$PACKAGE_DIR/pack.json"
+          fi
+          cp "$PACK_JSON" "$PACK_JSON_REL"
+
+          if [ -n "$PACK_CONTENTS_SCRIPT" ]; then
+            sh "$PACK_CONTENTS_SCRIPT" "$PACK_JSON_REL"
+          fi
+
+          TARBALL_COUNT=$(find "$PACKAGE_DIR" -maxdepth 1 -type f -name '*.tgz' | wc -l | tr -d ' ')
+          if [ "$TARBALL_COUNT" != "1" ]; then
+            echo "::error::Expected exactly one tarball in ${PACKAGE_DIR}, found ${TARBALL_COUNT}"
+            find "$PACKAGE_DIR" -maxdepth 1 -type f -name '*.tgz' -print
+            exit 1
+          fi
+
+          # A count of one is not proof of provenance: a stale .tgz left by the
+          # caller's test-command would satisfy it.
+          FOUND=$(find "$PACKAGE_DIR" -maxdepth 1 -type f -name '*.tgz')
+          FOUND_BASE=$(basename "$FOUND")
+          if [ "$FOUND_BASE" != "$EXPECTED_TARBALL" ]; then
+            echo "::error::Staged tarball ${FOUND_BASE} is not the artifact this pack produced (${EXPECTED_TARBALL}); refusing to publish a stale tarball"
+            exit 1
+          fi
+
+          mv "$FOUND" "$STAGE/"
+          ls -lh "$STAGE"/*.tgz
+
+      - name: Assert packed manifest is the requested package
+        env:
+          PACKAGE_NAME: ${{ inputs.package-name }}
+          VERSION: ${{ steps.pkg.outputs.version }}
+        run: |
+          # --- BEGIN inline:scripts/assert-packed-manifest.sh ---
+          assert_packed_manifest() (
+          # assert-packed-manifest.sh — verify a packed tarball is safe to publish.
+          #
+          # Reads package/package.json out of the SEALED tarball rather than the working
+          # tree, and checks two things:
+          #
+          #   1. Identity. The sealed name and version must match what the workflow was
+          #      asked to publish. Preflight already checked the on-disk manifest, but
+          #      prepack/prepare lifecycle scripts run between then and now and may
+          #      rewrite it. npm versions are immutable, so publishing the wrong package
+          #      cannot be undone - only superseded.
+          #
+          #   2. Dependency protocol class. Rejection works by allowlist: the accepted
+          #      set is npm's registry-resolution contract, verified against npm's own
+          #      npm-package-arg parser, while the rejected set is package-manager
+          #      workspace sugar that grows over time. A newly invented protocol
+          #      therefore fails loudly here instead of publishing silently.
+          #
+          # SCOPE OF THE SECOND CHECK. It matches a protocol PREFIX. It does not
+          # validate the rest of the specifier, so a malformed value carrying an allowed
+          # prefix passes - 'npm:', 'npm:@scope' and 'https:' all throw in
+          # npm-package-arg but pass here. The promise is therefore narrow: this guard
+          # rejects local-path and workspace-protocol dependency classes. It does not
+          # certify that a surviving specifier resolves. Malformed specifiers of that
+          # kind break the publisher's own install long before reaching this point; the
+          # failure this guard exists to prevent is a WELL-FORMED workspace: specifier
+          # that packs and publishes green.
+          #
+          # Usage:
+          #   ./scripts/assert-packed-manifest.sh <tarball-path> <expected-name> <expected-version>
+          #
+          # Exit codes:
+          #   0 — identity confirmed and no disallowed specifier
+          #   1 — identity mismatch, or one or more disallowed specifiers (all listed)
+          #   2 — the tarball is unreadable or has no package/package.json
+
+          set -euo pipefail
+
+          tarball="${1-}"
+          expected_name="${2-}"
+          expected_version="${3-}"
+
+          if [ -z "$expected_name" ] || [ -z "$expected_version" ]; then
+            echo "::error::usage: assert-packed-manifest.sh <tarball-path> <expected-name> <expected-version>" >&2
+            exit 2
+          fi
+          if [ -z "$tarball" ] || [ ! -f "$tarball" ]; then
+            echo "::error::assert-packed-manifest.sh: tarball '${tarball}' not found" >&2
+            exit 2
+          fi
+
+          manifest=$(tar -xzOf "$tarball" package/package.json 2>/dev/null || true)
+          if [ -z "$manifest" ]; then
+            echo "::error::${tarball} contains no package/package.json" >&2
+            exit 2
+          fi
+          if ! printf '%s' "$manifest" | jq -e . >/dev/null 2>&1; then
+            echo "::error::${tarball} package/package.json is not valid JSON" >&2
+            exit 2
+          fi
+
+          # --- identity ------------------------------------------------------------
+          sealed_name=$(printf '%s' "$manifest" | jq -r '.name // ""')
+          sealed_version=$(printf '%s' "$manifest" | jq -r '.version // ""')
+
+          if [ "$sealed_name" != "$expected_name" ]; then
+            echo "::error::Sealed manifest name '${sealed_name}' does not match the requested package '${expected_name}'. A prepack or prepare script may have rewritten package.json after preflight - refusing to publish" >&2
+            exit 1
+          fi
+          if [ "$sealed_version" != "$expected_version" ]; then
+            echo "::error::Sealed manifest version '${sealed_version}' does not match the requested version '${expected_version}' - refusing to publish" >&2
+            exit 1
+          fi
+
+          # --- dependency protocol class -------------------------------------------
+          # field <TAB> name <TAB> specifier, for the three fields a consumer installs.
+          # devDependencies are deliberately absent: they are never installed from a
+          # published package, so a workspace: there is harmless.
+          rows=$(printf '%s' "$manifest" | jq -r '
+            ["dependencies","optionalDependencies","peerDependencies"][] as $f
+            | (.[$f] // {}) | to_entries[]
+            | [$f, .key, (.value | tostring)] | @tsv
+          ')
+
+          violations=0
+          tab=$(printf '\t')
+
+          while IFS="$tab" read -r field name spec; do
+            if [ -z "$field" ]; then
+              continue
+            fi
+
+            # Anchored at the start so 'github:u/r#semver:^1.0.0' yields 'github:',
+            # never 'semver:'. Plain ranges, tags and '*' carry no colon at all.
+            proto=$(printf '%s' "$spec" \
+              | grep -oiE '^[a-z][a-z0-9+.-]*:' \
+              | tr '[:upper:]' '[:lower:]' || true)
+            if [ -z "$proto" ]; then
+              continue
+            fi
+
+            case "$proto" in
+              npm:|git:|git+ssh:|git+http:|git+https:|http:|https:|github:|gitlab:|bitbucket:|gist:)
+                continue ;;
+            esac
+
+            violations=$((violations + 1))
+            case "$proto" in
+              workspace:)
+                hint='set pack-command to "pnpm pack --json" and complete a frozen install before packing' ;;
+              catalog:)
+                hint='set pack-command to "pnpm pack --json" so pnpm resolves the catalog entry' ;;
+              link:|portal:|patch:|file:|git+file:)
+                hint='a local path cannot be published; depend on a registry version instead' ;;
+              *)
+                hint='unrecognized dependency protocol; if it is registry-resolvable, please open an issue' ;;
+            esac
+            printf '::error::%s.%s uses unpublishable specifier %s - %s\n' \
+              "$field" "$name" "$spec" "$hint" >&2
+          done <<EOF
+          $rows
+          EOF
+
+          if [ "$violations" -gt 0 ]; then
+            echo "::error::${tarball} sealed ${violations} unpublishable dependency specifier(s)" >&2
+            exit 1
+          fi
+
+          echo "${tarball} is ${sealed_name}@${sealed_version} with no unpublishable dependency specifiers."
+          )
+          # --- END inline:scripts/assert-packed-manifest.sh ---
+
+          set -euo pipefail
+
+          assert_packed_manifest "$RUNNER_TEMP/dist"/*.tgz "$PACKAGE_NAME" "$VERSION"
 
       - name: Upload tarball artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: npm-dist
-          path: "*.tgz"
+          path: ${{ runner.temp }}/dist/*.tgz
           if-no-files-found: error
           retention-days: 7
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -254,8 +254,8 @@ jobs:
           # field pins pnpm - which would break existing npm-packing callers.
           # Tolerant of a missing corepack so npm-only callers never regress.
           if command -v corepack >/dev/null 2>&1; then
-            corepack enable pnpm yarn
-            echo "corepack shims enabled for pnpm and yarn"
+            corepack enable pnpm yarn || echo "::warning::corepack enable failed; pnpm/yarn shims not installed"
+            echo "corepack shim setup attempted for pnpm and yarn"
           else
             echo "::warning::corepack unavailable; pnpm/yarn shims not installed"
           fi
@@ -318,7 +318,10 @@ jobs:
           # Recursive descent handles all three metadata shapes without
           # branching: npm's array, npm 12's name-keyed object, pnpm's flat
           # object. An empty result means the metadata is unusable.
-          EXPECTED_TARBALL=$(jq -r '.. | .filename? // empty' "$PACK_JSON" 2>/dev/null | head -n1)
+          # `|| true` so the diagnostic below survives: on malformed metadata
+          # jq exits non-zero, which would abort this step silently under
+          # `set -e` with pipefail on, printing nothing at all.
+          EXPECTED_TARBALL=$(jq -r '.. | .filename? // empty' "$PACK_JSON" 2>/dev/null | head -n1 || true)
           if [ -z "$EXPECTED_TARBALL" ]; then
             echo "::error::pack metadata carries no tarball filename; cannot prove which artifact this run produced"
             exit 1
@@ -374,10 +377,15 @@ jobs:
           #      cannot be undone - only superseded.
           #
           #   2. Dependency protocol class. Rejection works by allowlist: the accepted
-          #      set is npm's registry-resolution contract, verified against npm's own
+          #      set is npm's non-local resolution protocols - the registry, the git-host
+          #      shortcuts and remote tarballs - verified against npm's own
           #      npm-package-arg parser, while the rejected set is package-manager
           #      workspace sugar that grows over time. A newly invented protocol
           #      therefore fails loudly here instead of publishing silently.
+          #
+          # `private` is deliberately NOT re-checked here even though a prepack script
+          # could set it after preflight rejected it: `npm publish` refuses a private
+          # package outright, so that path already fails closed one job later.
           #
           # SCOPE OF THE SECOND CHECK. It matches a protocol PREFIX. It does not
           # validate the rest of the specifier, so a malformed value carrying an allowed
@@ -453,13 +461,24 @@ jobs:
               continue
             fi
 
+            # Trim leading whitespace so ' workspace:^' cannot slip past the anchor.
+            spec="${spec#"${spec%%[![:space:]]*}"}"
+
             # Anchored at the start so 'github:u/r#semver:^1.0.0' yields 'github:',
             # never 'semver:'. Plain ranges, tags and '*' carry no colon at all.
             proto=$(printf '%s' "$spec" \
               | grep -oiE '^[a-z][a-z0-9+.-]*:' \
               | tr '[:upper:]' '[:lower:]' || true)
             if [ -z "$proto" ]; then
-              continue
+              # npm-package-arg resolves a leading '.', '/' or '~/' to a local directory
+              # with no protocol prefix, so '../core' means exactly 'file:../core'.
+              # The 'C:' Windows-drive form npa also accepts is already caught above as
+              # an unknown protocol. The tilde is backslash-escaped because a case
+              # pattern is tilde-expanded: a bare ~/* would match $HOME, not '~/'.
+              case "$spec" in
+                .*|/*|\~/*) proto="file:" ;;
+                *) continue ;;
+              esac
             fi
 
             case "$proto" in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,11 @@ A reusable workflow cannot reliably check out *its own* repo's scripts: in a `wo
 
 `scripts/*.sh` is the source of truth; the inline copy is a derived artifact. **Editing a script means updating its inline copy too**, or `check-inline-sync.sh` fails CI. The sync is byte-for-byte after known normalizations (10-space YAML indent strip, shebang strip, function-wrapper strip). The pairs are listed in `check-inline-sync.sh` (`INLINE_PAIRS`):
 
-- `dependency-safety.yml` embeds `extract-deps.sh`, `check-release-age.sh`, `diff-touches-lockfile.sh`, `pr-body-to-deps.sh`, `classify-touched-paths.sh`, `pyproject-bump-extract.sh`, and `safety-verdict.sh`
+- `dependency-safety.yml` embeds `extract-deps.sh`, `check-release-age.sh`, `diff-touches-lockfile.sh`, `pr-body-to-deps.sh`, `classify-touched-paths.sh`, `pyproject-bump-extract.sh`, `npm-bump-extract.sh`, and `safety-verdict.sh`
 - `tag-release.yml` embeds `bump-version-files.sh`
+- `pre-commit-autoupdate.yml` embeds `pre-commit-autoupdate-preflight.sh`
+- `pnpm-packagemanager-update.yml` embeds `packagemanager-bump.sh` and `packagemanager-integrity.sh`
+- `publish-npm.yml` embeds `npm-package-preflight.sh` and `assert-packed-manifest.sh`
 
 `lint-workflow-call.sh` is the partner guard: it fails CI if any `workflow_call` file reintroduces a caller-scoped ref as a checkout `ref:`.
 

--- a/scripts/assert-packed-manifest.sh
+++ b/scripts/assert-packed-manifest.sh
@@ -11,10 +11,15 @@
 #      cannot be undone - only superseded.
 #
 #   2. Dependency protocol class. Rejection works by allowlist: the accepted
-#      set is npm's registry-resolution contract, verified against npm's own
+#      set is npm's non-local resolution protocols - the registry, the git-host
+#      shortcuts and remote tarballs - verified against npm's own
 #      npm-package-arg parser, while the rejected set is package-manager
 #      workspace sugar that grows over time. A newly invented protocol
 #      therefore fails loudly here instead of publishing silently.
+#
+# `private` is deliberately NOT re-checked here even though a prepack script
+# could set it after preflight rejected it: `npm publish` refuses a private
+# package outright, so that path already fails closed one job later.
 #
 # SCOPE OF THE SECOND CHECK. It matches a protocol PREFIX. It does not
 # validate the rest of the specifier, so a malformed value carrying an allowed
@@ -90,13 +95,24 @@ while IFS="$tab" read -r field name spec; do
     continue
   fi
 
+  # Trim leading whitespace so ' workspace:^' cannot slip past the anchor.
+  spec="${spec#"${spec%%[![:space:]]*}"}"
+
   # Anchored at the start so 'github:u/r#semver:^1.0.0' yields 'github:',
   # never 'semver:'. Plain ranges, tags and '*' carry no colon at all.
   proto=$(printf '%s' "$spec" \
     | grep -oiE '^[a-z][a-z0-9+.-]*:' \
     | tr '[:upper:]' '[:lower:]' || true)
   if [ -z "$proto" ]; then
-    continue
+    # npm-package-arg resolves a leading '.', '/' or '~/' to a local directory
+    # with no protocol prefix, so '../core' means exactly 'file:../core'.
+    # The 'C:' Windows-drive form npa also accepts is already caught above as
+    # an unknown protocol. The tilde is backslash-escaped because a case
+    # pattern is tilde-expanded: a bare ~/* would match $HOME, not '~/'.
+    case "$spec" in
+      .*|/*|\~/*) proto="file:" ;;
+      *) continue ;;
+    esac
   fi
 
   case "$proto" in

--- a/scripts/assert-packed-manifest.sh
+++ b/scripts/assert-packed-manifest.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# assert-packed-manifest.sh — verify a packed tarball is safe to publish.
+#
+# Reads package/package.json out of the SEALED tarball rather than the working
+# tree, and checks two things:
+#
+#   1. Identity. The sealed name and version must match what the workflow was
+#      asked to publish. Preflight already checked the on-disk manifest, but
+#      prepack/prepare lifecycle scripts run between then and now and may
+#      rewrite it. npm versions are immutable, so publishing the wrong package
+#      cannot be undone - only superseded.
+#
+#   2. Dependency protocol class. Rejection works by allowlist: the accepted
+#      set is npm's registry-resolution contract, verified against npm's own
+#      npm-package-arg parser, while the rejected set is package-manager
+#      workspace sugar that grows over time. A newly invented protocol
+#      therefore fails loudly here instead of publishing silently.
+#
+# SCOPE OF THE SECOND CHECK. It matches a protocol PREFIX. It does not
+# validate the rest of the specifier, so a malformed value carrying an allowed
+# prefix passes - 'npm:', 'npm:@scope' and 'https:' all throw in
+# npm-package-arg but pass here. The promise is therefore narrow: this guard
+# rejects local-path and workspace-protocol dependency classes. It does not
+# certify that a surviving specifier resolves. Malformed specifiers of that
+# kind break the publisher's own install long before reaching this point; the
+# failure this guard exists to prevent is a WELL-FORMED workspace: specifier
+# that packs and publishes green.
+#
+# Usage:
+#   ./scripts/assert-packed-manifest.sh <tarball-path> <expected-name> <expected-version>
+#
+# Exit codes:
+#   0 — identity confirmed and no disallowed specifier
+#   1 — identity mismatch, or one or more disallowed specifiers (all listed)
+#   2 — the tarball is unreadable or has no package/package.json
+
+set -euo pipefail
+
+tarball="${1-}"
+expected_name="${2-}"
+expected_version="${3-}"
+
+if [ -z "$expected_name" ] || [ -z "$expected_version" ]; then
+  echo "::error::usage: assert-packed-manifest.sh <tarball-path> <expected-name> <expected-version>" >&2
+  exit 2
+fi
+if [ -z "$tarball" ] || [ ! -f "$tarball" ]; then
+  echo "::error::assert-packed-manifest.sh: tarball '${tarball}' not found" >&2
+  exit 2
+fi
+
+manifest=$(tar -xzOf "$tarball" package/package.json 2>/dev/null || true)
+if [ -z "$manifest" ]; then
+  echo "::error::${tarball} contains no package/package.json" >&2
+  exit 2
+fi
+if ! printf '%s' "$manifest" | jq -e . >/dev/null 2>&1; then
+  echo "::error::${tarball} package/package.json is not valid JSON" >&2
+  exit 2
+fi
+
+# --- identity ------------------------------------------------------------
+sealed_name=$(printf '%s' "$manifest" | jq -r '.name // ""')
+sealed_version=$(printf '%s' "$manifest" | jq -r '.version // ""')
+
+if [ "$sealed_name" != "$expected_name" ]; then
+  echo "::error::Sealed manifest name '${sealed_name}' does not match the requested package '${expected_name}'. A prepack or prepare script may have rewritten package.json after preflight - refusing to publish" >&2
+  exit 1
+fi
+if [ "$sealed_version" != "$expected_version" ]; then
+  echo "::error::Sealed manifest version '${sealed_version}' does not match the requested version '${expected_version}' - refusing to publish" >&2
+  exit 1
+fi
+
+# --- dependency protocol class -------------------------------------------
+# field <TAB> name <TAB> specifier, for the three fields a consumer installs.
+# devDependencies are deliberately absent: they are never installed from a
+# published package, so a workspace: there is harmless.
+rows=$(printf '%s' "$manifest" | jq -r '
+  ["dependencies","optionalDependencies","peerDependencies"][] as $f
+  | (.[$f] // {}) | to_entries[]
+  | [$f, .key, (.value | tostring)] | @tsv
+')
+
+violations=0
+tab=$(printf '\t')
+
+while IFS="$tab" read -r field name spec; do
+  if [ -z "$field" ]; then
+    continue
+  fi
+
+  # Anchored at the start so 'github:u/r#semver:^1.0.0' yields 'github:',
+  # never 'semver:'. Plain ranges, tags and '*' carry no colon at all.
+  proto=$(printf '%s' "$spec" \
+    | grep -oiE '^[a-z][a-z0-9+.-]*:' \
+    | tr '[:upper:]' '[:lower:]' || true)
+  if [ -z "$proto" ]; then
+    continue
+  fi
+
+  case "$proto" in
+    npm:|git:|git+ssh:|git+http:|git+https:|http:|https:|github:|gitlab:|bitbucket:|gist:)
+      continue ;;
+  esac
+
+  violations=$((violations + 1))
+  case "$proto" in
+    workspace:)
+      hint='set pack-command to "pnpm pack --json" and complete a frozen install before packing' ;;
+    catalog:)
+      hint='set pack-command to "pnpm pack --json" so pnpm resolves the catalog entry' ;;
+    link:|portal:|patch:|file:|git+file:)
+      hint='a local path cannot be published; depend on a registry version instead' ;;
+    *)
+      hint='unrecognized dependency protocol; if it is registry-resolvable, please open an issue' ;;
+  esac
+  printf '::error::%s.%s uses unpublishable specifier %s - %s\n' \
+    "$field" "$name" "$spec" "$hint" >&2
+done <<EOF
+$rows
+EOF
+
+if [ "$violations" -gt 0 ]; then
+  echo "::error::${tarball} sealed ${violations} unpublishable dependency specifier(s)" >&2
+  exit 1
+fi
+
+echo "${tarball} is ${sealed_name}@${sealed_version} with no unpublishable dependency specifiers."

--- a/scripts/check-inline-sync.sh
+++ b/scripts/check-inline-sync.sh
@@ -24,6 +24,7 @@ INLINE_PAIRS=(
   ".github/workflows/pnpm-packagemanager-update.yml:scripts/packagemanager-bump.sh"
   ".github/workflows/pnpm-packagemanager-update.yml:scripts/packagemanager-integrity.sh"
   ".github/workflows/publish-npm.yml:scripts/npm-package-preflight.sh"
+  ".github/workflows/publish-npm.yml:scripts/assert-packed-manifest.sh"
 )
 
 YAML_INDENT="          "  # exactly 10 spaces — matches the `run: |` indent

--- a/scripts/check-inline-sync.sh
+++ b/scripts/check-inline-sync.sh
@@ -23,6 +23,7 @@ INLINE_PAIRS=(
   ".github/workflows/dependency-safety.yml:scripts/npm-bump-extract.sh"
   ".github/workflows/pnpm-packagemanager-update.yml:scripts/packagemanager-bump.sh"
   ".github/workflows/pnpm-packagemanager-update.yml:scripts/packagemanager-integrity.sh"
+  ".github/workflows/publish-npm.yml:scripts/npm-package-preflight.sh"
 )
 
 YAML_INDENT="          "  # exactly 10 spaces — matches the `run: |` indent

--- a/scripts/npm-package-preflight.sh
+++ b/scripts/npm-package-preflight.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# npm-package-preflight.sh — select and validate the package publish-npm.yml
+# is about to publish.
+#
+# Resolves <package-dir> inside GITHUB_WORKSPACE, refuses anything that could
+# reach outside the checkout, and verifies the selected manifest is the
+# package the caller named at the version the tag names. Runs before the
+# caller's test command and before packing so a misconfigured call fails
+# early and cheaply.
+#
+# This establishes identity at the SOURCE. That guarantee does not survive
+# packing, because prepack/prepare lifecycle scripts may rewrite the manifest,
+# so assert-packed-manifest.sh re-establishes it against the sealed artifact.
+#
+# Usage:
+#   ./scripts/npm-package-preflight.sh <package-dir> <package-name> <tag>
+#
+# Stdout (success only), shaped for appending to $GITHUB_OUTPUT:
+#   dir=<repository-relative directory>
+#   version=<semver parsed from the tag>
+#
+# Exit codes:
+#   0 — package selected and validated
+#   1 — the selected package is not publishable: private, name mismatch,
+#       version mismatch, or an unparseable tag. Caller MUST fail.
+#   2 — the package-dir input is malformed or unsafe: control characters,
+#       absolute, contains '..', escapes the checkout, missing, or has no
+#       readable package.json.
+
+set -euo pipefail
+
+raw_dir="${1-}"
+expected_name="${2-}"
+tag="${3-}"
+
+if [ -z "$expected_name" ] || [ -z "$tag" ]; then
+  echo "::error::usage: npm-package-preflight.sh <package-dir> <package-name> <tag>" >&2
+  exit 2
+fi
+
+workspace="${GITHUB_WORKSPACE:-$PWD}"
+
+# --- tag -> version ------------------------------------------------------
+# Anchored on the trailing semver, so a tag-prefix such as "permissions/v"
+# is ignored rather than needing to be configured here.
+version=$(printf '%s' "$tag" \
+  | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9][A-Za-z0-9.-]*)?$' || true)
+if [ -z "$version" ]; then
+  echo "::error::Could not parse semver version from tag '${tag}'" >&2
+  exit 1
+fi
+
+# --- reject control characters -------------------------------------------
+# 'dir=' is appended to $GITHUB_OUTPUT, whose key=value form treats a raw
+# newline as a record separator: an embedded newline would inject a second
+# output key and could override 'version'. Reject the whole control range
+# rather than only CR/LF - none of it is legitimate in a path here.
+#
+# This is robustness, not containment: a caller who can set package-dir can
+# already set pack-command, which is arbitrary shell. It earns its place by
+# turning a silently corrupted $GITHUB_OUTPUT into a named error.
+case "$raw_dir" in
+  *[[:cntrl:]]*)
+    echo "::error::package-dir contains a control character; only printable characters are allowed" >&2
+    exit 2 ;;
+esac
+
+# --- package-dir shape ---------------------------------------------------
+dir="$raw_dir"
+if [ -z "$dir" ]; then
+  dir="."
+fi
+while [ "${#dir}" -gt 1 ] && [ "${dir%/}" != "$dir" ]; do
+  dir="${dir%/}"
+done
+
+case "$dir" in
+  /*)
+    echo "::error::package-dir '${raw_dir}' is absolute; it must be relative to the repository root" >&2
+    exit 2 ;;
+esac
+
+# Reject '..' as a shape, not as an outcome: 'a/../a' is refused even though
+# it would resolve back inside the checkout.
+case "/$dir/" in
+  */../*)
+    echo "::error::package-dir '${raw_dir}' contains a '..' path segment" >&2
+    exit 2 ;;
+esac
+
+# --- resolve and contain -------------------------------------------------
+# 'cd && pwd -P' is the portable canonicalization: macOS realpath is BSD and
+# lacks GNU long options. -P resolves symlinks, so a symlinked directory
+# pointing outside the checkout is caught by the containment test below.
+ws_real=$(cd "$workspace" 2>/dev/null && pwd -P) || {
+  echo "::error::GITHUB_WORKSPACE '${workspace}' is not a directory" >&2
+  exit 2
+}
+pkg_real=$(cd "$ws_real/$dir" 2>/dev/null && pwd -P) || {
+  echo "::error::package-dir '${raw_dir}' does not exist in the checkout" >&2
+  exit 2
+}
+case "$pkg_real" in
+  "$ws_real") ;;
+  "$ws_real"/*) ;;
+  *)
+    echo "::error::package-dir '${raw_dir}' resolves to '${pkg_real}', outside the checkout" >&2
+    exit 2 ;;
+esac
+
+manifest="$pkg_real/package.json"
+if [ ! -f "$manifest" ]; then
+  echo "::error::package-dir '${raw_dir}' has no package.json" >&2
+  exit 2
+fi
+if ! jq -e . "$manifest" >/dev/null 2>&1; then
+  echo "::error::${dir}/package.json is not valid JSON" >&2
+  exit 2
+fi
+
+# --- manifest policy -----------------------------------------------------
+if [ "$(jq -r '.private // false' "$manifest")" = "true" ]; then
+  echo "::error::${dir}/package.json is marked private:true and cannot be published" >&2
+  exit 1
+fi
+
+actual_name=$(jq -r '.name // ""' "$manifest")
+if [ "$actual_name" != "$expected_name" ]; then
+  echo "::error::${dir}/package.json name '${actual_name}' does not match package-name input '${expected_name}'" >&2
+  exit 1
+fi
+
+actual_version=$(jq -r '.version // ""' "$manifest")
+if [ "$actual_version" != "$version" ]; then
+  echo "::error::Tag version ${version} != ${dir}/package.json version ${actual_version} - refusing to publish" >&2
+  exit 1
+fi
+
+printf 'dir=%s\n' "$dir"
+printf 'version=%s\n' "$version"

--- a/scripts/npm-package-preflight.sh
+++ b/scripts/npm-package-preflight.sh
@@ -40,16 +40,6 @@ fi
 
 workspace="${GITHUB_WORKSPACE:-$PWD}"
 
-# --- tag -> version ------------------------------------------------------
-# Anchored on the trailing semver, so a tag-prefix such as "permissions/v"
-# is ignored rather than needing to be configured here.
-version=$(printf '%s' "$tag" \
-  | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9][A-Za-z0-9.-]*)?$' || true)
-if [ -z "$version" ]; then
-  echo "::error::Could not parse semver version from tag '${tag}'" >&2
-  exit 1
-fi
-
 # --- reject control characters -------------------------------------------
 # 'dir=' is appended to $GITHUB_OUTPUT, whose key=value form treats a raw
 # newline as a record separator: an embedded newline would inject a second
@@ -116,6 +106,27 @@ fi
 if ! jq -e . "$manifest" >/dev/null 2>&1; then
   echo "::error::${dir}/package.json is not valid JSON" >&2
   exit 2
+fi
+
+# --- tag -> version --------------------------------------------------------
+# Anchored on the trailing semver, so a tag-prefix such as "permissions/v"
+# is ignored rather than needing to be configured here.
+#
+# This runs after every exit-2 (malformed input) check above, deliberately:
+# exit 2 must always win over exit 1 when both are wrong, or a bad
+# package-dir gets reported as "package not publishable" instead of
+# "caller misconfigured the call".
+#
+# No control-character guard is needed on $tag itself: grep -oE extracts
+# only the matched substring and discards everything else, and the matched
+# charset [0-9A-Za-z.-] contains no '=', so no forged 'key=value' line can
+# reach stdout through it. Widening the charset (e.g. to allow '+build'
+# metadata) would need this guarantee re-checked.
+version=$(printf '%s' "$tag" \
+  | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9][A-Za-z0-9.-]*)?$' || true)
+if [ -z "$version" ]; then
+  echo "::error::Could not parse semver version from tag '${tag}'" >&2
+  exit 1
 fi
 
 # --- manifest policy -----------------------------------------------------

--- a/tests/assert-packed-manifest.bats
+++ b/tests/assert-packed-manifest.bats
@@ -1,0 +1,174 @@
+bats_require_minimum_version 1.5.0
+#!/usr/bin/env bats
+# assert-packed-manifest.bats — coverage for the sealed-tarball guard used by
+# publish-npm.yml before artifact upload.
+#
+# Fixtures are readable directories under tests/fixtures/assert-packed-manifest/
+# that this file tars at test time. Committing .tgz blobs instead would make
+# the interesting content — the manifest — invisible in a diff.
+#
+# --separate-stderr throughout: plain `run` folds stderr into $output, so a
+# diagnostic that leaked onto stdout would be invisible to these assertions.
+# Every non-zero-exit test asserts stdout stays empty.
+
+SCRIPT="scripts/assert-packed-manifest.sh"
+FIXTURES="tests/fixtures/assert-packed-manifest"
+NAME="@probe/clean"
+VERSION="1.0.0"
+
+setup() {
+  REPO_ROOT="$PWD"
+  TEST_TMP=$(mktemp -d)
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+}
+
+tarball_for() {
+  local case_name="$1"
+  local out="$TEST_TMP/${case_name}.tgz"
+  ( cd "$REPO_ROOT/$FIXTURES/$case_name" && tar -czf "$out" package )
+  printf '%s' "$out"
+}
+
+# --- identity --------------------------------------------------------------
+
+@test "matching name and version pass" {
+  tgz="$(tarball_for clean)"
+  run --separate-stderr "$SCRIPT" "$tgz" "$NAME" "$VERSION"
+  [ "$status" -eq 0 ]
+  [ "$output" = "${tgz} is ${NAME}@${VERSION} with no unpublishable dependency specifiers." ]
+  [ -z "$stderr" ]
+}
+
+@test "a lifecycle script that renamed the package is caught" {
+  run --separate-stderr "$SCRIPT" "$(tarball_for renamed-by-lifecycle)" "$NAME" "$VERSION"
+  [ "$status" -eq 1 ]
+  [[ "$stderr" == *"@probe/something-else"* ]] || return 1
+  [[ "$stderr" == *"does not match the requested package"* ]] || return 1
+  [ -z "$output" ]
+}
+
+@test "a lifecycle script that changed the version is caught" {
+  run --separate-stderr "$SCRIPT" "$(tarball_for reversioned-by-lifecycle)" "$NAME" "$VERSION"
+  [ "$status" -eq 1 ]
+  [[ "$stderr" == *"9.9.9"* ]] || return 1
+  [[ "$stderr" == *"refusing to publish"* ]] || return 1
+  [ -z "$output" ]
+}
+
+@test "missing expected-name or expected-version is malformed input" {
+  run --separate-stderr "$SCRIPT" "$(tarball_for clean)"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"usage:"* ]] || return 1
+  [ -z "$output" ]
+}
+
+# --- protocols -------------------------------------------------------------
+
+@test "registry-resolvable specifiers pass" {
+  tgz="$(tarball_for clean)"
+  run --separate-stderr "$SCRIPT" "$tgz" "$NAME" "$VERSION"
+  [ "$status" -eq 0 ]
+  [ "$output" = "${tgz} is ${NAME}@${VERSION} with no unpublishable dependency specifiers." ]
+  [ -z "$stderr" ]
+}
+
+@test "every allowed protocol passes" {
+  tgz="$(tarball_for allowed-protocols)"
+  run --separate-stderr "$SCRIPT" "$tgz" "$NAME" "$VERSION"
+  [ "$status" -eq 0 ]
+  [ "$output" = "${tgz} is ${NAME}@${VERSION} with no unpublishable dependency specifiers." ]
+  [ -z "$stderr" ]
+}
+
+@test "github shortcut with an embedded semver fragment is not misparsed" {
+  tgz="$(tarball_for allowed-protocols)"
+  run --separate-stderr "$SCRIPT" "$tgz" "$NAME" "$VERSION"
+  [ "$status" -eq 0 ]
+  # A bare exit-0 with empty stderr already proves 'semver:' inside the
+  # github: fragment was never treated as its own violating protocol.
+  [ "$output" = "${tgz} is ${NAME}@${VERSION} with no unpublishable dependency specifiers." ]
+  [ -z "$stderr" ]
+}
+
+@test "workspace: in dependencies is rejected with pnpm remediation" {
+  run --separate-stderr "$SCRIPT" "$(tarball_for workspace-dep)" "$NAME" "$VERSION"
+  [ "$status" -eq 1 ]
+  [[ "$stderr" == *"dependencies.@probe/core"* ]] || return 1
+  [[ "$stderr" == *"workspace:^"* ]] || return 1
+  [[ "$stderr" == *"pnpm pack --json"* ]] || return 1
+  [[ "$stderr" == *"frozen install"* ]] || return 1
+  [ -z "$output" ]
+}
+
+@test "catalog: is rejected and does not demand a frozen install" {
+  run --separate-stderr "$SCRIPT" "$(tarball_for catalog-dep)" "$NAME" "$VERSION"
+  [ "$status" -eq 1 ]
+  [[ "$stderr" == *"pnpm pack --json"* ]] || return 1
+  ! printf '%s\n' "$stderr" | grep -q 'frozen install' || return 1
+  [ -z "$output" ]
+}
+
+@test "link: in optionalDependencies is rejected as a local path" {
+  run --separate-stderr "$SCRIPT" "$(tarball_for link-optional)" "$NAME" "$VERSION"
+  [ "$status" -eq 1 ]
+  [[ "$stderr" == *"optionalDependencies.@probe/core"* ]] || return 1
+  [[ "$stderr" == *"local path cannot be published"* ]] || return 1
+  [ -z "$output" ]
+}
+
+@test "file: in peerDependencies is rejected as a local path" {
+  run --separate-stderr "$SCRIPT" "$(tarball_for file-peer)" "$NAME" "$VERSION"
+  [ "$status" -eq 1 ]
+  [[ "$stderr" == *"peerDependencies.@probe/core"* ]] || return 1
+  [[ "$stderr" == *"local path cannot be published"* ]] || return 1
+  [ -z "$output" ]
+}
+
+@test "devDependencies are ignored" {
+  tgz="$(tarball_for dev-only)"
+  run --separate-stderr "$SCRIPT" "$tgz" "$NAME" "$VERSION"
+  [ "$status" -eq 0 ]
+  [ "$output" = "${tgz} is ${NAME}@${VERSION} with no unpublishable dependency specifiers." ]
+  [ -z "$stderr" ]
+}
+
+@test "an unrecognized protocol is rejected with the generic hint" {
+  run --separate-stderr "$SCRIPT" "$(tarball_for unknown-protocol)" "$NAME" "$VERSION"
+  [ "$status" -eq 1 ]
+  [[ "$stderr" == *"quantum:"* ]] || return 1
+  [[ "$stderr" == *"open an issue"* ]] || return 1
+  [ -z "$output" ]
+}
+
+@test "all violations are reported in one run, not just the first" {
+  run --separate-stderr "$SCRIPT" "$(tarball_for multi-violation)" "$NAME" "$VERSION"
+  [ "$status" -eq 1 ]
+  [[ "$stderr" == *"dependencies.a"* ]] || return 1
+  [[ "$stderr" == *"dependencies.b"* ]] || return 1
+  [[ "$stderr" == *"optionalDependencies.c"* ]] || return 1
+  [[ "$stderr" == *"peerDependencies.d"* ]] || return 1
+  [[ "$stderr" == *"4 unpublishable"* ]] || return 1
+  [ -z "$output" ]
+}
+
+# --- malformed input -------------------------------------------------------
+
+@test "a tarball without package/package.json is malformed input" {
+  mkdir -p "$TEST_TMP/other/notpackage"
+  printf 'x' > "$TEST_TMP/other/notpackage/file.txt"
+  ( cd "$TEST_TMP/other" && tar -czf "$TEST_TMP/bad.tgz" notpackage )
+  run --separate-stderr "$SCRIPT" "$TEST_TMP/bad.tgz" "$NAME" "$VERSION"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"no package/package.json"* ]] || return 1
+  [ -z "$output" ]
+}
+
+@test "a missing tarball is malformed input" {
+  run --separate-stderr "$SCRIPT" "$TEST_TMP/absent.tgz" "$NAME" "$VERSION"
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"not found"* ]] || return 1
+  [ -z "$output" ]
+}

--- a/tests/assert-packed-manifest.bats
+++ b/tests/assert-packed-manifest.bats
@@ -127,6 +127,39 @@ tarball_for() {
   [ -z "$output" ]
 }
 
+@test "bare relative and absolute paths are rejected as local paths" {
+  run --separate-stderr "$SCRIPT" "$(tarball_for bare-path-dep)" "$NAME" "$VERSION"
+  [ "$status" -eq 1 ]
+  # npm-package-arg resolves each of these to a local directory with no
+  # protocol prefix, so '../core' means exactly what 'file:../core' means.
+  [[ "$stderr" == *"dependencies.@probe/core"* ]] || return 1
+  [[ "$stderr" == *"dependencies.sib"* ]] || return 1
+  [[ "$stderr" == *"optionalDependencies.home"* ]] || return 1
+  [[ "$stderr" == *"peerDependencies.abs"* ]] || return 1
+  [[ "$stderr" == *"local path cannot be published"* ]] || return 1
+  [[ "$stderr" == *"4 unpublishable"* ]] || return 1
+  [ -z "$output" ]
+}
+
+@test "a leading space does not let a specifier slip past the protocol anchor" {
+  run --separate-stderr "$SCRIPT" "$(tarball_for leading-space-workspace)" "$NAME" "$VERSION"
+  [ "$status" -eq 1 ]
+  [[ "$stderr" == *"dependencies.@probe/core"* ]] || return 1
+  [[ "$stderr" == *"pnpm pack --json"* ]] || return 1
+  [[ "$stderr" == *"1 unpublishable"* ]] || return 1
+  [ -z "$output" ]
+}
+
+@test "a bare range, a dist-tag and '*' survive the local-path fallback" {
+  # The regression the local-path fallback could plausibly introduce: a
+  # colon-less specifier that is NOT a path must still reach `continue`.
+  tgz="$(tarball_for clean)"
+  run --separate-stderr "$SCRIPT" "$tgz" "$NAME" "$VERSION"
+  [ "$status" -eq 0 ]
+  [ "$output" = "${tgz} is ${NAME}@${VERSION} with no unpublishable dependency specifiers." ]
+  [ -z "$stderr" ]
+}
+
 @test "devDependencies are ignored" {
   tgz="$(tarball_for dev-only)"
   run --separate-stderr "$SCRIPT" "$tgz" "$NAME" "$VERSION"

--- a/tests/fixtures/assert-packed-manifest/allowed-protocols/package/package.json
+++ b/tests/fixtures/assert-packed-manifest/allowed-protocols/package/package.json
@@ -1,0 +1,13 @@
+{ "name": "@probe/clean", "version": "1.0.0",
+  "dependencies": {
+    "aliased": "npm:other@^1.0.0",
+    "viagit": "git+https://example.com/x/y.git",
+    "viassh": "git+ssh://git@example.com/x/y.git",
+    "viagitproto": "git://example.com/x/y.git",
+    "viahttps": "https://example.com/x/y.tgz",
+    "viahttp": "http://example.com/x/y.tgz",
+    "viagithub": "github:user/repo#semver:^1.0.0",
+    "viagitlab": "gitlab:user/repo",
+    "viabitbucket": "bitbucket:user/repo",
+    "viagist": "gist:abc123"
+  } }

--- a/tests/fixtures/assert-packed-manifest/bare-path-dep/package/package.json
+++ b/tests/fixtures/assert-packed-manifest/bare-path-dep/package/package.json
@@ -1,0 +1,4 @@
+{ "name": "@probe/clean", "version": "1.0.0",
+  "dependencies": { "@probe/core": "../core", "sib": "./sib" },
+  "optionalDependencies": { "home": "~/home" },
+  "peerDependencies": { "abs": "/x" } }

--- a/tests/fixtures/assert-packed-manifest/catalog-dep/package/package.json
+++ b/tests/fixtures/assert-packed-manifest/catalog-dep/package/package.json
@@ -1,0 +1,2 @@
+{ "name": "@probe/clean", "version": "1.0.0",
+  "dependencies": { "@probe/core": "catalog:" } }

--- a/tests/fixtures/assert-packed-manifest/clean/package/package.json
+++ b/tests/fixtures/assert-packed-manifest/clean/package/package.json
@@ -1,0 +1,2 @@
+{ "name": "@probe/clean", "version": "1.0.0",
+  "dependencies": { "left-pad": "^1.3.0", "tagged": "latest", "any": "*" } }

--- a/tests/fixtures/assert-packed-manifest/dev-only/package/package.json
+++ b/tests/fixtures/assert-packed-manifest/dev-only/package/package.json
@@ -1,0 +1,3 @@
+{ "name": "@probe/clean", "version": "1.0.0",
+  "dependencies": { "left-pad": "^1.3.0" },
+  "devDependencies": { "@probe/core": "workspace:^", "t": "link:../t" } }

--- a/tests/fixtures/assert-packed-manifest/file-peer/package/package.json
+++ b/tests/fixtures/assert-packed-manifest/file-peer/package/package.json
@@ -1,0 +1,2 @@
+{ "name": "@probe/clean", "version": "1.0.0",
+  "peerDependencies": { "@probe/core": "file:../core" } }

--- a/tests/fixtures/assert-packed-manifest/leading-space-workspace/package/package.json
+++ b/tests/fixtures/assert-packed-manifest/leading-space-workspace/package/package.json
@@ -1,0 +1,2 @@
+{ "name": "@probe/clean", "version": "1.0.0",
+  "dependencies": { "@probe/core": " workspace:^" } }

--- a/tests/fixtures/assert-packed-manifest/link-optional/package/package.json
+++ b/tests/fixtures/assert-packed-manifest/link-optional/package/package.json
@@ -1,0 +1,2 @@
+{ "name": "@probe/clean", "version": "1.0.0",
+  "optionalDependencies": { "@probe/core": "link:../core" } }

--- a/tests/fixtures/assert-packed-manifest/multi-violation/package/package.json
+++ b/tests/fixtures/assert-packed-manifest/multi-violation/package/package.json
@@ -1,0 +1,4 @@
+{ "name": "@probe/clean", "version": "1.0.0",
+  "dependencies": { "a": "workspace:^", "b": "catalog:" },
+  "optionalDependencies": { "c": "link:../c" },
+  "peerDependencies": { "d": "portal:../d" } }

--- a/tests/fixtures/assert-packed-manifest/renamed-by-lifecycle/package/package.json
+++ b/tests/fixtures/assert-packed-manifest/renamed-by-lifecycle/package/package.json
@@ -1,0 +1,2 @@
+{ "name": "@probe/something-else", "version": "1.0.0",
+  "dependencies": { "left-pad": "^1.3.0" } }

--- a/tests/fixtures/assert-packed-manifest/reversioned-by-lifecycle/package/package.json
+++ b/tests/fixtures/assert-packed-manifest/reversioned-by-lifecycle/package/package.json
@@ -1,0 +1,2 @@
+{ "name": "@probe/clean", "version": "9.9.9",
+  "dependencies": { "left-pad": "^1.3.0" } }

--- a/tests/fixtures/assert-packed-manifest/unknown-protocol/package/package.json
+++ b/tests/fixtures/assert-packed-manifest/unknown-protocol/package/package.json
@@ -1,0 +1,2 @@
+{ "name": "@probe/clean", "version": "1.0.0",
+  "dependencies": { "weird": "quantum:entangled" } }

--- a/tests/fixtures/assert-packed-manifest/workspace-dep/package/package.json
+++ b/tests/fixtures/assert-packed-manifest/workspace-dep/package/package.json
@@ -1,0 +1,2 @@
+{ "name": "@probe/clean", "version": "1.0.0",
+  "dependencies": { "@probe/core": "workspace:^" } }

--- a/tests/npm-package-preflight.bats
+++ b/tests/npm-package-preflight.bats
@@ -1,3 +1,4 @@
+bats_require_minimum_version 1.5.0
 #!/usr/bin/env bats
 # npm-package-preflight.bats — behavioral coverage for the package selector
 # used by publish-npm.yml's build job.
@@ -5,7 +6,6 @@
 SCRIPT="scripts/npm-package-preflight.sh"
 
 setup() {
-  REPO_ROOT="$PWD"
   TEST_TMP=$(mktemp -d)
   export GITHUB_WORKSPACE="$TEST_TMP/ws"
   OUTSIDE="$TEST_TMP/outside"
@@ -36,123 +36,164 @@ teardown() {
   rm -rf "$TEST_TMP"
 }
 
+# --separate-stderr throughout this file: plain `run` folds stderr into
+# $output, so a diagnostic that leaked onto stdout - the exact failure the
+# control-character guard exists to prevent - would be invisible to these
+# assertions. Task 3 pipes this script's stdout straight into
+# $GITHUB_OUTPUT, so stdout purity on every non-zero exit is load-bearing,
+# not cosmetic.
+
 @test "nested package resolves and emits dir and version" {
-  run "$SCRIPT" packages/perms @probe/perms v0.1.0
+  run --separate-stderr "$SCRIPT" packages/perms @probe/perms v0.1.0
   [ "$status" -eq 0 ]
-  [[ "$output" == *"dir=packages/perms"* ]]
-  [[ "$output" == *"version=0.1.0"* ]]
+  [ "$output" = "dir=packages/perms
+version=0.1.0" ]
+  [ -z "$stderr" ]
 }
 
 @test "root package with default dir keeps working" {
-  GITHUB_WORKSPACE="$TEST_TMP/rootrepo" run "$SCRIPT" . solo v1.2.3
+  GITHUB_WORKSPACE="$ROOTREPO" run --separate-stderr "$SCRIPT" . solo v1.2.3
   [ "$status" -eq 0 ]
-  [[ "$output" == *"dir=."* ]]
-  [[ "$output" == *"version=1.2.3"* ]]
+  [ "$output" = "dir=.
+version=1.2.3" ]
 }
 
 @test "empty package-dir normalizes to the repository root" {
-  GITHUB_WORKSPACE="$TEST_TMP/rootrepo" run "$SCRIPT" "" solo v1.2.3
+  GITHUB_WORKSPACE="$ROOTREPO" run --separate-stderr "$SCRIPT" "" solo v1.2.3
   [ "$status" -eq 0 ]
-  [[ "$output" == *"dir=."* ]]
+  [ "$output" = "dir=.
+version=1.2.3" ]
 }
 
 @test "trailing slashes are stripped" {
-  run "$SCRIPT" packages/perms/// @probe/perms v0.1.0
+  run --separate-stderr "$SCRIPT" packages/perms/// @probe/perms v0.1.0
   [ "$status" -eq 0 ]
-  [[ "$output" == *"dir=packages/perms"* ]]
+  [ "$output" = "dir=packages/perms
+version=0.1.0" ]
 }
 
 @test "prefixed tag yields the trailing semver" {
-  run "$SCRIPT" packages/perms @probe/perms permissions/v0.1.0
+  run --separate-stderr "$SCRIPT" packages/perms @probe/perms permissions/v0.1.0
   [ "$status" -eq 0 ]
-  [[ "$output" == *"version=0.1.0"* ]]
+  [ "$output" = "dir=packages/perms
+version=0.1.0" ]
 }
 
 @test "prerelease tag is parsed" {
   cat > "$GITHUB_WORKSPACE/packages/perms/package.json" <<'JSON'
 { "name": "@probe/perms", "version": "0.1.0-rc.1" }
 JSON
-  run "$SCRIPT" packages/perms @probe/perms v0.1.0-rc.1
+  run --separate-stderr "$SCRIPT" packages/perms @probe/perms v0.1.0-rc.1
   [ "$status" -eq 0 ]
-  [[ "$output" == *"version=0.1.0-rc.1"* ]]
+  [ "$output" = "dir=packages/perms
+version=0.1.0-rc.1" ]
 }
 
 # --- control characters: $GITHUB_OUTPUT record injection -------------------
 
 @test "package-dir containing a newline is rejected" {
-  run "$SCRIPT" "$(printf 'packages/perms\nversion=9.9.9')" @probe/perms v0.1.0
+  run --separate-stderr "$SCRIPT" "$(printf 'packages/perms\nversion=9.9.9')" @probe/perms v0.1.0
   [ "$status" -eq 2 ]
-  [[ "$output" == *"control character"* ]]
-  # The injection this exists to stop must not appear anywhere in the output.
-  ! printf '%s\n' "$output" | grep -q 'version=9.9.9' || return 1
+  [[ "$stderr" == *"control character"* ]] || return 1
+  # The injection this exists to stop must not appear anywhere on stdout.
+  [ -z "$output" ]
 }
 
 @test "package-dir containing a carriage return is rejected" {
-  run "$SCRIPT" "$(printf 'packages/perms\rx')" @probe/perms v0.1.0
+  run --separate-stderr "$SCRIPT" "$(printf 'packages/perms\rx')" @probe/perms v0.1.0
   [ "$status" -eq 2 ]
-  [[ "$output" == *"control character"* ]]
+  [[ "$stderr" == *"control character"* ]] || return 1
+  [ -z "$output" ]
 }
 
 @test "package-dir containing a tab is rejected" {
-  run "$SCRIPT" "$(printf 'packages/\tperms')" @probe/perms v0.1.0
+  run --separate-stderr "$SCRIPT" "$(printf 'packages/\tperms')" @probe/perms v0.1.0
   [ "$status" -eq 2 ]
-  [[ "$output" == *"control character"* ]]
+  [[ "$stderr" == *"control character"* ]] || return 1
+  [ -z "$output" ]
 }
 
 @test "package-dir containing a non-printing control byte is rejected" {
-  run "$SCRIPT" "$(printf 'packages/\001perms')" @probe/perms v0.1.0
+  run --separate-stderr "$SCRIPT" "$(printf 'packages/\001perms')" @probe/perms v0.1.0
   [ "$status" -eq 2 ]
-  [[ "$output" == *"control character"* ]]
+  [[ "$stderr" == *"control character"* ]] || return 1
+  [ -z "$output" ]
 }
 
 @test "a rejected package-dir emits no dir= line at all" {
-  run "$SCRIPT" "$(printf 'packages/perms\nversion=9.9.9')" @probe/perms v0.1.0
+  run --separate-stderr "$SCRIPT" "$(printf 'packages/perms\nversion=9.9.9')" @probe/perms v0.1.0
+  [ "$status" -eq 2 ]
   ! printf '%s\n' "$output" | grep -q '^dir=' || return 1
 }
 
 # --- path safety -----------------------------------------------------------
 
 @test "absolute package-dir is rejected as malformed input" {
-  run "$SCRIPT" /etc @probe/perms v0.1.0
+  run --separate-stderr "$SCRIPT" /etc @probe/perms v0.1.0
   [ "$status" -eq 2 ]
-  [[ "$output" == *"absolute"* ]]
+  [[ "$stderr" == *"absolute"* ]] || return 1
+  [ -z "$output" ]
 }
 
 @test "traversal through .. is rejected" {
-  run "$SCRIPT" ../outside @probe/perms v0.1.0
+  run --separate-stderr "$SCRIPT" ../outside @probe/perms v0.1.0
   [ "$status" -eq 2 ]
-  [[ "$output" == *".."* ]]
+  # Assert the discriminating fragment, not a bare "..": the message also
+  # echoes back the raw input '../outside', which itself contains ".." and
+  # would make a bare substring match pass for the wrong reason.
+  [[ "$stderr" == *"'..' path segment"* ]] || return 1
+  [ -z "$output" ]
 }
 
 @test "'..' that resolves back inside is still rejected" {
-  run "$SCRIPT" packages/../packages/perms @probe/perms v0.1.0
+  run --separate-stderr "$SCRIPT" packages/../packages/perms @probe/perms v0.1.0
   [ "$status" -eq 2 ]
-  [[ "$output" == *".."* ]]
+  [[ "$stderr" == *"'..' path segment"* ]] || return 1
+  [ -z "$output" ]
 }
 
 @test "symlink escaping the checkout is rejected" {
-  run "$SCRIPT" escape @probe/outside v9.9.9
+  run --separate-stderr "$SCRIPT" escape @probe/outside v9.9.9
   [ "$status" -eq 2 ]
-  [[ "$output" == *"outside the checkout"* ]]
+  [[ "$stderr" == *"outside the checkout"* ]] || return 1
+  [ -z "$output" ]
 }
 
 @test "nonexistent package-dir is rejected" {
-  run "$SCRIPT" packages/nope @probe/perms v0.1.0
+  run --separate-stderr "$SCRIPT" packages/nope @probe/perms v0.1.0
   [ "$status" -eq 2 ]
-  [[ "$output" == *"does not exist"* ]]
+  [[ "$stderr" == *"does not exist"* ]] || return 1
+  [ -z "$output" ]
 }
 
 @test "directory without package.json is rejected" {
-  run "$SCRIPT" empty @probe/perms v0.1.0
+  run --separate-stderr "$SCRIPT" empty @probe/perms v0.1.0
   [ "$status" -eq 2 ]
-  [[ "$output" == *"no package.json"* ]]
+  [[ "$stderr" == *"no package.json"* ]] || return 1
+  [ -z "$output" ]
 }
 
 @test "malformed package.json is rejected" {
   printf '{ not json' > "$GITHUB_WORKSPACE/packages/perms/package.json"
-  run "$SCRIPT" packages/perms @probe/perms v0.1.0
+  run --separate-stderr "$SCRIPT" packages/perms @probe/perms v0.1.0
   [ "$status" -eq 2 ]
-  [[ "$output" == *"not valid JSON"* ]]
+  [[ "$stderr" == *"not valid JSON"* ]] || return 1
+  [ -z "$output" ]
+}
+
+# --- validation order: malformed input beats policy verdicts ---------------
+#
+# Exit 2 (malformed/unsafe input) must win over exit 1 (policy verdict) when
+# both are independently true. A caller misconfiguration - here, a
+# control-character package-dir - must never be reported as "this package
+# is not publishable", which is what an unparseable tag alone would report.
+
+@test "a control character in package-dir wins over an unparseable tag" {
+  run --separate-stderr "$SCRIPT" "$(printf 'packages/\001perms')" @probe/perms release-candidate
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"control character"* ]] || return 1
+  [[ "$stderr" != *"Could not parse semver"* ]] || return 1
+  [ -z "$output" ]
 }
 
 # --- manifest policy -------------------------------------------------------
@@ -161,31 +202,36 @@ JSON
   cat > "$GITHUB_WORKSPACE/packages/perms/package.json" <<'JSON'
 { "name": "@probe/perms", "version": "0.1.0", "private": true }
 JSON
-  run "$SCRIPT" packages/perms @probe/perms v0.1.0
+  run --separate-stderr "$SCRIPT" packages/perms @probe/perms v0.1.0
   [ "$status" -eq 1 ]
-  [[ "$output" == *"private"* ]]
+  [[ "$stderr" == *"private"* ]] || return 1
+  [ -z "$output" ]
 }
 
 @test "name mismatch fails policy" {
-  run "$SCRIPT" packages/perms @probe/other v0.1.0
+  run --separate-stderr "$SCRIPT" packages/perms @probe/other v0.1.0
   [ "$status" -eq 1 ]
-  [[ "$output" == *"@probe/other"* ]]
+  [[ "$stderr" == *"@probe/other"* ]] || return 1
+  [ -z "$output" ]
 }
 
 @test "version mismatch fails policy" {
-  run "$SCRIPT" packages/perms @probe/perms v0.2.0
+  run --separate-stderr "$SCRIPT" packages/perms @probe/perms v0.2.0
   [ "$status" -eq 1 ]
-  [[ "$output" == *"refusing to publish"* ]]
+  [[ "$stderr" == *"refusing to publish"* ]] || return 1
+  [ -z "$output" ]
 }
 
 @test "unparseable tag fails policy" {
-  run "$SCRIPT" packages/perms @probe/perms release-candidate
+  run --separate-stderr "$SCRIPT" packages/perms @probe/perms release-candidate
   [ "$status" -eq 1 ]
-  [[ "$output" == *"Could not parse semver"* ]]
+  [[ "$stderr" == *"Could not parse semver"* ]] || return 1
+  [ -z "$output" ]
 }
 
 @test "missing arguments are rejected" {
-  run "$SCRIPT" packages/perms
+  run --separate-stderr "$SCRIPT" packages/perms
   [ "$status" -eq 2 ]
-  [[ "$output" == *"usage:"* ]]
+  [[ "$stderr" == *"usage:"* ]] || return 1
+  [ -z "$output" ]
 }

--- a/tests/npm-package-preflight.bats
+++ b/tests/npm-package-preflight.bats
@@ -1,0 +1,191 @@
+#!/usr/bin/env bats
+# npm-package-preflight.bats — behavioral coverage for the package selector
+# used by publish-npm.yml's build job.
+
+SCRIPT="scripts/npm-package-preflight.sh"
+
+setup() {
+  REPO_ROOT="$PWD"
+  TEST_TMP=$(mktemp -d)
+  export GITHUB_WORKSPACE="$TEST_TMP/ws"
+  OUTSIDE="$TEST_TMP/outside"
+
+  mkdir -p "$GITHUB_WORKSPACE/packages/perms" "$GITHUB_WORKSPACE/empty" "$OUTSIDE"
+
+  cat > "$GITHUB_WORKSPACE/package.json" <<'JSON'
+{ "name": "root", "private": true }
+JSON
+
+  cat > "$GITHUB_WORKSPACE/packages/perms/package.json" <<'JSON'
+{ "name": "@probe/perms", "version": "0.1.0" }
+JSON
+
+  cat > "$OUTSIDE/package.json" <<'JSON'
+{ "name": "@probe/outside", "version": "9.9.9" }
+JSON
+  ln -s "$OUTSIDE" "$GITHUB_WORKSPACE/escape"
+
+  ROOTREPO="$TEST_TMP/rootrepo"
+  mkdir -p "$ROOTREPO"
+  cat > "$ROOTREPO/package.json" <<'JSON'
+{ "name": "solo", "version": "1.2.3" }
+JSON
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+}
+
+@test "nested package resolves and emits dir and version" {
+  run "$SCRIPT" packages/perms @probe/perms v0.1.0
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dir=packages/perms"* ]]
+  [[ "$output" == *"version=0.1.0"* ]]
+}
+
+@test "root package with default dir keeps working" {
+  GITHUB_WORKSPACE="$TEST_TMP/rootrepo" run "$SCRIPT" . solo v1.2.3
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dir=."* ]]
+  [[ "$output" == *"version=1.2.3"* ]]
+}
+
+@test "empty package-dir normalizes to the repository root" {
+  GITHUB_WORKSPACE="$TEST_TMP/rootrepo" run "$SCRIPT" "" solo v1.2.3
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dir=."* ]]
+}
+
+@test "trailing slashes are stripped" {
+  run "$SCRIPT" packages/perms/// @probe/perms v0.1.0
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dir=packages/perms"* ]]
+}
+
+@test "prefixed tag yields the trailing semver" {
+  run "$SCRIPT" packages/perms @probe/perms permissions/v0.1.0
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"version=0.1.0"* ]]
+}
+
+@test "prerelease tag is parsed" {
+  cat > "$GITHUB_WORKSPACE/packages/perms/package.json" <<'JSON'
+{ "name": "@probe/perms", "version": "0.1.0-rc.1" }
+JSON
+  run "$SCRIPT" packages/perms @probe/perms v0.1.0-rc.1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"version=0.1.0-rc.1"* ]]
+}
+
+# --- control characters: $GITHUB_OUTPUT record injection -------------------
+
+@test "package-dir containing a newline is rejected" {
+  run "$SCRIPT" "$(printf 'packages/perms\nversion=9.9.9')" @probe/perms v0.1.0
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"control character"* ]]
+  # The injection this exists to stop must not appear anywhere in the output.
+  ! printf '%s\n' "$output" | grep -q 'version=9.9.9' || return 1
+}
+
+@test "package-dir containing a carriage return is rejected" {
+  run "$SCRIPT" "$(printf 'packages/perms\rx')" @probe/perms v0.1.0
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"control character"* ]]
+}
+
+@test "package-dir containing a tab is rejected" {
+  run "$SCRIPT" "$(printf 'packages/\tperms')" @probe/perms v0.1.0
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"control character"* ]]
+}
+
+@test "package-dir containing a non-printing control byte is rejected" {
+  run "$SCRIPT" "$(printf 'packages/\001perms')" @probe/perms v0.1.0
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"control character"* ]]
+}
+
+@test "a rejected package-dir emits no dir= line at all" {
+  run "$SCRIPT" "$(printf 'packages/perms\nversion=9.9.9')" @probe/perms v0.1.0
+  ! printf '%s\n' "$output" | grep -q '^dir=' || return 1
+}
+
+# --- path safety -----------------------------------------------------------
+
+@test "absolute package-dir is rejected as malformed input" {
+  run "$SCRIPT" /etc @probe/perms v0.1.0
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"absolute"* ]]
+}
+
+@test "traversal through .. is rejected" {
+  run "$SCRIPT" ../outside @probe/perms v0.1.0
+  [ "$status" -eq 2 ]
+  [[ "$output" == *".."* ]]
+}
+
+@test "'..' that resolves back inside is still rejected" {
+  run "$SCRIPT" packages/../packages/perms @probe/perms v0.1.0
+  [ "$status" -eq 2 ]
+  [[ "$output" == *".."* ]]
+}
+
+@test "symlink escaping the checkout is rejected" {
+  run "$SCRIPT" escape @probe/outside v9.9.9
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"outside the checkout"* ]]
+}
+
+@test "nonexistent package-dir is rejected" {
+  run "$SCRIPT" packages/nope @probe/perms v0.1.0
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"does not exist"* ]]
+}
+
+@test "directory without package.json is rejected" {
+  run "$SCRIPT" empty @probe/perms v0.1.0
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"no package.json"* ]]
+}
+
+@test "malformed package.json is rejected" {
+  printf '{ not json' > "$GITHUB_WORKSPACE/packages/perms/package.json"
+  run "$SCRIPT" packages/perms @probe/perms v0.1.0
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not valid JSON"* ]]
+}
+
+# --- manifest policy -------------------------------------------------------
+
+@test "private manifest fails policy" {
+  cat > "$GITHUB_WORKSPACE/packages/perms/package.json" <<'JSON'
+{ "name": "@probe/perms", "version": "0.1.0", "private": true }
+JSON
+  run "$SCRIPT" packages/perms @probe/perms v0.1.0
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"private"* ]]
+}
+
+@test "name mismatch fails policy" {
+  run "$SCRIPT" packages/perms @probe/other v0.1.0
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"@probe/other"* ]]
+}
+
+@test "version mismatch fails policy" {
+  run "$SCRIPT" packages/perms @probe/perms v0.2.0
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"refusing to publish"* ]]
+}
+
+@test "unparseable tag fails policy" {
+  run "$SCRIPT" packages/perms @probe/perms release-candidate
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Could not parse semver"* ]]
+}
+
+@test "missing arguments are rejected" {
+  run "$SCRIPT" packages/perms
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"usage:"* ]]
+}

--- a/tests/publish-npm-docs.bats
+++ b/tests/publish-npm-docs.bats
@@ -71,6 +71,59 @@ normalize_ws() {
   assert_contains "$section" 'does not run `npm ci` by default'
 }
 
+@test "README documents package-dir and pack-command" {
+  section="$(publish_npm_section)"
+  assert_contains "$section" '`package-dir`'
+  assert_contains "$section" '`pack-command`'
+  assert_contains "$section" 'npm pack --json'
+}
+
+@test "README states the working directory of each caller hook" {
+  section="$(publish_npm_section)"
+  normalized="$(printf '%s\n' "$section" | normalize_ws)"
+  assert_contains "$normalized" 'test-command` runs from the repository root'
+  assert_contains "$normalized" 'repository-root-relative'
+}
+
+@test "README states what the pre-upload guard does not promise" {
+  section="$(publish_npm_section)"
+  normalized="$(printf '%s\n' "$section" | normalize_ws)"
+  assert_contains "$normalized" 'does not certify'
+}
+
+@test "README scopes each invocation to a single package" {
+  section="$(publish_npm_section)"
+  normalized="$(printf '%s\n' "$section" | normalize_ws)"
+  assert_contains "$normalized" 'one package per invocation'
+  assert_contains "$section" 'tag-prefix'
+  assert_contains "$section" 'permissions/v'
+}
+
+@test "README documents the pnpm workspace requirements" {
+  section="$(publish_npm_section)"
+  assert_contains "$section" 'packageManager'
+  assert_contains "$section" 'pnpm pack --json'
+  assert_contains "$section" 'frozen'
+  assert_contains "$section" 'workspace:'
+}
+
+@test "README documents per-package trusted publisher setup" {
+  section="$(publish_npm_section)"
+  normalized="$(printf '%s\n' "$section" | normalize_ws)"
+  assert_contains "$normalized" 'separately for every npm package'
+  assert_contains "$section" 'id-token: write'
+}
+
+@test "the monorepo caller example is complete and copy-pasteable" {
+  section="$(publish_npm_section)"
+  assert_contains "$section" 'package-dir: packages/permissions'
+  assert_contains "$section" 'pack-command: pnpm pack --json'
+  # Every caller example must carry its own permissions block; an example
+  # missing id-token fails at publish time with an opaque OIDC error.
+  count=$(printf '%s\n' "$section" | grep -c 'id-token: write')
+  [ "$count" -ge 2 ]
+}
+
 @test "README publish-npm prose lines stay wrapped" {
   section="$(publish_npm_section)"
   in_fence=0

--- a/tests/publish-npm-docs.bats
+++ b/tests/publish-npm-docs.bats
@@ -118,10 +118,22 @@ normalize_ws() {
   section="$(publish_npm_section)"
   assert_contains "$section" 'package-dir: packages/permissions'
   assert_contains "$section" 'pack-command: pnpm pack --json'
-  # Every caller example must carry its own permissions block; an example
-  # missing id-token fails at publish time with an opaque OIDC error.
-  count=$(printf '%s\n' "$section" | grep -c 'id-token: write')
-  [ "$count" -ge 2 ]
+  # Scoped to the monorepo example itself, not the whole publish-npm section:
+  # an unscoped count stays >=2 (the "Caller setup" permissions block and the
+  # "Scope" prose sentence) even if this example's own permissions block is
+  # deleted outright, so it would never catch a missing id-token here.
+  example="$(printf '%s\n' "$section" | awk '/^### Example caller: monorepo package$/{f=1} f')"
+  count=$(printf '%s\n' "$example" | grep -c 'id-token: write')
+  [ "$count" -ge 1 ]
+}
+
+@test "README inputs table documents the pack-contents-script metadata path" {
+  section="$(publish_npm_section)"
+  row="$(printf '%s\n' "$section" | grep '^| `pack-contents-script`')"
+  [ -n "$row" ]
+  assert_contains "$row" '<package-dir>/pack.json'
+  assert_contains "$row" 'for a root package'
+  assert_contains "$row" 'after packing'
 }
 
 @test "README publish-npm prose lines stay wrapped" {

--- a/tests/publish-npm-pack-seam.bats
+++ b/tests/publish-npm-pack-seam.bats
@@ -1,0 +1,224 @@
+bats_require_minimum_version 1.5.0
+#!/usr/bin/env bats
+# publish-npm-pack-seam.bats — execute the pack step's run block against
+# shell stubs.
+#
+# WHY THIS FILE EXISTS. publish-npm-workflow-contract.bats is grep-over-YAML:
+# it pins the SHAPE of the pack step and nothing about what its bash DOES. The
+# provenance check, the metadata-shape handling and the leak-timing fix are all
+# behavior, and all three are silently deletable without this file.
+#
+# No packer is involved. PACK_COMMAND is plain shell, so every case is bash,
+# and nothing here touches npm, pnpm or the network.
+#
+# --separate-stderr throughout. The step writes its ::error:: diagnostics to
+# STDOUT, as GitHub Actions workflow commands conventionally are, so the
+# diagnostic assertions target $output and the empty-stream assertions target
+# $stderr — the reverse of the scripts/*.sh test files in this suite.
+#
+# EVERY negated assertion carries `|| return 1`. Bash exempts `! cmd` from
+# errexit, so a bare mid-body negation is a silent no-op under bats.
+
+WF=".github/workflows/publish-npm.yml"
+STEP="Pack once and stage the tarball"
+
+extract_step_block() {
+  awk -v want="      - name: $1" '
+    $0 == want { found=1; next }
+    found && /^        run: \|$/ { inrun=1; next }
+    inrun && /^      - / { exit }
+    inrun { sub(/^          /, ""); print }
+  ' "$WF"
+}
+
+setup() {
+  REPO_ROOT="$PWD"
+  TEST_TMP=$(mktemp -d)
+  export RUNNER_TEMP="$TEST_TMP/runner"
+  mkdir -p "$RUNNER_TEMP"
+  WORKDIR="$TEST_TMP/work"
+  mkdir -p "$WORKDIR/packages/perms"
+  export PACKAGE_DIR="packages/perms"
+  export PACK_CONTENTS_SCRIPT=""
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+}
+
+run_pack_step() {
+  local script="$TEST_TMP/pack.sh"
+  { echo 'set -e'; extract_step_block "$STEP"; } > "$script"
+  ( cd "$WORKDIR" && bash "$script" )
+}
+
+# --- the seam itself -------------------------------------------------------
+
+@test "the pack step block extracts non-empty" {
+  block="$(extract_step_block "$STEP")"
+  [ -n "$block" ]
+  [[ "$block" == *"EXPECTED_TARBALL"* ]]
+}
+
+# --- happy paths and metadata shapes ---------------------------------------
+
+@test "happy path stages the produced tarball" {
+  export PACK_COMMAND='printf "{\"filename\":\"good-1.0.0.tgz\"}" && touch good-1.0.0.tgz'
+  run --separate-stderr run_pack_step
+  [ "$status" -eq 0 ]
+  [ -z "$stderr" ]
+  [ -f "$RUNNER_TEMP/dist/good-1.0.0.tgz" ]
+  # Moved, not copied: the package dir must not still hold a publishable tarball.
+  [ ! -f "$WORKDIR/packages/perms/good-1.0.0.tgz" ]
+}
+
+@test "npm array metadata shape yields the filename" {
+  export PACK_COMMAND='printf "[{\"filename\":\"arr-1.0.0.tgz\"}]" && touch arr-1.0.0.tgz'
+  run --separate-stderr run_pack_step
+  [ "$status" -eq 0 ]
+  [ -z "$stderr" ]
+  [ -f "$RUNNER_TEMP/dist/arr-1.0.0.tgz" ]
+}
+
+@test "npm keyed-object metadata shape yields the filename" {
+  export PACK_COMMAND='printf "{\"pkg\":{\"filename\":\"key-1.0.0.tgz\"}}" && touch key-1.0.0.tgz'
+  run --separate-stderr run_pack_step
+  [ "$status" -eq 0 ]
+  [ -z "$stderr" ]
+  [ -f "$RUNNER_TEMP/dist/key-1.0.0.tgz" ]
+}
+
+# --- provenance ------------------------------------------------------------
+
+@test "a stale tarball is refused even though the count is one" {
+  touch "$WORKDIR/packages/perms/stale-0.0.1.tgz"
+  export PACK_COMMAND='printf "{\"filename\":\"fresh-1.0.0.tgz\"}"'
+  run --separate-stderr run_pack_step
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"refusing to publish a stale tarball"* ]] || return 1
+  [[ "$output" == *"stale-0.0.1.tgz"* ]] || return 1
+  [[ "$output" == *"fresh-1.0.0.tgz"* ]] || return 1
+  [ ! -f "$RUNNER_TEMP/dist/stale-0.0.1.tgz" ]
+}
+
+@test "a stale tarball left in the staging dir is cleared before packing" {
+  mkdir -p "$RUNNER_TEMP/dist"
+  touch "$RUNNER_TEMP/dist/previous-0.0.1.tgz"
+  export PACK_COMMAND='printf "{\"filename\":\"good-1.0.0.tgz\"}" && touch good-1.0.0.tgz'
+  run --separate-stderr run_pack_step
+  [ "$status" -eq 0 ]
+  [ ! -f "$RUNNER_TEMP/dist/previous-0.0.1.tgz" ]
+  [ -f "$RUNNER_TEMP/dist/good-1.0.0.tgz" ]
+}
+
+@test "no tarball fails the count check" {
+  export PACK_COMMAND='printf "{\"filename\":\"x-1.0.0.tgz\"}"'
+  run --separate-stderr run_pack_step
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Expected exactly one tarball in packages/perms, found 0"* ]] || return 1
+  [ -z "$stderr" ]
+}
+
+@test "two tarballs fail the count check" {
+  export PACK_COMMAND='printf "{\"filename\":\"a.tgz\"}" && touch a.tgz b.tgz'
+  run --separate-stderr run_pack_step
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Expected exactly one tarball in packages/perms, found 2"* ]] || return 1
+  [ ! -f "$RUNNER_TEMP/dist/a.tgz" ]
+  [ ! -f "$RUNNER_TEMP/dist/b.tgz" ]
+}
+
+# --- unusable or failing pack metadata -------------------------------------
+
+@test "malformed metadata fails before staging" {
+  export PACK_COMMAND='printf "not json" && touch x.tgz'
+  run --separate-stderr run_pack_step
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cannot prove which artifact this run produced"* ]] || return 1
+  [ ! -f "$RUNNER_TEMP/dist/x.tgz" ]
+}
+
+@test "metadata without a filename fails before staging" {
+  export PACK_COMMAND='printf "{}" && touch x.tgz'
+  run --separate-stderr run_pack_step
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cannot prove which artifact this run produced"* ]] || return 1
+  [ ! -f "$RUNNER_TEMP/dist/x.tgz" ]
+}
+
+@test "empty metadata fails before staging" {
+  export PACK_COMMAND='true && touch x.tgz'
+  run --separate-stderr run_pack_step
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cannot prove which artifact this run produced"* ]] || return 1
+  [ ! -f "$RUNNER_TEMP/dist/x.tgz" ]
+}
+
+@test "an error object with exit 0 is caught" {
+  export PACK_COMMAND='printf "{\"error\":{\"message\":\"boom\"}}"'
+  run --separate-stderr run_pack_step
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"pack command reported an error: boom"* ]] || return 1
+}
+
+@test "a non-zero packer surfaces its own message" {
+  export PACK_COMMAND='printf "{\"error\":{\"message\":\"needs install\"}}"; exit 1'
+  run --separate-stderr run_pack_step
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"pack command failed in packages/perms"* ]] || return 1
+  [[ "$output" == *"::error::needs install"* ]] || return 1
+}
+
+# --- the sealed-pack.json leak regression ----------------------------------
+
+@test "pack metadata is absent from the package dir DURING packing" {
+  # The regression test for the sealed-pack.json leak. The stub records what
+  # it sees at pack time; the assertion is about that observation, not about
+  # where the file ends up.
+  export PACK_COMMAND='ls pack.json > "$RUNNER_TEMP/seen" 2>&1 || true; printf "{\"filename\":\"t-1.0.0.tgz\"}" && touch t-1.0.0.tgz'
+  run --separate-stderr run_pack_step
+  [ "$status" -eq 0 ]
+  # Non-empty proves the stub ran, so the negation below cannot pass vacuously.
+  [ -s "$RUNNER_TEMP/seen" ]
+  ! grep -q '^pack.json$' "$RUNNER_TEMP/seen" || return 1
+  [ -f "$WORKDIR/packages/perms/pack.json" ]
+}
+
+# --- pack-contents-script argument -----------------------------------------
+
+@test "pack-contents-script receives a repository-root-relative path" {
+  cat > "$WORKDIR/echo-arg.sh" <<'SH'
+printf '%s' "$1" > "$RUNNER_TEMP/arg"
+SH
+  export PACK_CONTENTS_SCRIPT="echo-arg.sh"
+  export PACK_COMMAND='printf "{\"filename\":\"r-1.0.0.tgz\"}" && touch r-1.0.0.tgz'
+  run --separate-stderr run_pack_step
+  [ "$status" -eq 0 ]
+  [ "$(cat "$RUNNER_TEMP/arg")" = "packages/perms/pack.json" ]
+}
+
+@test "a root package receives the literal pack.json, as before" {
+  export PACKAGE_DIR="."
+  cat > "$WORKDIR/echo-arg.sh" <<'SH'
+printf '%s' "$1" > "$RUNNER_TEMP/arg"
+SH
+  export PACK_CONTENTS_SCRIPT="echo-arg.sh"
+  export PACK_COMMAND='printf "{\"filename\":\"root-1.0.0.tgz\"}" && touch root-1.0.0.tgz'
+  run --separate-stderr run_pack_step
+  [ "$status" -eq 0 ]
+  [ "$(cat "$RUNNER_TEMP/arg")" = "pack.json" ]
+  [ -f "$RUNNER_TEMP/dist/root-1.0.0.tgz" ]
+}
+
+@test "a failing pack-contents-script fails the step" {
+  cat > "$WORKDIR/reject.sh" <<'SH'
+echo "contents rejected"
+exit 3
+SH
+  export PACK_CONTENTS_SCRIPT="reject.sh"
+  export PACK_COMMAND='printf "{\"filename\":\"c-1.0.0.tgz\"}" && touch c-1.0.0.tgz'
+  run --separate-stderr run_pack_step
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"contents rejected"* ]] || return 1
+  [ ! -f "$RUNNER_TEMP/dist/c-1.0.0.tgz" ]
+}

--- a/tests/publish-npm-pack-seam.bats
+++ b/tests/publish-npm-pack-seam.bats
@@ -22,6 +22,11 @@ bats_require_minimum_version 1.5.0
 WF=".github/workflows/publish-npm.yml"
 STEP="Pack once and stage the tarball"
 
+# npm's real failure envelope, verified against npm 12.0.2: a failing prepack
+# exits 7 and writes {"error":{"code","summary","detail"}} to stdout. There is
+# no "message" key, so these stubs are modeled on the packer, not on the code.
+NPM_ERROR_ENVELOPE='{"error":{"code":7,"summary":"command failed","detail":"sh -c exit 7"}}'
+
 extract_step_block() {
   awk -v want="      - name: $1" '
     $0 == want { found=1; next }
@@ -99,6 +104,7 @@ run_pack_step() {
   [[ "$output" == *"stale-0.0.1.tgz"* ]] || return 1
   [[ "$output" == *"fresh-1.0.0.tgz"* ]] || return 1
   [ ! -f "$RUNNER_TEMP/dist/stale-0.0.1.tgz" ]
+  [ -z "$stderr" ]
 }
 
 @test "a stale tarball left in the staging dir is cleared before packing" {
@@ -109,6 +115,7 @@ run_pack_step() {
   [ "$status" -eq 0 ]
   [ ! -f "$RUNNER_TEMP/dist/previous-0.0.1.tgz" ]
   [ -f "$RUNNER_TEMP/dist/good-1.0.0.tgz" ]
+  [ -z "$stderr" ]
 }
 
 @test "no tarball fails the count check" {
@@ -126,6 +133,7 @@ run_pack_step() {
   [[ "$output" == *"Expected exactly one tarball in packages/perms, found 2"* ]] || return 1
   [ ! -f "$RUNNER_TEMP/dist/a.tgz" ]
   [ ! -f "$RUNNER_TEMP/dist/b.tgz" ]
+  [ -z "$stderr" ]
 }
 
 # --- unusable or failing pack metadata -------------------------------------
@@ -136,6 +144,7 @@ run_pack_step() {
   [ "$status" -ne 0 ]
   [[ "$output" == *"cannot prove which artifact this run produced"* ]] || return 1
   [ ! -f "$RUNNER_TEMP/dist/x.tgz" ]
+  [ -z "$stderr" ]
 }
 
 @test "metadata without a filename fails before staging" {
@@ -144,6 +153,7 @@ run_pack_step() {
   [ "$status" -ne 0 ]
   [[ "$output" == *"cannot prove which artifact this run produced"* ]] || return 1
   [ ! -f "$RUNNER_TEMP/dist/x.tgz" ]
+  [ -z "$stderr" ]
 }
 
 @test "empty metadata fails before staging" {
@@ -152,21 +162,44 @@ run_pack_step() {
   [ "$status" -ne 0 ]
   [[ "$output" == *"cannot prove which artifact this run produced"* ]] || return 1
   [ ! -f "$RUNNER_TEMP/dist/x.tgz" ]
+  [ -z "$stderr" ]
 }
 
 @test "an error object with exit 0 is caught" {
-  export PACK_COMMAND='printf "{\"error\":{\"message\":\"boom\"}}"'
+  export PACK_COMMAND="printf '%s' '$NPM_ERROR_ENVELOPE'"
   run --separate-stderr run_pack_step
   [ "$status" -ne 0 ]
-  [[ "$output" == *"pack command reported an error: boom"* ]] || return 1
+  [[ "$output" == *"pack command reported an error"* ]] || return 1
+  [[ "$output" == *"::error::command failed: sh -c exit 7"* ]] || return 1
+  [ -z "$stderr" ]
 }
 
-@test "a non-zero packer surfaces its own message" {
-  export PACK_COMMAND='printf "{\"error\":{\"message\":\"needs install\"}}"; exit 1'
+@test "a non-zero packer surfaces npm's summary and detail" {
+  export PACK_COMMAND="printf '%s' '$NPM_ERROR_ENVELOPE'; exit 7"
   run --separate-stderr run_pack_step
   [ "$status" -ne 0 ]
   [[ "$output" == *"pack command failed in packages/perms"* ]] || return 1
+  [[ "$output" == *"::error::command failed: sh -c exit 7"* ]] || return 1
+  [ -z "$stderr" ]
+}
+
+@test "an unrecognized error envelope still surfaces the raw metadata" {
+  # Nothing may be silently swallowed: with no summary/detail/message the whole
+  # envelope is dumped, so a caller never has to reproduce the failure locally.
+  export PACK_COMMAND='printf "{\"error\":{\"code\":7}}"; exit 7'
+  run --separate-stderr run_pack_step
+  [ "$status" -ne 0 ]
+  [[ "$output" == *'::error::{"error":{"code":7}}'* ]] || return 1
+  [ -z "$stderr" ]
+}
+
+@test "a packer reporting only message is still surfaced" {
+  # Covers the defensive third element of the jq fallback list.
+  export PACK_COMMAND='printf "{\"error\":{\"message\":\"needs install\"}}"; exit 1'
+  run --separate-stderr run_pack_step
+  [ "$status" -ne 0 ]
   [[ "$output" == *"::error::needs install"* ]] || return 1
+  [ -z "$stderr" ]
 }
 
 # --- the sealed-pack.json leak regression ----------------------------------
@@ -182,6 +215,7 @@ run_pack_step() {
   [ -s "$RUNNER_TEMP/seen" ]
   ! grep -q '^pack.json$' "$RUNNER_TEMP/seen" || return 1
   [ -f "$WORKDIR/packages/perms/pack.json" ]
+  [ -z "$stderr" ]
 }
 
 # --- pack-contents-script argument -----------------------------------------
@@ -195,6 +229,7 @@ SH
   run --separate-stderr run_pack_step
   [ "$status" -eq 0 ]
   [ "$(cat "$RUNNER_TEMP/arg")" = "packages/perms/pack.json" ]
+  [ -z "$stderr" ]
 }
 
 @test "a root package receives the literal pack.json, as before" {
@@ -208,6 +243,7 @@ SH
   [ "$status" -eq 0 ]
   [ "$(cat "$RUNNER_TEMP/arg")" = "pack.json" ]
   [ -f "$RUNNER_TEMP/dist/root-1.0.0.tgz" ]
+  [ -z "$stderr" ]
 }
 
 @test "a failing pack-contents-script fails the step" {
@@ -221,4 +257,5 @@ SH
   [ "$status" -ne 0 ]
   [[ "$output" == *"contents rejected"* ]] || return 1
   [ ! -f "$RUNNER_TEMP/dist/c-1.0.0.tgz" ]
+  [ -z "$stderr" ]
 }

--- a/tests/publish-npm-workflow-contract.bats
+++ b/tests/publish-npm-workflow-contract.bats
@@ -90,6 +90,8 @@ run_blocks() {
   assert_contains "$job" 'npm_package_preflight "$PACKAGE_DIR" "$PACKAGE_NAME" "$TAG"'
   assert_contains "$job" 'refusing to publish'
   assert_lacks "$job" "require('./package.json').version"
+  assert_contains "$job" 'cat "$OUT" >> "$GITHUB_OUTPUT"'
+  assert_contains "$job" 'version: ${{ steps.pkg.outputs.version }}'
 }
 
 @test "build job uses Node 24 and optional caller pre-pack hooks" {
@@ -176,9 +178,12 @@ run_blocks() {
 @test "preflight runs before the caller test command" {
   pre="$(step_line 'Resolve package directory and preflight')"
   tst="$(step_line 'Run caller test command')"
+  pck="$(step_line 'Pack once and assert tarball contents')"
   [ -n "$pre" ]
   [ -n "$tst" ]
+  [ -n "$pck" ]
   [ "$pre" -lt "$tst" ]
+  [ "$pre" -lt "$pck" ]
 }
 
 @test "preflight logic is embedded inline, not fetched at runtime" {
@@ -187,6 +192,6 @@ run_blocks() {
 }
 
 @test "preflight is invoked exactly once" {
-  count=$(grep -cF 'npm_package_preflight "$PACKAGE_DIR"' "$YAML")
+  count=$(grep -oF 'npm_package_preflight "$PACKAGE_DIR"' "$YAML" | wc -l | tr -d ' ')
   [ "$count" -eq 1 ]
 }

--- a/tests/publish-npm-workflow-contract.bats
+++ b/tests/publish-npm-workflow-contract.bats
@@ -278,3 +278,12 @@ run_blocks() {
   count=$(grep -oF 'npm_package_preflight "$PACKAGE_DIR"' "$YAML" | wc -l | tr -d ' ')
   [ "$count" -eq 1 ]
 }
+
+@test "pack-contents-script description documents both root and monorepo metadata paths" {
+  desc="$(input_block pack-contents-script)"
+  # A root caller (package-dir omitted) still gets the literal 'pack.json';
+  # only a monorepo caller gets '<package-dir>/pack.json'. The description
+  # must name both, or a monorepo caller reads stale root-only docs.
+  assert_contains "$desc" 'pack.json for a root package'
+  assert_contains "$desc" '<package-dir>/pack.json otherwise'
+}

--- a/tests/publish-npm-workflow-contract.bats
+++ b/tests/publish-npm-workflow-contract.bats
@@ -24,6 +24,10 @@ input_block() {
   workflow_inputs_block | sed -n "/^      ${input}:$/,/^      [a-zA-Z0-9_-]*:$/p"
 }
 
+step_line() {
+  grep -n "^      - name: $1\$" "$YAML" | head -n1 | cut -d: -f1
+}
+
 assert_contains() {
   local text="$1"
   local expected="$2"
@@ -79,11 +83,13 @@ run_blocks() {
   assert_contains "$job" 'merge-base --is-ancestor'
 }
 
-@test "build job gates tag version against package.json version" {
+@test "build job preflights the selected package before tests or packing" {
   job="$(build_job)"
-  assert_contains "$job" "require('./package.json').version"
+  assert_contains "$job" 'PACKAGE_DIR: ${{ inputs.package-dir }}'
+  assert_contains "$job" 'PACKAGE_NAME: ${{ inputs.package-name }}'
+  assert_contains "$job" 'npm_package_preflight "$PACKAGE_DIR" "$PACKAGE_NAME" "$TAG"'
   assert_contains "$job" 'refusing to publish'
-  assert_contains "$job" 'version=$VERSION'
+  assert_lacks "$job" "require('./package.json').version"
 }
 
 @test "build job uses Node 24 and optional caller pre-pack hooks" {
@@ -157,4 +163,30 @@ run_blocks() {
   runs="$(run_blocks)"
   assert_contains "$runs" 'npm publish ./*.tgz'
   assert_lacks "$runs" '${{ inputs.'
+}
+
+@test "publish-npm.yml exposes package-dir and pack-command with safe defaults" {
+  inputs="$(workflow_inputs_block)"
+  assert_contains "$inputs" "package-dir:"
+  assert_contains "$inputs" "pack-command:"
+  assert_contains "$(input_block package-dir)" 'default: "."'
+  assert_contains "$(input_block pack-command)" 'default: "npm pack --json"'
+}
+
+@test "preflight runs before the caller test command" {
+  pre="$(step_line 'Resolve package directory and preflight')"
+  tst="$(step_line 'Run caller test command')"
+  [ -n "$pre" ]
+  [ -n "$tst" ]
+  [ "$pre" -lt "$tst" ]
+}
+
+@test "preflight logic is embedded inline, not fetched at runtime" {
+  grep -qF '# --- BEGIN inline:scripts/npm-package-preflight.sh ---' "$YAML"
+  grep -qF '# --- END inline:scripts/npm-package-preflight.sh ---' "$YAML"
+}
+
+@test "preflight is invoked exactly once" {
+  count=$(grep -cF 'npm_package_preflight "$PACKAGE_DIR"' "$YAML")
+  [ "$count" -eq 1 ]
 }

--- a/tests/publish-npm-workflow-contract.bats
+++ b/tests/publish-npm-workflow-contract.bats
@@ -143,19 +143,36 @@ run_blocks() {
 @test "the staged tarball is bound to the pack metadata filename" {
   job="$(build_job)"
   assert_contains "$job" 'EXPECTED_TARBALL'
-  assert_contains "$job" 'stale tarball'
+  assert_contains "$job" 'if [ "$FOUND_BASE" != "$EXPECTED_TARBALL" ]; then'
+  assert_contains "$job" 'refusing to publish a stale tarball'
+  # The echo alone would not stop the publish; the refusal must exit non-zero.
+  printf '%s\n' "$job" \
+    | grep -A1 'refusing to publish a stale tarball' \
+    | grep -qE '^[[:space:]]*exit 1$'
 }
 
 @test "corepack enables only pnpm and yarn, never the npm shim" {
   job="$(build_job)"
   assert_contains "$job" 'corepack enable pnpm yarn'
-  ! printf '%s\n' "$job" | grep -qE 'corepack enable[[:space:]]*$' || return 1
+  # Bare `corepack enable`, `--all`, and any explicit `npm` argument all install
+  # the npm shim, which hard-errors in a repo pinning packageManager: pnpm@...
+  # Only real command lines are considered, so the explanatory comment above the
+  # command (which names npm in prose) cannot satisfy or defeat this check.
+  ! printf '%s\n' "$job" \
+    | grep -E '^[[:space:]]*corepack enable' \
+    | grep -qE '(enable[[:space:]]*$|[[:space:]]npm([[:space:]]|$)|--all)' || return 1
 }
 
-@test "pack failures surface the packer's own error message" {
+@test "pack failures surface the packer's real error keys" {
   job="$(build_job)"
-  assert_contains "$job" 'jq -r '"'"'.error.message // empty'"'"' "$PACK_JSON"'
+  # npm's envelope is {"error":{"code","summary","detail"}} - there is no
+  # "message" key, so pinning it alone would certify a dead branch.
+  assert_contains "$job" '[.error.summary, .error.detail, .error.message]'
+  assert_lacks "$job" '.error.message // empty'
+  assert_lacks "$job" '.error.message // "unknown"'
   assert_contains "$job" 'has("error")'
+  # Safety net: unrecognized envelopes are dumped, never swallowed.
+  assert_contains "$job" 'sed '"'"'s/^/::error::/'"'"' "$PACK_JSON"'
 }
 
 @test "the packed manifest is asserted before upload" {

--- a/tests/publish-npm-workflow-contract.bats
+++ b/tests/publish-npm-workflow-contract.bats
@@ -100,15 +100,81 @@ run_blocks() {
   assert_contains "$job" 'TEST_COMMAND: ${{ inputs.test-command }}'
   assert_contains "$job" 'if [ -n "$TEST_COMMAND" ]; then'
   assert_contains "$job" 'PACK_CONTENTS_SCRIPT: ${{ inputs.pack-contents-script }}'
-  assert_contains "$job" 'sh "$PACK_CONTENTS_SCRIPT" pack.json'
+  assert_contains "$job" 'sh "$PACK_CONTENTS_SCRIPT" "$PACK_JSON_REL"'
 }
 
-@test "build job packs once and uploads npm-dist tarball artifact" {
+@test "build job packs once from the selected directory and stages the tarball" {
   job="$(build_job)"
-  assert_contains "$job" 'npm pack --json > pack.json'
+  assert_contains "$job" 'PACKAGE_DIR: ${{ steps.pkg.outputs.dir }}'
+  assert_contains "$job" 'PACK_COMMAND: ${{ inputs.pack-command }}'
+  assert_contains "$job" 'PACK_JSON="$RUNNER_TEMP/pack.json"'
+  assert_contains "$job" 'STAGE="$RUNNER_TEMP/dist"'
+  assert_contains "$job" 'Expected exactly one tarball'
   assert_contains "$job" "name: npm-dist"
-  assert_contains "$job" 'path: "*.tgz"'
+  assert_contains "$job" 'path: ${{ runner.temp }}/dist/*.tgz'
   assert_contains "$job" 'if-no-files-found: error'
+  assert_lacks "$job" 'npm pack --json > pack.json'
+  assert_lacks "$job" 'path: "*.tgz"'
+}
+
+@test "the pack command is invoked exactly once" {
+  count=$(grep -oF 'sh -c "$PACK_COMMAND"' "$YAML" | wc -l | tr -d ' ')
+  [ "$count" -eq 1 ]
+}
+
+@test "the guard is invoked exactly once" {
+  count=$(grep -oF 'assert_packed_manifest "$RUNNER_TEMP/dist"' "$YAML" | wc -l | tr -d ' ')
+  [ "$count" -eq 1 ]
+}
+
+@test "the guard receives the requested name and version" {
+  job="$(build_job)"
+  assert_contains "$job" 'PACKAGE_NAME: ${{ inputs.package-name }}'
+  assert_contains "$job" 'VERSION: ${{ steps.pkg.outputs.version }}'
+  assert_contains "$job" 'assert_packed_manifest "$RUNNER_TEMP/dist"/*.tgz "$PACKAGE_NAME" "$VERSION"'
+}
+
+@test "pack metadata is written outside the workspace" {
+  job="$(build_job)"
+  assert_contains "$job" 'PACK_JSON="$RUNNER_TEMP/pack.json"'
+  assert_lacks "$job" '> pack.json'
+}
+
+@test "the staged tarball is bound to the pack metadata filename" {
+  job="$(build_job)"
+  assert_contains "$job" 'EXPECTED_TARBALL'
+  assert_contains "$job" 'stale tarball'
+}
+
+@test "corepack enables only pnpm and yarn, never the npm shim" {
+  job="$(build_job)"
+  assert_contains "$job" 'corepack enable pnpm yarn'
+  ! printf '%s\n' "$job" | grep -qE 'corepack enable[[:space:]]*$' || return 1
+}
+
+@test "pack failures surface the packer's own error message" {
+  job="$(build_job)"
+  assert_contains "$job" 'jq -r '"'"'.error.message // empty'"'"' "$PACK_JSON"'
+  assert_contains "$job" 'has("error")'
+}
+
+@test "the packed manifest is asserted before upload" {
+  asrt="$(step_line 'Assert packed manifest is the requested package')"
+  upld="$(step_line 'Upload tarball artifact')"
+  [ -n "$asrt" ]
+  [ -n "$upld" ]
+  [ "$asrt" -lt "$upld" ]
+  grep -qF '# --- BEGIN inline:scripts/assert-packed-manifest.sh ---' "$YAML"
+  grep -qF '# --- END inline:scripts/assert-packed-manifest.sh ---' "$YAML"
+}
+
+@test "publish and github-release jobs stay artifact-driven" {
+  pub="$(publish_job)"
+  rel="$(github_release_job)"
+  assert_contains "$pub" 'npm publish ./*.tgz'
+  assert_contains "$rel" 'gh release upload "$TAG" ./*.tgz --clobber'
+  assert_lacks "$pub" 'package-dir'
+  assert_lacks "$rel" 'package-dir'
 }
 
 @test "publish job declares OIDC permission and npm environment" {
@@ -178,7 +244,7 @@ run_blocks() {
 @test "preflight runs before the caller test command" {
   pre="$(step_line 'Resolve package directory and preflight')"
   tst="$(step_line 'Run caller test command')"
-  pck="$(step_line 'Pack once and assert tarball contents')"
+  pck="$(step_line 'Pack once and stage the tarball')"
   [ -n "$pre" ]
   [ -n "$tst" ]
   [ -n "$pck" ]

--- a/tests/publish-npm-workflow-contract.bats
+++ b/tests/publish-npm-workflow-contract.bats
@@ -161,6 +161,11 @@ run_blocks() {
   ! printf '%s\n' "$job" \
     | grep -E '^[[:space:]]*corepack enable' \
     | grep -qE '(enable[[:space:]]*$|[[:space:]]npm([[:space:]]|$)|--all)' || return 1
+  # A failing corepack must not take down an npm-only caller's release, so the
+  # enable carries its own fallback rather than relying on the step's `-e`.
+  printf '%s\n' "$job" \
+    | grep -E '^[[:space:]]*corepack enable' \
+    | grep -qF '||'
 }
 
 @test "pack failures surface the packer's real error keys" {
@@ -258,7 +263,7 @@ run_blocks() {
   assert_contains "$(input_block pack-command)" 'default: "npm pack --json"'
 }
 
-@test "preflight runs before the caller test command" {
+@test "preflight runs before the caller test command and before packing" {
   pre="$(step_line 'Resolve package directory and preflight')"
   tst="$(step_line 'Run caller test command')"
   pck="$(step_line 'Pack once and stage the tarball')"


### PR DESCRIPTION
Adds monorepo support to `publish-npm.yml` so a single workspace package can be
published while the root manifest stays private and versionless, and hardens the
publish path against uploading the wrong artifact.

## What changed

Two new optional inputs, both defaulting to today's behavior:

| Input | Default | Purpose |
|---|---|---|
| `package-dir` | `"."` | Directory of the package to publish |
| `pack-command` | `"npm pack --json"` | Packer to invoke, for pnpm/yarn workspaces |

Only the `build` job becomes package-aware. `publish` and `github-release` are
**byte-identical** to `main`.

New pipeline: preflight → corepack → pack → provenance check → sealed-manifest
guard → staged upload.

- **`scripts/npm-package-preflight.sh`** resolves `package-dir` safely inside the
  checkout (rejecting `..` segments, absolute paths, symlink escapes and control
  characters) and validates the source manifest against the tag and
  `package-name`.
- **`scripts/assert-packed-manifest.sh`** inspects the sealed tarball. It
  re-establishes identity from the **packed** manifest — a `prepack` lifecycle
  script can rewrite `package.json` after preflight — and rejects dependency
  specifiers npm cannot resolve from the registry, by default-deny allowlist.
- The pack step binds the staged tarball to the `filename` in the packer's own
  metadata, so a stale `.tgz` cannot be published.
- Pack metadata is written outside the workspace and copied back **after** the
  tarball is sealed. `npm pack --json > pack.json` leaked `pack.json` into
  tarballs of packages with no `files` allowlist, because the shell truncates the
  redirect target before the packer runs. This is a timing fix; no caller-visible
  interface changed.
- `corepack enable pnpm yarn`, never bare `corepack enable`, which also shims
  `npm` and hard-errors in a repo pinning `packageManager: pnpm@…`.

## Backward compatibility

`j7an/superpowers-wrapper` publishes through this workflow today and passes
neither new input. Verified:

- `pack-contents-script` still receives the literal string `pack.json` for a
  root-package caller — asserted by exact equality in a seam test.
- Its manifest has a `files` allowlist and its expected-contents fixture does not
  list `pack.json`, so the leak fix is a no-op for its tarball.
- It has no `dependencies`/`optionalDependencies`/`peerDependencies`, so the
  protocol guard cannot fire on it.
- The artifact is still `npm-dist` containing exactly one `*.tgz` at its root.

## Verification

- `bats tests/` — **684 pass, 0 fail** (was 681 on `main`)
- `./scripts/check-inline-sync.sh` — PASS, 14 pairs including both new ones
- `./scripts/lint-workflow-call.sh` — PASS

Every task went through an independent review plus a scoped re-review, and the
branch through a final whole-branch review. Two defects those reviews caught are
worth calling out, because both were empirically demonstrated rather than argued:

1. **The plan specified `jq '.error.message'` to surface pack failures — a key
   npm never emits.** The real envelope is
   `{"error":{"code":7,"summary":…,"detail":…}}`, so both error-surfacing
   branches were inert against the default packer. Fixed to read the real keys
   with a raw-metadata fallback.
2. **A bare relative-path dependency defeated the guard.** The protocol regex
   found no colon in `"../core"`, so it fell through to default-allow — but
   `npm-package-arg` resolves a leading `.`, `..`, `/` or `~/` to a local
   directory, and both `npm pack` and `pnpm pack` seal it unchanged. Fixed by
   treating colon-less local paths as `file:`, with fixtures proven to fail
   against the pre-fix logic.

## Known follow-up (not a blocker)

A dependency specifier beginning with a literal **tab or newline** followed by a
relative path still bypasses the guard: `jq @tsv` escapes real control characters
into two-character `\t` / `\n` sequences before the whitespace trim runs, so the
first character seen is a backslash. This is a strictly narrower instance of the
fix above, requires a control character at the start of a `package.json`
dependency value, and was equally open before this branch. Closing it means
trimming after unescaping, or moving the row encoding off `@tsv`.

## Canary status

`AGENTS.md` requires downstream canary evidence before declaring release-workflow
changes fixed. **That gate is open by design here** — it will be validated
manually once the downstream repo is ready. No monorepo consumer exists yet, and
the root-package path is byte-compatible, so merging ahead of it is safe, but the
`@v4` release should wait for the canary.

Fixes #138.
