### PR TITLE
fix(ci): harden Bats setup downloads

### DIFF
--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -24,6 +24,13 @@ jobs:
 
       - name: Install bats
         uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # v4.0.0
+        with:
+          github-token: ${{ github.token }}
+          bats-version: "1.14.0"
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
 
       - name: Run bats
         run: bats tests/

--- a/tests/ci-scripts-workflow-contract.bats
+++ b/tests/ci-scripts-workflow-contract.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+# ci-scripts-workflow-contract.bats - static contracts for the repository's
+# script-test workflow.
+
+. "$BATS_TEST_DIRNAME/helpers/action-pin-assertions.bash"
+
+YAML=".github/workflows/ci-scripts.yml"
+
+step_block() {
+  awk -v name="      - name: $1" '
+    $0 == name { flag=1; print; next }
+    flag && /^      - / { exit }
+    flag && /^    [A-Za-z0-9_-]+:/ { exit }
+    flag { print }
+  ' "$YAML"
+}
+
+step_input() {
+  step_block "Install bats" | awk -v key="          $1:" '
+    index($0, key) == 1 {
+      sub(/^[[:space:]]*[A-Za-z0-9_-]+:[[:space:]]*/, "")
+      print
+      exit
+    }
+  '
+}
+
+@test "Bats setup authenticates downloads and pins a stable version" {
+  block=$(step_block "Install bats")
+  assert_action_pin "$block" "bats-core/bats-action"
+
+  [ "$(step_input github-token)" = '${{ github.token }}' ]
+
+  version=$(step_input bats-version)
+  version=${version#\"}
+  version=${version%\"}
+  [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+
+@test "Bats setup disables unused helper libraries" {
+  for input in support-install assert-install detik-install file-install; do
+    [ "$(step_input "$input")" = "false" ]
+  done
+}


### PR DESCRIPTION
## Summary

- authenticate Bats action downloads with the job's read-only GitHub token
- pin Bats 1.14.0 and disable four unused helper-library installations
- add a semantic workflow contract for the action pin, token, stable Bats version, and disabled helpers

## Root cause

Three concurrent Dependabot PR runs failed before repository tests started because an anonymous GitHub API download returned non-gzip content:

- https://github.com/j7an/shared-workflows/actions/runs/32086977652
- https://github.com/j7an/shared-workflows/actions/runs/32086964661
- https://github.com/j7an/shared-workflows/actions/runs/32086961431

The narrowed setup changes a cold-cache installation from release discovery plus Bats and four helper downloads to one authenticated, versioned Bats archive request.

## Test plan

- `bats --formatter junit tests/` (686 tests, 0 failures/errors)
- `./scripts/check-inline-sync.sh`
- `./scripts/lint-workflow-call.sh`
- `./scripts/lint-workflows.sh .github/workflows/ci-scripts.yml`
- `git diff --check`
