### PR TITLE
fix(dependabot): group routine action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,11 @@ updates:
       prefix: "deps"
     cooldown:
       default-days: 5
+    groups:
+      all-actions:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'scripts/**'
       - 'tests/**'
+      - '.github/dependabot.yml'
       - '.github/workflows/**'
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 5
+    groups:
+      all-actions:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -57,6 +65,9 @@ updates:
       npm-minor-patch:
         update-types: ["minor", "patch"]
 ```
+
+The `all-actions` group combines routine minor and patch version updates into
+one pull request. Major and security update handling remains unchanged.
 
 See [Dependabot cool-down docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown--) for per-severity and per-ecosystem overrides.
 

--- a/tests/dependabot-config-contract.bats
+++ b/tests/dependabot-config-contract.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+@test "GitHub Actions minor and patch version updates are grouped together" {
+  config="$BATS_TEST_DIRNAME/../.github/dependabot.yml"
+
+  run ruby - "$config" <<'RUBY'
+require "yaml"
+
+config = YAML.safe_load(File.read(ARGV.fetch(0)))
+updates = config.fetch("updates")
+actions = updates.select do |update|
+  update["package-ecosystem"] == "github-actions" && update["directory"] == "/"
+end
+
+abort "expected exactly one root GitHub Actions updater" unless actions.length == 1
+
+groups = actions.first.fetch("groups", {})
+abort "expected all-actions to be the only GitHub Actions group" unless groups.keys == ["all-actions"]
+
+group = groups.fetch("all-actions")
+abort "all-actions must apply only to version updates" unless group["applies-to"] == "version-updates"
+abort "all-actions must match every action" unless group["patterns"] == ["*"]
+abort "all-actions must group only minor and patch updates" unless group.fetch("update-types", []).sort == %w[minor patch]
+RUBY
+
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- group GitHub Actions minor and patch version updates into one Dependabot PR
- leave major and security update behavior unchanged
- enforce the policy with a semantic YAML contract and run it on config changes
- align the README Quick Start example with the repository policy

## Testing

- `bats tests/` (687 tests)
- `./scripts/check-inline-sync.sh`
- `./scripts/lint-workflow-call.sh`
- `./scripts/lint-workflows.sh`
